### PR TITLE
Add unit test for WebBrowserProgressChangedEventArgs

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WebBrowserProgressChangedEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WebBrowserProgressChangedEventArgsTests.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 namespace System.Windows.Forms.Tests;
 
 // NB: doesn't require thread affinity
@@ -16,5 +18,36 @@ public class WebBrowserProgressChangedEventArgsTests
         WebBrowserProgressChangedEventArgs e = new(currentProgress, maximumProgress);
         Assert.Equal(currentProgress, e.CurrentProgress);
         Assert.Equal(maximumProgress, e.MaximumProgress);
+    }
+
+    [WinFormsFact]
+    public void Constructor_ShouldSetPropertiesCorrectly()
+    {
+        long expectedCurrentProgress = 50;
+        long expectedMaximumProgress = 100;
+
+        WebBrowserProgressChangedEventArgs eventArgs = new(expectedCurrentProgress, expectedMaximumProgress);
+
+        eventArgs.CurrentProgress.Should().Be(expectedCurrentProgress, "CurrentProgress property was not set correctly.");
+        eventArgs.MaximumProgress.Should().Be(expectedMaximumProgress, "MaximumProgress property was not set correctly.");
+    }
+
+    [WinFormsFact]
+    public void CurrentProgress_ShouldReturnCorrectValue()
+    {
+        long expectedCurrentProgress = 75;
+        WebBrowserProgressChangedEventArgs eventArgs = new(expectedCurrentProgress, 100);
+
+        eventArgs.CurrentProgress.Should().Be(expectedCurrentProgress);
+    }
+
+    [WinFormsFact]
+    public void MaximumProgress_ShouldReturnCorrectValue()
+    {
+        long expectedMaximumProgress = 200;
+
+        WebBrowserProgressChangedEventArgs eventArgs = new(50, expectedMaximumProgress);
+
+        eventArgs.MaximumProgress.Should().Be(expectedMaximumProgress);
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WebBrowserProgressChangedEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WebBrowserProgressChangedEventArgsTests.cs
@@ -36,6 +36,7 @@ public class WebBrowserProgressChangedEventArgsTests
     public void CurrentProgress_ShouldReturnCorrectValue()
     {
         long expectedCurrentProgress = 75;
+
         WebBrowserProgressChangedEventArgs eventArgs = new(expectedCurrentProgress, 100);
 
         eventArgs.CurrentProgress.Should().Be(expectedCurrentProgress);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

related https://github.com/dotnet/winforms/issues/10453


## Proposed changes

- Add unit tests for WebBrowserProgressChangedEventArgs.cs to test its constructor and the properties CurrentProgress and MaximumProgress
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12778)