### PR TITLE
fix issue #12589 Keyboard tooltip of toolStripDropDown item keeps displaying when tab to other control

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
@@ -3048,6 +3048,8 @@ public abstract partial class ToolStripItem :
                 ParentInternal.RestoreFocusInternal();
             }
 
+            Owner?.UpdateToolTip(this, true);
+
             return true;
         }
 


### PR DESCRIPTION
Fixes #12589 

## Root cause
https://github.com/dotnet/winforms/blob/012e82d6d2627bb10b47d7048d5ef117c74ee02f/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs#L4489-L4518

ToolStrip.UpdateToolTip can be used to show or hide the `ToolTip` of `ToolStrip`.
But we didn't update tooltip when Enter key is hit on ToolStripItem.

## Proposed changes

Update ToolTip when Enter key is hit on ToolStripItem

<!-- 
## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-
 -->
## Screenshots 

### Before

Keyboard tooltip of toolStripDropDown item keeps displaying when tab to other control:

![Image](https://github.com/user-attachments/assets/abe18a63-78ab-46fe-8bf3-01a7ff489b65)

https://github.com/user-attachments/assets/a8b70e73-11c5-42c9-8063-59e5d1be4051

### After

https://github.com/user-attachments/assets/f56efa61-5f6f-4503-bea8-08503291dc89

## Test methodology
Manually

<!-- 
## Accessibility testing  



## Test environment(s) 
-->
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12750)