### PR TITLE
Refactor DataFormats

### DIFF
--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Core/Ole/IDataFormat.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Core/Ole/IDataFormat.cs
@@ -3,8 +3,30 @@
 
 namespace System.Private.Windows.Core.Ole;
 
+/// <summary>
+///  Internal interface for a data format.
+/// </summary>
 internal interface IDataFormat
 {
+    /// <summary>
+    ///  Specifies the name of this format.
+    /// </summary>
     string Name { get; }
+
+    /// <summary>
+    ///  Specifies the ID number for this format.
+    /// </summary>
     int Id { get; }
+}
+
+/// <summary>
+///  Typed interface for a data format that allows for creation.
+/// </summary>
+internal interface IDataFormat<T> : IDataFormat
+    where T : IDataFormat
+{
+    /// <summary>
+    ///  Creates a new instance of the data format.
+    /// </summary>
+    static abstract T Create(string name, int id);
 }

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Core/Ole/IDataFormat.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Core/Ole/IDataFormat.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Private.Windows.Core.Ole;
+
+internal interface IDataFormat
+{
+    string Name { get; }
+    int Id { get; }
+}

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Core/Ole/TextDataFormat.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Core/Ole/TextDataFormat.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Private.Windows.Core.Ole;
+
+internal enum TextDataFormat
+{
+    /// <summary>
+    ///  Specifies the standard ANSI text format.
+    /// </summary>
+    Text,
+
+    /// <summary>
+    ///  Specifies the standard Windows Unicode text format.
+    /// </summary>
+    UnicodeText,
+
+    /// <summary>
+    ///  Specifies text consisting of Rich Text Format (RTF) data.
+    /// </summary>
+    Rtf,
+
+    /// <summary>
+    ///  Specifies text consisting of HTML data.
+    /// </summary>
+    Html,
+
+    /// <summary>
+    ///  Specifies a comma-separated value (CSV) format, which is a
+    ///  common interchange format used by spreadsheets.
+    /// </summary>
+    CommaSeparatedValue,
+
+    /// <summary>
+    ///  Specifies a data format as Xaml.
+    /// </summary>
+    Xaml
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataFormats.Format.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataFormats.Format.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using PrivateOle = System.Private.Windows.Core.Ole;
+
 namespace System.Windows.Forms;
 
 /// <summary>
@@ -14,7 +16,7 @@ public static partial class DataFormats
     /// <summary>
     ///  Represents a format type.
     /// </summary>
-    public class Format
+    public class Format : PrivateOle.IDataFormat
     {
         /// <summary>
         ///  Initializes a new instance of the <see cref="Format"/> class and

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataFormats.Format.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataFormats.Format.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using PrivateOle = System.Private.Windows.Core.Ole;
+using System.Private.Windows.Core.Ole;
 
 namespace System.Windows.Forms;
 
@@ -16,7 +16,7 @@ public static partial class DataFormats
     /// <summary>
     ///  Represents a format type.
     /// </summary>
-    public class Format : PrivateOle.IDataFormat
+    public class Format : IDataFormat<Format>
     {
         /// <summary>
         ///  Initializes a new instance of the <see cref="Format"/> class and
@@ -28,14 +28,10 @@ public static partial class DataFormats
             Id = id;
         }
 
-        /// <summary>
-        ///  Specifies the name of this format.
-        /// </summary>
         public string Name { get; }
 
-        /// <summary>
-        ///  Specifies the ID number for this format.
-        /// </summary>
         public int Id { get; }
+
+        static Format IDataFormat<Format>.Create(string name, int id) => new(name, id);
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/TextDataFormat.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/TextDataFormat.cs
@@ -1,17 +1,28 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using PrivateOle = System.Private.Windows.Core.Ole;
+
 namespace System.Windows.Forms;
 
 /// <summary>
-///  Specifies the formats that can be used with Clipboard.GetText and
-///  Clipboard.SetText methods
+///  Specifies the formats used with text-related methods of the
+///  <see cref="Clipboard"/> and <see cref="DataObject"/> classes.
 /// </summary>
 public enum TextDataFormat
 {
-    Text,
-    UnicodeText,
-    Rtf,
-    Html,
-    CommaSeparatedValue
+    /// <inheritdoc cref="PrivateOle.TextDataFormat.Text"/>/>
+    Text = PrivateOle.TextDataFormat.Text,
+
+    /// <inheritdoc cref="PrivateOle.TextDataFormat.UnicodeText"/>
+    UnicodeText = PrivateOle.TextDataFormat.UnicodeText,
+
+    /// <inheritdoc cref="PrivateOle.TextDataFormat.Rtf"/>
+    Rtf = PrivateOle.TextDataFormat.Rtf,
+
+    /// <inheritdoc cref="PrivateOle.TextDataFormat.Html"/>
+    Html = PrivateOle.TextDataFormat.Html,
+
+    /// <inheritdoc cref="PrivateOle.TextDataFormat.CommaSeparatedValue"/>
+    CommaSeparatedValue = PrivateOle.TextDataFormat.CommaSeparatedValue
 }


### PR DESCRIPTION
Prepare DataFormats to move core implementation to share with WPF.

This splits the format list into two collections. The first is the known predefined format ids that come from Windows headers. The second collection contains ones that must be looked up. This optimizes allocations for typical user scenarios in WinForms and WPF.

An internal interface is used to abstract the Format class.

Next PR will move the shared logic into the shared assembly.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12802)