### PR TITLE
Don't unwrap wrapped DataObject inner data store

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
@@ -56,11 +56,7 @@ public unsafe partial class DataObject :
     /// </remarks>
     public DataObject(object data)
     {
-        if (data is DataObject dataObject)
-        {
-            _innerData = dataObject._innerData;
-        }
-        else if (data is IDataObject iDataObject)
+        if (data is IDataObject iDataObject)
         {
             _innerData = Composition.CreateFromWinFormsDataObject(iDataObject);
         }
@@ -302,7 +298,10 @@ public unsafe partial class DataObject :
         Func<TypeName, Type>? resolver,
         bool autoConvert,
         [NotNullWhen(true), MaybeNullWhen(false)] out T data) =>
-            _innerData.TryGetData(format, resolver!, autoConvert, out data);
+        // Invoke the appropriate overload so we don't fail a null check on a nested object if the resolver is null.
+        resolver is null
+            ? _innerData.TryGetData(format, autoConvert, out data)
+            : _innerData.TryGetData(format, resolver, autoConvert, out data);
 
     public virtual bool ContainsAudio() => GetDataPresent(DataFormats.WaveAudioConstant, autoConvert: false);
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
@@ -1259,4 +1259,33 @@ public class ClipboardTests
         byte[] array = stream.ToArray();
         array.Should().BeEquivalentTo("Hello, World!\0"u8.ToArray());
     }
+
+    [WinFormsFact]
+    public void Clipboard_DerivedDataObject_DataPresent()
+    {
+        // https://github.com/dotnet/winforms/issues/12789
+        SomeDataObject data = new();
+
+        // This was provided as a workaround for the above and should not break, but should
+        // also work without it.
+        data.SetData(SomeDataObject.Format, data);
+
+        Clipboard.SetDataObject(data);
+        Clipboard.ContainsData(SomeDataObject.Format).Should().BeTrue();
+        Clipboard.GetDataObject()!.GetDataPresent(SomeDataObject.Format).Should().BeTrue();
+
+        data = new();
+        Clipboard.SetDataObject(data);
+        Clipboard.ContainsData(SomeDataObject.Format).Should().BeTrue();
+        Clipboard.GetDataObject()!.GetDataPresent(SomeDataObject.Format).Should().BeTrue();
+    }
+
+    public class SomeDataObject : DataObject
+    {
+        public static string Format => "SomeDataObjectId";
+        public override string[] GetFormats() => [Format];
+
+        public override bool GetDataPresent(string format, bool autoConvert)
+            => format == Format || base.GetDataPresent(format, autoConvert);
+    }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
@@ -3042,4 +3042,77 @@ public partial class DataObjectTests
         dataObject.TryGetData("test", out Bitmap data).Should().BeFalse();
         data.Should().BeNull();
     }
+
+    [Fact]
+    public void DataObject_CreateFromDataObject_DoesNotUnwrapDataStore()
+    {
+        // The inner data should not have it's data store unwrapped.
+        DataObject dataObject = new();
+        DataObject wrapped = new(dataObject);
+        DataObject.Composition composition = wrapped.TestAccessor().Dynamic._innerData;
+        IDataObject original = composition.TestAccessor().Dynamic._winFormsDataObject;
+        original.Should().BeSameAs(dataObject);
+    }
+
+    [Fact]
+    public void DataObject_CreateFromDataObject_VirtualsAreCalled()
+    {
+        Mock<DataObject> mock = new(MockBehavior.Loose);
+        DataObject wrapped = new(mock.Object);
+
+        wrapped.GetData("Foo", false);
+        mock.Verify(o => o.GetData("Foo", false), Times.Once());
+        mock.VerifyNoOtherCalls();
+        mock.Reset();
+
+        wrapped.GetData("Foo");
+        mock.Verify(o => o.GetData("Foo", true), Times.Once());
+        mock.VerifyNoOtherCalls();
+        mock.Reset();
+
+        wrapped.GetData(typeof(string));
+        mock.Verify(o => o.GetData("System.String", true), Times.Once());
+        mock.VerifyNoOtherCalls();
+        mock.Reset();
+
+        wrapped.GetDataPresent("Foo", false);
+        mock.Verify(o => o.GetDataPresent("Foo", false), Times.Once());
+        mock.VerifyNoOtherCalls();
+        mock.Reset();
+
+        wrapped.GetDataPresent("Foo");
+        mock.Verify(o => o.GetDataPresent("Foo", true), Times.Once());
+        mock.VerifyNoOtherCalls();
+        mock.Reset();
+
+        wrapped.GetDataPresent(typeof(string));
+        mock.Verify(o => o.GetDataPresent("System.String", true), Times.Once());
+        mock.VerifyNoOtherCalls();
+        mock.Reset();
+
+        wrapped.GetFormats(false);
+        mock.Verify(o => o.GetFormats(false), Times.Once());
+        mock.VerifyNoOtherCalls();
+        mock.Reset();
+
+        wrapped.GetFormats();
+        mock.Verify(o => o.GetFormats(true), Times.Once());
+        mock.VerifyNoOtherCalls();
+        mock.Reset();
+
+        wrapped.SetData("Foo", "Bar");
+        mock.Verify(o => o.SetData("Foo", "Bar"), Times.Once());
+        mock.VerifyNoOtherCalls();
+        mock.Reset();
+
+        wrapped.SetData(typeof(string), "Bar");
+        mock.Verify(o => o.SetData(typeof(string), "Bar"), Times.Once());
+        mock.VerifyNoOtherCalls();
+        mock.Reset();
+
+        wrapped.SetData("Bar");
+        mock.Verify(o => o.SetData("Bar"), Times.Once());
+        mock.VerifyNoOtherCalls();
+        mock.Reset();
+    }
 }


### PR DESCRIPTION
When creating a DataObject from another DataObject we need to keep the original DataObject as the "inner" data so that virtuals get called as they historically have.

Also pass through to correct overload on TryGetDataCore.

Fixes #12789

(Note that #12789 is "fixed" by wrapping/unwrapping the original DataObject in #12738, but that doesn't fix the underlying problem.)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12800)