### PR TITLE
[release/9.0] Only Unwrap If Given IDataObject

### DIFF
--- a/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/ComHelpers.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/ComHelpers.cs
@@ -132,7 +132,7 @@ internal static unsafe partial class ComHelpers
     /// <summary>
     ///  Attempts to unwrap a ComWrapper CCW as a particular managed object.
     /// </summary>
-    private static bool TryUnwrapComWrapperCCW<TWrapper>(
+    public static bool TryUnwrapComWrapperCCW<TWrapper>(
         IUnknown* unknown,
         [NotNullWhen(true)] out TWrapper? @interface) where TWrapper : class
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
@@ -73,9 +73,9 @@ public unsafe partial class DataObject :
     internal DataObject(string format, bool autoConvert, object data) : this() => SetData(format, autoConvert, data);
 
     /// <summary>
-    ///  Flags that the original data was wrapped for clipboard purposes.
+    ///  Flags that the original data was not a user passed <see cref="IDataObject"/>.
     /// </summary>
-    internal bool IsWrappedForClipboard { get; init; }
+    internal bool IsOriginalNotIDataObject { get; init; }
 
     /// <summary>
     ///  Returns the inner data that the <see cref="DataObject"/> was created with if the original data implemented
@@ -84,7 +84,7 @@ public unsafe partial class DataObject :
     /// </summary>
     internal IDataObject TryUnwrapInnerIDataObject()
     {
-        Debug.Assert(IsWrappedForClipboard, "This method should only be used for clipboard purposes.");
+        Debug.Assert(!IsOriginalNotIDataObject, "This method should only be used for clipboard purposes.");
         return _innerData.OriginalIDataObject is { } original ? original : this;
     }
 

--- a/src/System.Windows.Forms/tests/ComDisabledTests/ClipboardComTests.cs
+++ b/src/System.Windows.Forms/tests/ComDisabledTests/ClipboardComTests.cs
@@ -4,6 +4,8 @@
 #nullable enable
 
 using System.Drawing;
+using System.Runtime.InteropServices;
+using ComTypes = System.Runtime.InteropServices.ComTypes;
 
 namespace System.Windows.Forms.Tests;
 
@@ -27,5 +29,69 @@ public partial class ClipboardTests
 
         Clipboard.ContainsData(format).Should().BeTrue();
         Clipboard.GetData(format).Should().Be(Color.Black);
+    }
+
+    [WinFormsFact]
+    public void Clipboard_GetSet_IDataObject_RoundTrip_ReturnsExpected()
+    {
+        CustomDataObject realDataObject = new();
+        Clipboard.SetDataObject(realDataObject);
+
+        IDataObject clipboardDataObject = Clipboard.GetDataObject().Should().BeAssignableTo<IDataObject>().Subject;
+        clipboardDataObject.Should().BeSameAs(realDataObject);
+        clipboardDataObject.GetDataPresent("Foo").Should().BeTrue();
+        clipboardDataObject.GetData("Foo").Should().Be("Bar");
+    }
+
+    [WinFormsFact]
+    public void Clipboard_SetDataObject_DerivedDataObject_ReturnsExpected()
+    {
+        DerivedDataObject derived = new();
+        Clipboard.SetDataObject(derived);
+        Clipboard.GetDataObject().Should().BeSameAs(derived);
+    }
+
+    private class DerivedDataObject : DataObject { }
+
+    private class CustomDataObject : IDataObject, ComTypes.IDataObject
+    {
+        [DllImport("shell32.dll")]
+        public static extern int SHCreateStdEnumFmtEtc(uint cfmt, ComTypes.FORMATETC[] afmt, out ComTypes.IEnumFORMATETC ppenumFormatEtc);
+
+        int ComTypes.IDataObject.DAdvise(ref ComTypes.FORMATETC pFormatetc, ComTypes.ADVF advf, ComTypes.IAdviseSink adviseSink, out int connection) => throw new NotImplementedException();
+        void ComTypes.IDataObject.DUnadvise(int connection) => throw new NotImplementedException();
+        int ComTypes.IDataObject.EnumDAdvise(out ComTypes.IEnumSTATDATA enumAdvise) => throw new NotImplementedException();
+        ComTypes.IEnumFORMATETC ComTypes.IDataObject.EnumFormatEtc(ComTypes.DATADIR direction)
+        {
+            if (direction == ComTypes.DATADIR.DATADIR_GET)
+            {
+                // Create enumerator and return it
+                ComTypes.IEnumFORMATETC enumerator;
+                if (SHCreateStdEnumFmtEtc(0, [], out enumerator) == 0)
+                {
+                    return enumerator;
+                }
+            }
+
+            throw new NotImplementedException();
+        }
+
+        int ComTypes.IDataObject.GetCanonicalFormatEtc(ref ComTypes.FORMATETC formatIn, out ComTypes.FORMATETC formatOut) => throw new NotImplementedException();
+        object IDataObject.GetData(string format, bool autoConvert) => format == "Foo" ? "Bar" : null!;
+        object IDataObject.GetData(string format) => format == "Foo" ? "Bar" : null!;
+        object IDataObject.GetData(Type format) => null!;
+        void ComTypes.IDataObject.GetData(ref ComTypes.FORMATETC format, out ComTypes.STGMEDIUM medium) => throw new NotImplementedException();
+        void ComTypes.IDataObject.GetDataHere(ref ComTypes.FORMATETC format, ref ComTypes.STGMEDIUM medium) => throw new NotImplementedException();
+        bool IDataObject.GetDataPresent(string format, bool autoConvert) => format == "Foo";
+        bool IDataObject.GetDataPresent(string format) => format == "Foo";
+        bool IDataObject.GetDataPresent(Type format) => false;
+        string[] IDataObject.GetFormats(bool autoConvert) => ["Foo"];
+        string[] IDataObject.GetFormats() => ["Foo"];
+        int ComTypes.IDataObject.QueryGetData(ref ComTypes.FORMATETC format) => throw new NotImplementedException();
+        void IDataObject.SetData(string format, bool autoConvert, object? data) => throw new NotImplementedException();
+        void IDataObject.SetData(string format, object? data) => throw new NotImplementedException();
+        void IDataObject.SetData(Type format, object? data) => throw new NotImplementedException();
+        void IDataObject.SetData(object? data) => throw new NotImplementedException();
+        void ComTypes.IDataObject.SetData(ref ComTypes.FORMATETC formatIn, ref ComTypes.STGMEDIUM medium, bool release) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
Backport of https://github.com/dotnet/winforms/pull/12738

## Customer Impact
When users set an object that is not an IDataObject onto our Clipboard using the SetDataObject API, calls to our clipboard APIs with `autoConvert = false` (either directly or indirectly) will no longer recognize equivalent clipboard formats as it had done in .NET 8, producing unintended behavior change.

This regressed because in .NET 9, we had switched to leveraging cswin32 and ComWrappers for our OLE interop. During this we discovered that switching from built-in COM to ComWrappers took away the ability to automatically cast native pointers back to their original managed object when round tripping through native code. In order to remedy this, we updated to wrap the data when setting it onto the clipboard and unwrap manually on clipboard retrieval before returning it in order to get the original data.

While doing this, however, we had missed the fact that the native IDataObject interface doesn't have the concept of explicit `autoConvert`. Meaning that when calling our Clipboard APIs with `autoConvert = false`, it will effectively be ignored and produce same results as `autoConvert = true`, recognizing equivalent clipboard formats if we're calling to a native IDataObject interface. In .NET 9, since we always unwrap the object retrieved from the clipboard to get our completely managed DataObject, we lost this behavior for types that don't already derive from managed IDataObject.

## Testing
Run on regression test suite and added unit tests covering scenario.

## Risk
Low. The fix is that when we wrap types that don't already derive from the managed IDataObject, we won't unwrap to the wrapping DataObject we created so that calls go through the native IDataObject interface, restoring behavior we had in .NET 8.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12745)