### PR TITLE
[release/9.0] WinForms ComboBox border and drop down button are not visible sometimes

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.FlatComboAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.FlatComboAdapter.cs
@@ -23,9 +23,7 @@ public partial class ComboBox
         private const int OFFSET_2PIXELS = 2;
         protected static int s_offsetPixels = OFFSET_2PIXELS;
 
-        private bool ShouldRedrawAsSmallButton { get; }
-
-        public FlatComboAdapter(ComboBox comboBox, bool shouldRedrawAsSmallButton)
+        public FlatComboAdapter(ComboBox comboBox, bool smallButton)
         {
             // adapter is re-created when combobox is resized, see IsValid method, thus we don't need to handle DPI changed explicitly
             s_offsetPixels = comboBox.LogicalToDeviceUnits(OFFSET_2PIXELS);
@@ -37,10 +35,8 @@ public partial class ComboBox
             _innerInnerBorder = new Rectangle(_innerBorder.X + 1, _innerBorder.Y + 1, _innerBorder.Width - 2, _innerBorder.Height - 2);
             _dropDownRect = new Rectangle(_innerBorder.Right + 1, _innerBorder.Y, dropDownButtonWidth, _innerBorder.Height + 1);
 
-            ShouldRedrawAsSmallButton = shouldRedrawAsSmallButton;
-
             // fill in several pixels of the dropdown rect with white so that it looks like the combo button is thinner.
-            if (shouldRedrawAsSmallButton)
+            if (smallButton)
             {
                 _whiteFillRect = _dropDownRect;
                 _whiteFillRect.Width = WhiteFillRectWidth;
@@ -62,48 +58,6 @@ public partial class ComboBox
         public bool IsValid(ComboBox combo)
         {
             return (combo.ClientRectangle == _clientRect && combo.RightToLeft == _origRightToLeft);
-        }
-
-        public virtual void DrawPopUpCombo(ComboBox comboBox, Graphics g)
-        {
-            if (comboBox.DropDownStyle == ComboBoxStyle.Simple)
-            {
-                return;
-            }
-
-            if (ShouldRedrawAsSmallButton)
-            {
-                DrawFlatCombo(comboBox, g);
-            }
-
-            bool rightToLeft = comboBox.RightToLeft == RightToLeft.Yes;
-
-            // Draw a dark border around everything if we're in popup mode
-            if ((!comboBox.Enabled) || (comboBox.FlatStyle == FlatStyle.Popup))
-            {
-                bool focused = comboBox.ContainsFocus || comboBox.MouseIsOver;
-                Color borderPenColor = GetPopupOuterBorderColor(comboBox, focused);
-
-                using var borderPen = borderPenColor.GetCachedPenScope();
-                Pen innerPen = comboBox.Enabled ? borderPen : SystemPens.Control;
-
-                // Draw a border around the dropdown.
-                if (rightToLeft)
-                {
-                    g.DrawRectangle(
-                        innerPen,
-                        new Rectangle(_outerBorder.X, _outerBorder.Y, _dropDownRect.Width + 1, _outerBorder.Height));
-                }
-                else
-                {
-                    g.DrawRectangle(
-                        innerPen,
-                        new Rectangle(_dropDownRect.X, _outerBorder.Y, _outerBorder.Right - _dropDownRect.X, _outerBorder.Height));
-                }
-
-                // Draw a border around the whole comboBox.
-                g.DrawRectangle(borderPen, _outerBorder);
-            }
         }
 
         /// <summary>
@@ -153,6 +107,33 @@ public partial class ComboBox
             using var innerBorderPen = innerBorderColor.GetCachedPenScope();
             g.DrawRectangle(innerBorderPen, _innerBorder);
             g.DrawRectangle(innerBorderPen, _innerInnerBorder);
+
+            // Draw a dark border around everything if we're in popup mode
+            if ((!comboBox.Enabled) || (comboBox.FlatStyle == FlatStyle.Popup))
+            {
+                bool focused = comboBox.ContainsFocus || comboBox.MouseIsOver;
+                Color borderPenColor = GetPopupOuterBorderColor(comboBox, focused);
+
+                using var borderPen = borderPenColor.GetCachedPenScope();
+                Pen innerPen = comboBox.Enabled ? borderPen : SystemPens.Control;
+
+                // Around the dropdown
+                if (rightToLeft)
+                {
+                    g.DrawRectangle(
+                        innerPen,
+                        new Rectangle(_outerBorder.X, _outerBorder.Y, _dropDownRect.Width + 1, _outerBorder.Height));
+                }
+                else
+                {
+                    g.DrawRectangle(
+                        innerPen,
+                        new Rectangle(_dropDownRect.X, _outerBorder.Y, _outerBorder.Right - _dropDownRect.X, _outerBorder.Height));
+                }
+
+                // Around the whole combobox.
+                g.DrawRectangle(borderPen, _outerBorder);
+            }
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
@@ -3899,14 +3899,7 @@ public partial class ComboBox : ListControl
                     }
 
                     using Graphics g = Graphics.FromHdcInternal((IntPtr)dc);
-                    if ((!Enabled || FlatStyle == FlatStyle.Popup) && MouseIsOver)
-                    {
-                        FlatComboBoxAdapter.DrawPopUpCombo(this, g);
-                    }
-                    else
-                    {
-                        FlatComboBoxAdapter.DrawFlatCombo(this, g);
-                    }
+                    FlatComboBoxAdapter.DrawFlatCombo(this, g);
 
                     return;
                 }
@@ -3990,5 +3983,5 @@ public partial class ComboBox : ListControl
     }
 
     internal virtual FlatComboAdapter CreateFlatComboAdapterInstance()
-        => new(this, shouldRedrawAsSmallButton: false);
+        => new(this, smallButton: false);
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripComboBox.ToolStripComboBoxControl.ToolStripComboBoxFlatComboAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripComboBox.ToolStripComboBoxControl.ToolStripComboBoxFlatComboAdapter.cs
@@ -12,7 +12,7 @@ public partial class ToolStripComboBox
     {
         internal class ToolStripComboBoxFlatComboAdapter : FlatComboAdapter
         {
-            public ToolStripComboBoxFlatComboAdapter(ComboBox comboBox) : base(comboBox, shouldRedrawAsSmallButton: true)
+            public ToolStripComboBoxFlatComboAdapter(ComboBox comboBox) : base(comboBox, smallButton: true)
             {
             }
 


### PR DESCRIPTION
Backport #12737 to 9.0
Fixes #12744
Fixes #12590

## Customer Impact

- `ComboBox` drop down button disappears when switching RightToLeft property, or recreating the `ComboBox` for any other reason.
- `ComboBox` focus border is not shown when TAB-ing into ToolStripComboBoxItem

## Root Cause

- Regression introduced by PRs #11529 and #11761, which modified how `ComboBox` controls was be drawn. It was an attempt to fix flickering of the control border when the mouse hovers over the control by reducing the number of times control is re-drawn, but we missed some cases where re-drawing was required. We don't have a better fix for the original flickering issue at the moment.

## Proposed changes

- Revert code from PRs #11529 and #11761, as that issue is less impactful than the new one we inadvertently introduced.

## Regression?

- Yes

## Risk

- Minimal

## Screenshots

### Before

![backport-9-before](https://github.com/user-attachments/assets/4f615f12-e22e-49e8-a199-2e1478df2196)

### After

![backport-9-after](https://github.com/user-attachments/assets/0e1f7a44-593e-4e72-b2d8-30e934daf93a)

## Test methodology

- Manual

## Test environment(s)

- 9.0.100
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12785)