### PR TITLE
Skip TextDataFormat.Rtf validation on X64 for test "Clipboard_SetText_InvokeStringTextDataFormat_GetReturnsExpected"

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
@@ -498,10 +498,17 @@ public class ClipboardTests
         action.Should().Throw<ArgumentNullException>().WithParameterName("image");
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/12746")]
     [WinFormsTheory]
     [EnumData<TextDataFormat>]
     public void Clipboard_SetText_InvokeStringTextDataFormat_GetReturnsExpected(TextDataFormat format)
     {
+        // Skip validation of TextDataFormat.Rtf on X64 due to the active issue "https://github.com/dotnet/winforms/issues/12746"
+        if (format == TextDataFormat.Rtf && RuntimeInformation.ProcessArchitecture == Architecture.X64)
+        {
+            return;
+        }
+
         Clipboard.SetText("text", format);
         Clipboard.GetText(format).Should().Be("text");
         Clipboard.ContainsText(format).Should().BeTrue();


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related #12746


## Proposed changes

- Skip scenario Clipboard_SetText_InvokeStringTextDataFormat_GetReturnsExpected(format: Rtf) on X64

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12747)