### PR TITLE
fix #12777 Keyboard tooltip of toolStripDropDownButton item still displaying when tab to other control

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
@@ -3286,6 +3286,7 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
     {
         base.OnLostFocus(e);
         ClearAllSelections();
+        ToolTip.Hide(this);
     }
 
     protected internal override void OnLeave(EventArgs e)


### PR DESCRIPTION

fix #12777


## Proposed changes

- 
- add hiding ToolTip logic, When toolstrip loses focus, 
- 



## Customer Impact
- 
- now tooltip can disappear.
- 
<!--  
## Regression? 

- Yes / No

## Risk

-
-->



## Screenshots 

### Before

https://github.com/user-attachments/assets/296542aa-5bc1-4ed4-b018-f19b28a33bcc

### After


https://github.com/user-attachments/assets/bfc07993-6bab-49b4-aec0-c44033ec6fe7




## Test methodology 

- 
- manual
- 
<!--

## Accessibility testing 

  -->


 

## Test environment(s) 

10.0.0-alpha.1.25064.15

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12797)