### PR TITLE
Revert "fix issue 12680 [HDPI]The dot line disappeared between checkb…

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -1915,10 +1915,6 @@ public partial class TreeView : Control
         {
             PInvokeCore.SendMessage(this, PInvoke.TVM_SETINDENT, (WPARAM)_indent);
         }
-        else if (ScaleHelper.IsScalingRequired)
-        {
-            PInvokeCore.SendMessage(this, PInvoke.TVM_SETINDENT, (WPARAM)ScaleHelper.ScaleToInitialSystemDpi(DefaultTreeViewIndent));
-        }
 
         if (_itemHeight != -1)
         {


### PR DESCRIPTION
Revert PR [12706](https://github.com/dotnet/winforms/pull/12706), Because it introduced a issue.

When the screen is scaled to 300%.

https://github.com/user-attachments/assets/ebdadaf2-01ff-4221-a3e0-b27bc73684ac



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12798)