### PR TITLE
Add unit tests for DataGridViewSortCompareEventArgs

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSortCompareEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSortCompareEventArgsTests.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace System.Windows.Forms;
+
+public class DataGridViewSortCompareEventArgsTests : IDisposable
+{
+    private readonly DataGridView _dataGridView;
+    private readonly DataGridViewTextBoxColumn _column;
+
+    public DataGridViewSortCompareEventArgsTests()
+    {
+        _dataGridView = new();
+        _column = new DataGridViewTextBoxColumn { Index = 1 };
+        _dataGridView.Columns.Add(_column);
+    }
+
+    public void Dispose()
+    {
+        _dataGridView.Dispose();
+        _column.Dispose();
+    }
+
+    [WinFormsFact]
+    public void DataGridViewSortCompareEventArgs_Constructor_InitializesProperties()
+    {
+        var cellValue1 = "Value1";
+        var cellValue2 = "Value2";
+        int rowIndex1 = 0;
+        int rowIndex2 = 1;
+
+        var e = new DataGridViewSortCompareEventArgs(_column, cellValue1, cellValue2, rowIndex1, rowIndex2);
+
+        e.Column.Should().Be(_column);
+        e.CellValue1.Should().Be(cellValue1);
+        e.CellValue2.Should().Be(cellValue2);
+        e.RowIndex1.Should().Be(rowIndex1);
+        e.RowIndex2.Should().Be(rowIndex2);
+        e.SortResult.Should().Be(0);
+    }
+
+    [WinFormsFact]
+    public void DataGridViewSortCompareEventArgs_SortResult_Set_GetReturnsExpected()
+    {
+        var e = new DataGridViewSortCompareEventArgs(_column, null, null, 0, 1)
+        {
+            SortResult = 1
+        };
+
+        e.SortResult.Should().Be(1);
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSortCompareEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSortCompareEventArgsTests.cs
@@ -44,7 +44,12 @@ public class DataGridViewSortCompareEventArgsTests : IDisposable
     [Fact]
     public void DataGridViewSortCompareEventArgs_SortResult_Set_GetReturnsExpected()
     {
-        var e = new DataGridViewSortCompareEventArgs(_column, null, null, 0, 1)
+        var e = new DataGridViewSortCompareEventArgs(
+            _column,
+            cellValue1: null,
+            cellValue2: null,
+            rowIndex1: 0,
+            rowIndex2: 1)
         {
             SortResult = 1
         };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSortCompareEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSortCompareEventArgsTests.cs
@@ -23,7 +23,7 @@ public class DataGridViewSortCompareEventArgsTests : IDisposable
         _column.Dispose();
     }
 
-    [WinFormsFact]
+    [Fact]
     public void DataGridViewSortCompareEventArgs_Constructor_InitializesProperties()
     {
         var cellValue1 = "Value1";
@@ -41,7 +41,7 @@ public class DataGridViewSortCompareEventArgsTests : IDisposable
         e.SortResult.Should().Be(0);
     }
 
-    [WinFormsFact]
+    [Fact]
     public void DataGridViewSortCompareEventArgs_SortResult_Set_GetReturnsExpected()
     {
         var e = new DataGridViewSortCompareEventArgs(_column, null, null, 0, 1)


### PR DESCRIPTION
related https://github.com/dotnet/winforms/issues/10453

## Proposed changes
- Add unit tests for DataGridViewSortCompareEventArgs to test its Constructor initialization, SortResult property
- Enable nullability in DataGridViewSortCompareEventArgsTests.cs



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12768)