### PR TITLE
Removing unused variable from test DataGridViewCell_OnContentClick_ClearAndReAddCell_InvokeOnMouseUpInternal

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellTests.cs
@@ -6523,8 +6523,6 @@ public partial class DataGridViewCellTests
             dataGridView.Rows.Clear();
             dataGridView.Rows.Add();
         });
-        string cellName = "TestCellName";
-        cell.Value = false;
 
         Action act = () => cell.MouseClick(new DataGridViewCellMouseEventArgs(0, 0, 10, 10, new MouseEventArgs(MouseButtons.Left, 1, 10, 10, 0)));
         act.Should().NotThrow();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellTests.cs
@@ -6523,7 +6523,8 @@ public partial class DataGridViewCellTests
             dataGridView.Rows.Clear();
             dataGridView.Rows.Add();
         });
-
+        // Set cell value to ensure it is properly formatted.
+        cell.Value = false;
         Action act = () => cell.MouseClick(new DataGridViewCellMouseEventArgs(0, 0, 10, 10, new MouseEventArgs(MouseButtons.Left, 1, 10, 10, 0)));
         act.Should().NotThrow();
     }


### PR DESCRIPTION
Remove unused variable from test DataGridViewCell_OnContentClick_ClearAndReAddCell_InvokeOnMouseUpInternal
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12743)