### PR TITLE
Remove Clipboard.Clear From Some Tests

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
@@ -894,7 +894,6 @@ public class ClipboardTests
     [WinFormsFact]
     public void Clipboard_SetDataAsJson_DataObject_Throws()
     {
-        Clipboard.Clear();
         string format = "format";
         Action action = () => Clipboard.SetDataAsJson(format, new DataObject());
         action.Should().Throw<InvalidOperationException>();
@@ -905,7 +904,6 @@ public class ClipboardTests
     [WinFormsFact]
     public void Clipboard_SetDataAsJson_WithGeneric_ReturnsExpected()
     {
-        Clipboard.Clear();
         List<Point> generic1 = [];
         string format = "list";
         Clipboard.SetDataAsJson(format, generic1);
@@ -942,7 +940,6 @@ public class ClipboardTests
     [WinFormsFact]
     public void Clipboard_SetDataAsJson_ReturnsExpected()
     {
-        Clipboard.Clear();
         SimpleTestData testData = new() { X = 1, Y = 1 };
 
         Clipboard.SetDataAsJson("testDataFormat", testData);
@@ -955,7 +952,6 @@ public class ClipboardTests
     [WinFormsFact]
     public void Clipboard_SetDataAsJson_GetData()
     {
-        Clipboard.Clear();
         SimpleTestData testData = new() { X = 1, Y = 1 };
         // Note that this simulates out of process scenario.
         Clipboard.SetDataAsJson("test", testData);
@@ -973,7 +969,6 @@ public class ClipboardTests
     [BoolData]
     public void Clipboard_SetDataObject_WithJson_ReturnsExpected(bool copy)
     {
-        Clipboard.Clear();
         SimpleTestData testData = new() { X = 1, Y = 1 };
 
         DataObject dataObject = new();
@@ -999,7 +994,6 @@ public class ClipboardTests
     [BoolData]
     public void Clipboard_SetDataObject_WithMultipleData_ReturnsExpected(bool copy)
     {
-        Clipboard.Clear();
         SimpleTestData testData1 = new() { X = 1, Y = 1 };
         SimpleTestData testData2 = new() { Y = 2, X = 2 };
         DataObject data = new();
@@ -1022,7 +1016,6 @@ public class ClipboardTests
         // This test demonstrates how a user can manually deserialize JsonData<T> that has been serialized onto
         // the clipboard from stream. This may need to be done if type JsonData<T> does not exist in the .NET version
         // the user is utilizing.
-        Clipboard.Clear();
         SimpleTestData testData = new() { X = 1, Y = 1 };
         Clipboard.SetDataAsJson("testFormat", testData);
 


### PR DESCRIPTION
Related: https://github.com/dotnet/winforms/pull/12738#discussion_r1909558485

Clipboard.Clear was added to some Clipboard tests to help with flakyness in https://github.com/dotnet/winforms/pull/11527. At the time it was unclear why we were experiencing increased flaky Clipboard tests locally, but in https://github.com/dotnet/winforms/pull/12738 moved test that was added in JSON PR that was accessing Clipboard without being under same collection as other clipboard tests. Since this is now under same collection Clipboard.Clear should not be necessary so removing.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12755)