### PR TITLE
Add unit tests for CommandSet

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/CommandSetTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/CommandSetTests.cs
@@ -27,19 +27,20 @@ public class CommandSetTests
         mockSite.Setup(s => s.GetService(typeof(ISelectionService))).Returns(mockSelectionService.Object);
         mockSite.Setup(s => s.GetService(typeof(IDictionaryService))).Returns(mockDictionaryService.Object);
 
-        CommandSet commandSet = new(mockSite.Object);
+        using (CommandSet commandSet = new(mockSite.Object))
+        {
+            commandSet.Dispose();
 
-        commandSet.Dispose();
+            mockMenuCommandService.Verify(m => m.RemoveCommand(It.IsAny<MenuCommand>()), Times.AtLeastOnce);
+            mockEventHandlerService.VerifyRemove(e => e.EventHandlerChanged -= It.IsAny<EventHandler>(), Times.Once);
+            mockDesignerHost.VerifyRemove(h => h.Activated -= It.IsAny<EventHandler>(), Times.Once);
+            mockSelectionService.VerifyRemove(s => s.SelectionChanged -= It.IsAny<EventHandler>(), Times.Once);
 
-        mockMenuCommandService.Verify(m => m.RemoveCommand(It.IsAny<MenuCommand>()), Times.AtLeastOnce);
-        mockEventHandlerService.VerifyRemove(e => e.EventHandlerChanged -= It.IsAny<EventHandler>(), Times.Once);
-        mockDesignerHost.VerifyRemove(h => h.Activated -= It.IsAny<EventHandler>(), Times.Once);
-        mockSelectionService.VerifyRemove(s => s.SelectionChanged -= It.IsAny<EventHandler>(), Times.Once);
+            dynamic accessor = commandSet.TestAccessor().Dynamic;
 
-        dynamic accessor = commandSet.TestAccessor().Dynamic;
-
-        ((object)accessor.SelectionService).Should().BeNull();
-        ((object)accessor.BehaviorService).Should().BeNull();
-        ((object)accessor._menuService).Should().BeNull();
+            ((object)accessor.SelectionService).Should().BeNull();
+            ((object)accessor.BehaviorService).Should().BeNull();
+            ((object)accessor._menuService).Should().BeNull();
+        }
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/CommandSetTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/CommandSetTests.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using Moq;
+using System.ComponentModel;
+using System.ComponentModel.Design;
+
+namespace System.Windows.Forms.Design.Tests;
+
+public class CommandSetTests
+{
+    [Fact]
+    public void Dispose_DisposesResourcesCorrectly()
+    {
+        Mock<ISite> mockSite = new();
+        Mock<IEventHandlerService> mockEventHandlerService = new();
+        Mock<IDesignerHost> mockDesignerHost = new();
+        Mock<IMenuCommandService> mockMenuCommandService = new();
+        Mock<ISelectionService> mockSelectionService = new();
+        Mock<IDictionaryService> mockDictionaryService = new();
+
+        mockSite.Setup(s => s.GetService(typeof(IEventHandlerService))).Returns(mockEventHandlerService.Object);
+        mockSite.Setup(s => s.GetService(typeof(IDesignerHost))).Returns(mockDesignerHost.Object);
+        mockSite.Setup(s => s.GetService(typeof(IMenuCommandService))).Returns(mockMenuCommandService.Object);
+        mockSite.Setup(s => s.GetService(typeof(ISelectionService))).Returns(mockSelectionService.Object);
+        mockSite.Setup(s => s.GetService(typeof(IDictionaryService))).Returns(mockDictionaryService.Object);
+
+        CommandSet commandSet = new(mockSite.Object);
+
+        commandSet.Dispose();
+
+        mockMenuCommandService.Verify(m => m.RemoveCommand(It.IsAny<MenuCommand>()), Times.AtLeastOnce);
+        mockEventHandlerService.VerifyRemove(e => e.EventHandlerChanged -= It.IsAny<EventHandler>(), Times.Once);
+        mockDesignerHost.VerifyRemove(h => h.Activated -= It.IsAny<EventHandler>(), Times.Once);
+        mockSelectionService.VerifyRemove(s => s.SelectionChanged -= It.IsAny<EventHandler>(), Times.Once);
+
+        dynamic accessor = commandSet.TestAccessor().Dynamic;
+
+        ((object)accessor.SelectionService).Should().BeNull();
+        ((object)accessor.BehaviorService).Should().BeNull();
+        ((object)accessor._menuService).Should().BeNull();
+    }
+}

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/CommandSetTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/CommandSetTests.cs
@@ -27,15 +27,16 @@ public class CommandSetTests
         mockSite.Setup(s => s.GetService(typeof(ISelectionService))).Returns(mockSelectionService.Object);
         mockSite.Setup(s => s.GetService(typeof(IDictionaryService))).Returns(mockDictionaryService.Object);
 
-        using CommandSet commandSet = new(mockSite.Object);
-        commandSet.Dispose();
+        dynamic accessor;
+        using (CommandSet commandSet = new(mockSite.Object))
+        {
+            accessor = commandSet.TestAccessor().Dynamic;
+        }
 
         mockMenuCommandService.Verify(m => m.RemoveCommand(It.IsAny<MenuCommand>()), Times.AtLeastOnce);
         mockEventHandlerService.VerifyRemove(e => e.EventHandlerChanged -= It.IsAny<EventHandler>(), Times.Once);
         mockDesignerHost.VerifyRemove(h => h.Activated -= It.IsAny<EventHandler>(), Times.Once);
         mockSelectionService.VerifyRemove(s => s.SelectionChanged -= It.IsAny<EventHandler>(), Times.Once);
-
-        dynamic accessor = commandSet.TestAccessor().Dynamic;
 
         ((object)accessor.SelectionService).Should().BeNull();
         ((object)accessor.BehaviorService).Should().BeNull();

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/CommandSetTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/CommandSetTests.cs
@@ -27,20 +27,18 @@ public class CommandSetTests
         mockSite.Setup(s => s.GetService(typeof(ISelectionService))).Returns(mockSelectionService.Object);
         mockSite.Setup(s => s.GetService(typeof(IDictionaryService))).Returns(mockDictionaryService.Object);
 
-        using (CommandSet commandSet = new(mockSite.Object))
-        {
-            commandSet.Dispose();
+        using CommandSet commandSet = new(mockSite.Object);
+        commandSet.Dispose();
 
-            mockMenuCommandService.Verify(m => m.RemoveCommand(It.IsAny<MenuCommand>()), Times.AtLeastOnce);
-            mockEventHandlerService.VerifyRemove(e => e.EventHandlerChanged -= It.IsAny<EventHandler>(), Times.Once);
-            mockDesignerHost.VerifyRemove(h => h.Activated -= It.IsAny<EventHandler>(), Times.Once);
-            mockSelectionService.VerifyRemove(s => s.SelectionChanged -= It.IsAny<EventHandler>(), Times.Once);
+        mockMenuCommandService.Verify(m => m.RemoveCommand(It.IsAny<MenuCommand>()), Times.AtLeastOnce);
+        mockEventHandlerService.VerifyRemove(e => e.EventHandlerChanged -= It.IsAny<EventHandler>(), Times.Once);
+        mockDesignerHost.VerifyRemove(h => h.Activated -= It.IsAny<EventHandler>(), Times.Once);
+        mockSelectionService.VerifyRemove(s => s.SelectionChanged -= It.IsAny<EventHandler>(), Times.Once);
 
-            dynamic accessor = commandSet.TestAccessor().Dynamic;
+        dynamic accessor = commandSet.TestAccessor().Dynamic;
 
-            ((object)accessor.SelectionService).Should().BeNull();
-            ((object)accessor.BehaviorService).Should().BeNull();
-            ((object)accessor._menuService).Should().BeNull();
-        }
+        ((object)accessor.SelectionService).Should().BeNull();
+        ((object)accessor.BehaviorService).Should().BeNull();
+        ((object)accessor._menuService).Should().BeNull();
     }
 }


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773


## Proposed changes

- Add unit test CommandSetTests.cs for public method of the CommandSet.
- Enable nullability in CommandSetTests.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12769)