### PR TITLE
Move DataFormat code to Core

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -1192,7 +1192,7 @@ public sealed unsafe partial class Graphics : MarshalByRefObject, IDisposable, I
     public void Clear(Color color) => CheckStatus(PInvokeGdiPlus.GdipGraphicsClear(NativeGraphics, (uint)color.ToArgb()));
 
 #if NET9_0_OR_GREATER
-    /// <inheritdoc cref="FillRoundedRectangle(Brush, RectangleF, SizeF)"/>/>
+    /// <inheritdoc cref="FillRoundedRectangle(Brush, RectangleF, SizeF)"/>
     public void FillRoundedRectangle(Brush brush, Rectangle rect, Size radius) =>
         FillRoundedRectangle(brush, (RectangleF)rect, radius);
 

--- a/src/System.Private.Windows.Core/src/NativeMethods.txt
+++ b/src/System.Private.Windows.Core/src/NativeMethods.txt
@@ -5,6 +5,7 @@ BOOL
 CLIPBRD_E_BAD_DATA
 CLR_*
 CallWindowProc
+CLIPBOARD_FORMAT
 CoCreateInstance
 CombineRgn
 CopyImage
@@ -78,6 +79,7 @@ GetWindowText
 GetWindowTextLength
 GET_CLASS_LONG_INDEX
 GetClientRect
+GetClipboardFormatName
 GetClipRgn
 GetDC
 GetDCEx
@@ -171,6 +173,7 @@ PWSTR
 RealizePalette
 RECT
 REGDB_E_CLASSNOTREG
+RegisterClipboardFormat
 ReleaseDC
 RestoreDC
 RPC_E_CHANGED_MODE

--- a/src/System.Private.Windows.Core/src/Resources/SR.resx
+++ b/src/System.Private.Windows.Core/src/Resources/SR.resx
@@ -125,4 +125,7 @@
   <data name="Serialization_MissingType" xml:space="preserve">
     <value>Could not find type '{0}'.</value>
   </data>
+  <data name="RegisterCFFailed" xml:space="preserve">
+    <value>Clipboard format registration did not succeed.</value>
+  </data>
 </root>

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Core/Ole/DataFormatConstants.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Core/Ole/DataFormatConstants.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Private.Windows.Core.Ole;
+
+internal static partial class DataFormatConstants
+{
+    internal const string Text = "Text";
+    internal const string UnicodeText = "UnicodeText";
+    internal const string Dib = "DeviceIndependentBitmap";
+    internal const string Bitmap = "Bitmap";
+    internal const string Emf = "EnhancedMetafile";
+    internal const string Wmf = "MetaFilePict";
+    internal const string SymbolicLink = "SymbolicLink";
+    internal const string Dif = "DataInterchangeFormat";
+    internal const string Tiff = "TaggedImageFileFormat";
+    internal const string OemText = "OEMText";
+    internal const string Palette = "Palette";
+    internal const string PenData = "PenData";
+    internal const string Riff = "RiffAudio";
+    internal const string WaveAudio = "WaveAudio";
+    internal const string FileDrop = "FileDrop";
+    internal const string Locale = "Locale";
+    internal const string Html = "HTML Format";
+    internal const string Rtf = "Rich Text Format";
+    internal const string Csv = "Csv";
+    internal const string String = "System.String";
+    internal const string Serializable = "WindowsForms10PersistentObject";
+    internal const string Xaml = "Xaml";
+    internal const string XamlPackage = "XamlPackage";
+    internal const string InkSerializedFormat = "Ink Serialized Format";
+}

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Core/Ole/DataFormatNames.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Core/Ole/DataFormatNames.cs
@@ -3,7 +3,7 @@
 
 namespace System.Private.Windows.Core.Ole;
 
-internal static partial class DataFormatConstants
+internal static partial class DataFormatNames
 {
     internal const string Text = "Text";
     internal const string UnicodeText = "UnicodeText";

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Core/Ole/DataFormatsCore.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Core/Ole/DataFormatsCore.cs
@@ -145,22 +145,22 @@ internal static partial class DataFormatsCore<T> where T : IDataFormat<T>
         s_predefinedFormatList ??=
         [
             // Text name                                    Win32 format ID
-            T.Create(DataFormatConstants.UnicodeText,       (int)CLIPBOARD_FORMAT.CF_UNICODETEXT),
-            T.Create(DataFormatConstants.Text,              (int)CLIPBOARD_FORMAT.CF_TEXT),
-            T.Create(DataFormatConstants.Bitmap,            (int)CLIPBOARD_FORMAT.CF_BITMAP),
-            T.Create(DataFormatConstants.Wmf,               (int)CLIPBOARD_FORMAT.CF_METAFILEPICT),
-            T.Create(DataFormatConstants.Emf,               (int)CLIPBOARD_FORMAT.CF_ENHMETAFILE),
-            T.Create(DataFormatConstants.Dif,               (int)CLIPBOARD_FORMAT.CF_DIF),
-            T.Create(DataFormatConstants.Tiff,              (int)CLIPBOARD_FORMAT.CF_TIFF),
-            T.Create(DataFormatConstants.OemText,           (int)CLIPBOARD_FORMAT.CF_OEMTEXT),
-            T.Create(DataFormatConstants.Dib,               (int)CLIPBOARD_FORMAT.CF_DIB),
-            T.Create(DataFormatConstants.Palette,           (int)CLIPBOARD_FORMAT.CF_PALETTE),
-            T.Create(DataFormatConstants.PenData,           (int)CLIPBOARD_FORMAT.CF_PENDATA),
-            T.Create(DataFormatConstants.Riff,              (int)CLIPBOARD_FORMAT.CF_RIFF),
-            T.Create(DataFormatConstants.WaveAudio,         (int)CLIPBOARD_FORMAT.CF_WAVE),
-            T.Create(DataFormatConstants.SymbolicLink,      (int)CLIPBOARD_FORMAT.CF_SYLK),
-            T.Create(DataFormatConstants.FileDrop,          (int)CLIPBOARD_FORMAT.CF_HDROP),
-            T.Create(DataFormatConstants.Locale,            (int)CLIPBOARD_FORMAT.CF_LOCALE)
+            T.Create(DataFormatNames.UnicodeText,       (int)CLIPBOARD_FORMAT.CF_UNICODETEXT),
+            T.Create(DataFormatNames.Text,              (int)CLIPBOARD_FORMAT.CF_TEXT),
+            T.Create(DataFormatNames.Bitmap,            (int)CLIPBOARD_FORMAT.CF_BITMAP),
+            T.Create(DataFormatNames.Wmf,               (int)CLIPBOARD_FORMAT.CF_METAFILEPICT),
+            T.Create(DataFormatNames.Emf,               (int)CLIPBOARD_FORMAT.CF_ENHMETAFILE),
+            T.Create(DataFormatNames.Dif,               (int)CLIPBOARD_FORMAT.CF_DIF),
+            T.Create(DataFormatNames.Tiff,              (int)CLIPBOARD_FORMAT.CF_TIFF),
+            T.Create(DataFormatNames.OemText,           (int)CLIPBOARD_FORMAT.CF_OEMTEXT),
+            T.Create(DataFormatNames.Dib,               (int)CLIPBOARD_FORMAT.CF_DIB),
+            T.Create(DataFormatNames.Palette,           (int)CLIPBOARD_FORMAT.CF_PALETTE),
+            T.Create(DataFormatNames.PenData,           (int)CLIPBOARD_FORMAT.CF_PENDATA),
+            T.Create(DataFormatNames.Riff,              (int)CLIPBOARD_FORMAT.CF_RIFF),
+            T.Create(DataFormatNames.WaveAudio,         (int)CLIPBOARD_FORMAT.CF_WAVE),
+            T.Create(DataFormatNames.SymbolicLink,      (int)CLIPBOARD_FORMAT.CF_SYLK),
+            T.Create(DataFormatNames.FileDrop,          (int)CLIPBOARD_FORMAT.CF_HDROP),
+            T.Create(DataFormatNames.Locale,            (int)CLIPBOARD_FORMAT.CF_LOCALE)
         ];
     }
 }

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Core/Ole/DataFormatsCore.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Core/Ole/DataFormatsCore.cs
@@ -1,0 +1,166 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+using System.Private.Windows.Core.Resources;
+using Windows.Win32;
+using Windows.Win32.System.Ole;
+
+namespace System.Private.Windows.Core.Ole;
+
+internal static partial class DataFormatsCore<T> where T : IDataFormat<T>
+{
+    private static List<T>? s_formatList;
+    private static T[]? s_predefinedFormatList;
+
+#if NET9_0_OR_GREATER
+    private static readonly Lock s_internalSyncObject = new();
+#else
+    private static readonly object s_internalSyncObject = new();
+#endif
+
+    internal static T GetOrAddFormat(string format)
+    {
+        lock (s_internalSyncObject)
+        {
+            EnsurePredefined();
+
+            // It is much faster to do a case sensitive search here.
+            // So do the case sensitive compare first, then the expensive one.
+            if (TryFindFormat(s_predefinedFormatList, format, StringComparison.Ordinal, out var found)
+                || TryFindFormat(s_formatList, format, StringComparison.Ordinal, out found)
+                || TryFindFormat(s_predefinedFormatList, format, StringComparison.OrdinalIgnoreCase, out found)
+                || TryFindFormat(s_formatList, format, StringComparison.OrdinalIgnoreCase, out found))
+            {
+                return found;
+            }
+
+            // Need to add this format string
+            uint formatId = PInvokeCore.RegisterClipboardFormat(format);
+            if (formatId == 0)
+            {
+                throw new Win32Exception(SR.RegisterCFFailed);
+            }
+
+            s_formatList ??= [];
+            T newFormat = T.Create(format, (int)formatId);
+            s_formatList.Add(newFormat);
+            return newFormat;
+        }
+
+        static bool TryFindFormat(
+            IReadOnlyList<T>? formats,
+            string name,
+            StringComparison comparison,
+            [NotNullWhen(true)] out T? format)
+        {
+            if (formats is not null)
+            {
+                for (int i = 0; i < formats.Count; i++)
+                {
+                    format = formats[i];
+                    if (string.Equals(format.Name, name, comparison))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            format = default;
+            return false;
+        }
+    }
+
+    internal static unsafe T GetOrAddFormat(int id)
+    {
+        // Win32 uses an unsigned 16 bit type as a format ID, thus stripping off the leading bits.
+        // Registered format IDs are in the range 0xC000 through 0xFFFF, thus it's important
+        // to represent format as an unsigned type.
+        ushort shortId = (ushort)(id & 0xFFFF);
+
+        lock (s_internalSyncObject)
+        {
+            EnsurePredefined();
+
+            if (TryFindFormat(s_predefinedFormatList, shortId, out T? found)
+                || TryFindFormat(s_formatList, shortId, out found))
+            {
+                return found;
+            }
+
+            // The max length of the name of clipboard formats is equal to the max length
+            // of a Win32 Atom of 255 chars. An additional null terminator character is added,
+            // giving a required capacity of 256 chars.
+
+            string? name = null;
+            Span<char> buffer = stackalloc char[256];
+            fixed (char* pBuffer = buffer)
+            {
+                int length = PInvokeCore.GetClipboardFormatName(shortId, pBuffer, 256);
+                if (length != 0)
+                {
+                    name = buffer[..length].ToString();
+                }
+            }
+
+            // This can happen if windows adds a standard format that we don't know about,
+            // so we should play it safe.
+            name ??= $"Format{shortId}";
+
+            s_formatList ??= [];
+            T newFormat = T.Create(name, shortId);
+            s_formatList.Add(newFormat);
+            return newFormat;
+
+            static bool TryFindFormat(
+                IReadOnlyList<T>? formats,
+                int id,
+                [NotNullWhen(true)] out T? format)
+            {
+                if (formats is not null)
+                {
+                    for (int i = 0; i < formats.Count; i++)
+                    {
+                        format = formats[i];
+                        if (format.Id == id)
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                format = default;
+                return false;
+            }
+        }
+    }
+
+    /// <summary>
+    ///  Ensures that the Win32 predefined formats are setup in our format list.
+    ///  This is called anytime we need to search the list
+    /// </summary>
+    [MemberNotNull(nameof(s_predefinedFormatList))]
+    private static void EnsurePredefined()
+    {
+        s_predefinedFormatList ??=
+        [
+            // Text name                                    Win32 format ID
+            T.Create(DataFormatConstants.UnicodeText,       (int)CLIPBOARD_FORMAT.CF_UNICODETEXT),
+            T.Create(DataFormatConstants.Text,              (int)CLIPBOARD_FORMAT.CF_TEXT),
+            T.Create(DataFormatConstants.Bitmap,            (int)CLIPBOARD_FORMAT.CF_BITMAP),
+            T.Create(DataFormatConstants.Wmf,               (int)CLIPBOARD_FORMAT.CF_METAFILEPICT),
+            T.Create(DataFormatConstants.Emf,               (int)CLIPBOARD_FORMAT.CF_ENHMETAFILE),
+            T.Create(DataFormatConstants.Dif,               (int)CLIPBOARD_FORMAT.CF_DIF),
+            T.Create(DataFormatConstants.Tiff,              (int)CLIPBOARD_FORMAT.CF_TIFF),
+            T.Create(DataFormatConstants.OemText,           (int)CLIPBOARD_FORMAT.CF_OEMTEXT),
+            T.Create(DataFormatConstants.Dib,               (int)CLIPBOARD_FORMAT.CF_DIB),
+            T.Create(DataFormatConstants.Palette,           (int)CLIPBOARD_FORMAT.CF_PALETTE),
+            T.Create(DataFormatConstants.PenData,           (int)CLIPBOARD_FORMAT.CF_PENDATA),
+            T.Create(DataFormatConstants.Riff,              (int)CLIPBOARD_FORMAT.CF_RIFF),
+            T.Create(DataFormatConstants.WaveAudio,         (int)CLIPBOARD_FORMAT.CF_WAVE),
+            T.Create(DataFormatConstants.SymbolicLink,      (int)CLIPBOARD_FORMAT.CF_SYLK),
+            T.Create(DataFormatConstants.FileDrop,          (int)CLIPBOARD_FORMAT.CF_HDROP),
+            T.Create(DataFormatConstants.Locale,            (int)CLIPBOARD_FORMAT.CF_LOCALE)
+        ];
+    }
+}

--- a/src/System.Private.Windows.Core/src/Windows/Win32/PInvokeCore.DrawIconEx.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/PInvokeCore.DrawIconEx.cs
@@ -5,7 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvokeCore
 {
-    /// <inheritdoc cref="DrawIconEx(HDC, int, int, HICON, int, int, uint, HBRUSH, DI_FLAGS)"/>/>
+    /// <inheritdoc cref="DrawIconEx(HDC, int, int, HICON, int, int, uint, HBRUSH, DI_FLAGS)"/>
     public static BOOL DrawIconEx<T>(
         HDC hDC,
         int xLeft,

--- a/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
+++ b/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
@@ -150,7 +150,6 @@ GetCaretBlinkTime
 GetCaretPos
 GetClassInfo
 GetClassName
-GetClipboardFormatName
 GetClipBox
 GetClipCursor
 GetClipRgn
@@ -551,7 +550,6 @@ Rectangle
 RedrawWindow
 REGDB_E_CLASSNOTREG
 RegisterClass
-RegisterClipboardFormat
 RegisterDragDrop
 RegisterWindowMessage
 RegLoadMUIString

--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -5013,9 +5013,6 @@ Stack trace where the illegal operation occurred was:
   <data name="ReadonlyControlsCollection" xml:space="preserve">
     <value>Collection is read only.</value>
   </data>
-  <data name="RegisterCFFailed" xml:space="preserve">
-    <value>Clipboard format registration did not succeed.</value>
-  </data>
   <data name="RelatedListManagerChild" xml:space="preserve">
     <value>Child list for field {0} cannot be created.</value>
   </data>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -8714,11 +8714,6 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">Kolekce je jen pro čtení.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RegisterCFFailed">
-        <source>Clipboard format registration did not succeed.</source>
-        <target state="translated">Registrace formátu schránky se nezdařila.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RelatedListManagerChild">
         <source>Child list for field {0} cannot be created.</source>
         <target state="translated">Nelze vytvořit podřízený seznam pro pole {0}.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -8714,11 +8714,6 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">Die Sammlung ist schreibgeschützt.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RegisterCFFailed">
-        <source>Clipboard format registration did not succeed.</source>
-        <target state="translated">Fehler beim Registrieren des Zwischenablagenformats.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RelatedListManagerChild">
         <source>Child list for field {0} cannot be created.</source>
         <target state="translated">Die untergeordnete Liste für das Feld {0} kann nicht erstellt werden.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -8714,11 +8714,6 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">La colección es de solo lectura.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RegisterCFFailed">
-        <source>Clipboard format registration did not succeed.</source>
-        <target state="translated">No se pudo registrar el formato del portapapeles.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RelatedListManagerChild">
         <source>Child list for field {0} cannot be created.</source>
         <target state="translated">No se puede crear una lista secundaria para el campo {0}.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -8714,11 +8714,6 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">La collection est en lecture seule.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RegisterCFFailed">
-        <source>Clipboard format registration did not succeed.</source>
-        <target state="translated">Impossible d'inscrire le format du Presse-papiers.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RelatedListManagerChild">
         <source>Child list for field {0} cannot be created.</source>
         <target state="translated">Impossible de créer une liste enfant pour le champ {0}.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -8714,11 +8714,6 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">Raccolta in sola lettura.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RegisterCFFailed">
-        <source>Clipboard format registration did not succeed.</source>
-        <target state="translated">Registrazione del formato degli Appunti non riuscita.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RelatedListManagerChild">
         <source>Child list for field {0} cannot be created.</source>
         <target state="translated">Impossibile creare un elenco di elementi figlio per il campo {0}.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -8714,11 +8714,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">このコレクションは読み取り専用です。</target>
         <note />
       </trans-unit>
-      <trans-unit id="RegisterCFFailed">
-        <source>Clipboard format registration did not succeed.</source>
-        <target state="translated">クリップボード形式を登録することができませんでした。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RelatedListManagerChild">
         <source>Child list for field {0} cannot be created.</source>
         <target state="translated">フィールド {0} の子リストを作成できません。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -8714,11 +8714,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">컬렉션이 읽기 전용입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RegisterCFFailed">
-        <source>Clipboard format registration did not succeed.</source>
-        <target state="translated">클립보드 형식을 등록하지 못했습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RelatedListManagerChild">
         <source>Child list for field {0} cannot be created.</source>
         <target state="translated">{0} 필드의 자식 목록을 만들 수 없습니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -8714,11 +8714,6 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">Kolekcja jest tylko do odczytu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RegisterCFFailed">
-        <source>Clipboard format registration did not succeed.</source>
-        <target state="translated">Nie można zarejestrować formatu schowka.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RelatedListManagerChild">
         <source>Child list for field {0} cannot be created.</source>
         <target state="translated">Nie można utworzyć listy elementów podrzędnych pola {0}.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -8714,11 +8714,6 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">A coleção é somente leitura.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RegisterCFFailed">
-        <source>Clipboard format registration did not succeed.</source>
-        <target state="translated">O registro do formato de área de transferência não teve êxito.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RelatedListManagerChild">
         <source>Child list for field {0} cannot be created.</source>
         <target state="translated">Não é possível criar uma lista filho para o campo {0}.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -8715,11 +8715,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">Коллекция предназначена только для чтения.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RegisterCFFailed">
-        <source>Clipboard format registration did not succeed.</source>
-        <target state="translated">Регистрация формата буфера обмена не удалась.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RelatedListManagerChild">
         <source>Child list for field {0} cannot be created.</source>
         <target state="translated">Список потомков для поля {0} создать нельзя.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -8714,11 +8714,6 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">Koleksiyon salt okunur.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RegisterCFFailed">
-        <source>Clipboard format registration did not succeed.</source>
-        <target state="translated">Pano biçimi kaydı yapılamadı.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RelatedListManagerChild">
         <source>Child list for field {0} cannot be created.</source>
         <target state="translated">{0} alanı için al liste oluşturulamıyor.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -8714,11 +8714,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">集合为只读。</target>
         <note />
       </trans-unit>
-      <trans-unit id="RegisterCFFailed">
-        <source>Clipboard format registration did not succeed.</source>
-        <target state="translated">剪贴板格式注册失败。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RelatedListManagerChild">
         <source>Child list for field {0} cannot be created.</source>
         <target state="translated">无法创建字段 {0} 的子列表。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -8714,11 +8714,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">集合是唯讀的。</target>
         <note />
       </trans-unit>
-      <trans-unit id="RegisterCFFailed">
-        <source>Clipboard format registration did not succeed.</source>
-        <target state="translated">剪貼簿格式註冊失敗。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RelatedListManagerChild">
         <source>Child list for field {0} cannot be created.</source>
         <target state="translated">無法對欄位 {0} 建立子清單。</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
@@ -4,6 +4,7 @@
 using System.Collections.Specialized;
 using System.Drawing;
 using System.Formats.Nrbf;
+using System.Private.Windows.Core.Ole;
 using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization.Formatters.Binary;
@@ -157,7 +158,7 @@ public static class Clipboard
     /// <summary>
     ///  Indicates whether there is data on the Clipboard in the <see cref="DataFormats.WaveAudio"/> format.
     /// </summary>
-    public static bool ContainsAudio() => ContainsData(DataFormats.WaveAudioConstant);
+    public static bool ContainsAudio() => ContainsData(DataFormatConstants.WaveAudio);
 
     /// <summary>
     ///  Indicates whether there is data on the Clipboard that is in the specified format
@@ -199,7 +200,7 @@ public static class Clipboard
     /// <summary>
     ///  Retrieves an audio stream from the <see cref="Clipboard"/>.
     /// </summary>
-    public static Stream? GetAudioStream() => GetTypedDataIfAvailable<Stream>(DataFormats.WaveAudioConstant);
+    public static Stream? GetAudioStream() => GetTypedDataIfAvailable<Stream>(DataFormatConstants.WaveAudio);
 
     /// <summary>
     ///  Retrieves data from the <see cref="Clipboard"/> in the specified format.
@@ -395,7 +396,7 @@ public static class Clipboard
     {
         StringCollection result = [];
 
-        if (GetTypedDataIfAvailable<string[]?>(DataFormats.FileDropConstant) is string[] strings)
+        if (GetTypedDataIfAvailable<string[]?>(DataFormatConstants.FileDrop) is string[] strings)
         {
             result.AddRange(strings);
         }
@@ -452,7 +453,7 @@ public static class Clipboard
     ///  Clears the <see cref="Clipboard"/> and then adds data in the <see cref="DataFormats.WaveAudio"/> format.
     /// </summary>
     public static void SetAudio(Stream audioStream) =>
-        SetDataObject(new DataObject(DataFormats.WaveAudioConstant, audioStream.OrThrowIfNull()), copy: true);
+        SetDataObject(new DataObject(DataFormatConstants.WaveAudio, audioStream.OrThrowIfNull()), copy: true);
 
     /// <summary>
     ///  Clears the Clipboard and then adds data in the specified format.
@@ -551,14 +552,14 @@ public static class Clipboard
             }
         }
 
-        SetDataObject(new DataObject(DataFormats.FileDropConstant, autoConvert: true, filePathsArray), copy: true);
+        SetDataObject(new DataObject(DataFormatConstants.FileDrop, autoConvert: true, filePathsArray), copy: true);
     }
 
     /// <summary>
     ///  Clears the Clipboard and then adds an <see cref="Image"/> in the <see cref="DataFormats.Bitmap"/> format.
     /// </summary>
     public static void SetImage(Image image) =>
-        SetDataObject(new DataObject(DataFormats.BitmapConstant, autoConvert: true, image.OrThrowIfNull()), copy: true);
+        SetDataObject(new DataObject(DataFormatConstants.Bitmap, autoConvert: true, image.OrThrowIfNull()), copy: true);
 
     /// <summary>
     ///  Clears the Clipboard and then adds text data in the <see cref="TextDataFormat.UnicodeText"/> format.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
@@ -158,7 +158,7 @@ public static class Clipboard
     /// <summary>
     ///  Indicates whether there is data on the Clipboard in the <see cref="DataFormats.WaveAudio"/> format.
     /// </summary>
-    public static bool ContainsAudio() => ContainsData(DataFormatConstants.WaveAudio);
+    public static bool ContainsAudio() => ContainsData(DataFormatNames.WaveAudio);
 
     /// <summary>
     ///  Indicates whether there is data on the Clipboard that is in the specified format
@@ -200,7 +200,7 @@ public static class Clipboard
     /// <summary>
     ///  Retrieves an audio stream from the <see cref="Clipboard"/>.
     /// </summary>
-    public static Stream? GetAudioStream() => GetTypedDataIfAvailable<Stream>(DataFormatConstants.WaveAudio);
+    public static Stream? GetAudioStream() => GetTypedDataIfAvailable<Stream>(DataFormatNames.WaveAudio);
 
     /// <summary>
     ///  Retrieves data from the <see cref="Clipboard"/> in the specified format.
@@ -396,7 +396,7 @@ public static class Clipboard
     {
         StringCollection result = [];
 
-        if (GetTypedDataIfAvailable<string[]?>(DataFormatConstants.FileDrop) is string[] strings)
+        if (GetTypedDataIfAvailable<string[]?>(DataFormatNames.FileDrop) is string[] strings)
         {
             result.AddRange(strings);
         }
@@ -453,7 +453,7 @@ public static class Clipboard
     ///  Clears the <see cref="Clipboard"/> and then adds data in the <see cref="DataFormats.WaveAudio"/> format.
     /// </summary>
     public static void SetAudio(Stream audioStream) =>
-        SetDataObject(new DataObject(DataFormatConstants.WaveAudio, audioStream.OrThrowIfNull()), copy: true);
+        SetDataObject(new DataObject(DataFormatNames.WaveAudio, audioStream.OrThrowIfNull()), copy: true);
 
     /// <summary>
     ///  Clears the Clipboard and then adds data in the specified format.
@@ -552,14 +552,14 @@ public static class Clipboard
             }
         }
 
-        SetDataObject(new DataObject(DataFormatConstants.FileDrop, autoConvert: true, filePathsArray), copy: true);
+        SetDataObject(new DataObject(DataFormatNames.FileDrop, autoConvert: true, filePathsArray), copy: true);
     }
 
     /// <summary>
     ///  Clears the Clipboard and then adds an <see cref="Image"/> in the <see cref="DataFormats.Bitmap"/> format.
     /// </summary>
     public static void SetImage(Image image) =>
-        SetDataObject(new DataObject(DataFormatConstants.Bitmap, autoConvert: true, image.OrThrowIfNull()), copy: true);
+        SetDataObject(new DataObject(DataFormatNames.Bitmap, autoConvert: true, image.OrThrowIfNull()), copy: true);
 
     /// <summary>
     ///  Clears the Clipboard and then adds text data in the <see cref="TextDataFormat.UnicodeText"/> format.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataFormats.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataFormats.cs
@@ -16,109 +16,109 @@ public static partial class DataFormats
     /// <summary>
     ///  Specifies the standard ANSI text format.
     /// </summary>
-    public static readonly string Text = DataFormatConstants.Text;
+    public static readonly string Text = DataFormatNames.Text;
 
     /// <summary>
     ///  Specifies the standard Windows Unicode text format.
     /// </summary>
-    public static readonly string UnicodeText = DataFormatConstants.UnicodeText;
+    public static readonly string UnicodeText = DataFormatNames.UnicodeText;
 
     /// <summary>
     ///  Specifies the Windows Device Independent Bitmap (DIB) format.
     /// </summary>
-    public static readonly string Dib = DataFormatConstants.Dib;
+    public static readonly string Dib = DataFormatNames.Dib;
 
     /// <summary>
     ///  Specifies a Windows bitmap format.
     /// </summary>
-    public static readonly string Bitmap = DataFormatConstants.Bitmap;
+    public static readonly string Bitmap = DataFormatNames.Bitmap;
 
     /// <summary>
     ///  Specifies the Windows enhanced metafile format.
     /// </summary>
-    public static readonly string EnhancedMetafile = DataFormatConstants.Emf;
+    public static readonly string EnhancedMetafile = DataFormatNames.Emf;
 
     /// <summary>
     ///  Specifies the Windows metafile format, which WinForms does not directly use.
     /// </summary>
-    public static readonly string MetafilePict = DataFormatConstants.Wmf;
+    public static readonly string MetafilePict = DataFormatNames.Wmf;
 
     /// <summary>
     ///  Specifies the Windows symbolic link format, which WinForms does not directly use.
     /// </summary>
-    public static readonly string SymbolicLink = DataFormatConstants.SymbolicLink;
+    public static readonly string SymbolicLink = DataFormatNames.SymbolicLink;
 
     /// <summary>
     ///  Specifies the Windows data interchange format, which WinForms does not directly use.
     /// </summary>
-    public static readonly string Dif = DataFormatConstants.Dif;
+    public static readonly string Dif = DataFormatNames.Dif;
 
     /// <summary>
     ///  Specifies the Tagged Image File Format (TIFF), which WinForms does not directly use.
     /// </summary>
-    public static readonly string Tiff = DataFormatConstants.Tiff;
+    public static readonly string Tiff = DataFormatNames.Tiff;
 
     /// <summary>
     ///  Specifies the standard Windows original equipment manufacturer (OEM) text format.
     /// </summary>
-    public static readonly string OemText = DataFormatConstants.OemText;
+    public static readonly string OemText = DataFormatNames.OemText;
 
     /// <summary>
     ///  Specifies the Windows palette format.
     /// </summary>
-    public static readonly string Palette = DataFormatConstants.Palette;
+    public static readonly string Palette = DataFormatNames.Palette;
 
     /// <summary>
     ///  Specifies the Windows pen data format, which consists of pen strokes for handwriting
     ///  software; WinForms does not use this format.
     /// </summary>
-    public static readonly string PenData = DataFormatConstants.PenData;
+    public static readonly string PenData = DataFormatNames.PenData;
 
     /// <summary>
     ///  Specifies the Resource Interchange File Format (RIFF) audio format, which WinForms does not directly use.
     /// </summary>
-    public static readonly string Riff = DataFormatConstants.Riff;
+    public static readonly string Riff = DataFormatNames.Riff;
 
     /// <summary>
     ///  Specifies the wave audio format, which Win Forms does not directly use.
     /// </summary>
-    public static readonly string WaveAudio = DataFormatConstants.WaveAudio;
+    public static readonly string WaveAudio = DataFormatNames.WaveAudio;
 
     /// <summary>
     ///  Specifies the Windows file drop format, which WinForms does not directly use.
     /// </summary>
-    public static readonly string FileDrop = DataFormatConstants.FileDrop;
+    public static readonly string FileDrop = DataFormatNames.FileDrop;
 
     /// <summary>
     ///  Specifies the Windows culture format, which WinForms does not directly use.
     /// </summary>
-    public static readonly string Locale = DataFormatConstants.Locale;
+    public static readonly string Locale = DataFormatNames.Locale;
 
     /// <summary>
     ///  Specifies text consisting of HTML data.
     /// </summary>
-    public static readonly string Html = DataFormatConstants.Html;
+    public static readonly string Html = DataFormatNames.Html;
 
     /// <summary>
     ///  Specifies text consisting of Rich Text Format (RTF) data.
     /// </summary>
-    public static readonly string Rtf = DataFormatConstants.Rtf;
+    public static readonly string Rtf = DataFormatNames.Rtf;
 
     /// <summary>
     ///  Specifies a comma-separated value (CSV) format, which is a common interchange format
     ///  used by spreadsheets. This format is not used directly by WinForms.
     /// </summary>
-    public static readonly string CommaSeparatedValue = DataFormatConstants.Csv;
+    public static readonly string CommaSeparatedValue = DataFormatNames.Csv;
 
     /// <summary>
     ///  Specifies the WinForms string class format, which WinForms uses to store string objects.
     /// </summary>
-    public static readonly string StringFormat = DataFormatConstants.String;
+    public static readonly string StringFormat = DataFormatNames.String;
 
     /// <summary>
     ///  Specifies a format that encapsulates any type of WinForms object.
     /// </summary>
-    public static readonly string Serializable = DataFormatConstants.Serializable;
+    public static readonly string Serializable = DataFormatNames.Serializable;
 
     /// <summary>
     ///  Gets a <see cref="Format"/> with the Windows Clipboard numeric ID and name for the specified format.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataFormats.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataFormats.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.ComponentModel;
 using System.Private.Windows.Core.Ole;
-using Windows.Win32.System.Ole;
 
 namespace System.Windows.Forms;
 
@@ -15,134 +13,112 @@ namespace System.Windows.Forms;
 /// </summary>
 public static partial class DataFormats
 {
-    internal const string TextConstant = "Text";
-    internal const string UnicodeTextConstant = "UnicodeText";
-    internal const string DibConstant = "DeviceIndependentBitmap";
-    internal const string BitmapConstant = "Bitmap";
-    internal const string EmfConstant = "EnhancedMetafile";
-    internal const string WmfConstant = "MetaFilePict";
-    internal const string SymbolicLinkConstant = "SymbolicLink";
-    internal const string DifConstant = "DataInterchangeFormat";
-    internal const string TiffConstant = "TaggedImageFileFormat";
-    internal const string OemTextConstant = "OEMText";
-    internal const string PaletteConstant = "Palette";
-    internal const string PenDataConstant = "PenData";
-    internal const string RiffConstant = "RiffAudio";
-    internal const string WaveAudioConstant = "WaveAudio";
-    internal const string FileDropConstant = "FileDrop";
-    internal const string LocaleConstant = "Locale";
-    internal const string HtmlConstant = "HTML Format";
-    internal const string RtfConstant = "Rich Text Format";
-    internal const string CsvConstant = "Csv";
-    internal const string StringConstant = "System.String";
-    internal const string SerializableConstant = "WindowsForms10PersistentObject";
-
     /// <summary>
     ///  Specifies the standard ANSI text format.
     /// </summary>
-    public static readonly string Text = TextConstant;
+    public static readonly string Text = DataFormatConstants.Text;
 
     /// <summary>
     ///  Specifies the standard Windows Unicode text format.
     /// </summary>
-    public static readonly string UnicodeText = UnicodeTextConstant;
+    public static readonly string UnicodeText = DataFormatConstants.UnicodeText;
 
     /// <summary>
     ///  Specifies the Windows Device Independent Bitmap (DIB) format.
     /// </summary>
-    public static readonly string Dib = DibConstant;
+    public static readonly string Dib = DataFormatConstants.Dib;
 
     /// <summary>
     ///  Specifies a Windows bitmap format.
     /// </summary>
-    public static readonly string Bitmap = BitmapConstant;
+    public static readonly string Bitmap = DataFormatConstants.Bitmap;
 
     /// <summary>
     ///  Specifies the Windows enhanced metafile format.
     /// </summary>
-    public static readonly string EnhancedMetafile = EmfConstant;
+    public static readonly string EnhancedMetafile = DataFormatConstants.Emf;
 
     /// <summary>
     ///  Specifies the Windows metafile format, which WinForms does not directly use.
     /// </summary>
-    public static readonly string MetafilePict = WmfConstant;
+    public static readonly string MetafilePict = DataFormatConstants.Wmf;
 
     /// <summary>
     ///  Specifies the Windows symbolic link format, which WinForms does not directly use.
     /// </summary>
-    public static readonly string SymbolicLink = SymbolicLinkConstant;
+    public static readonly string SymbolicLink = DataFormatConstants.SymbolicLink;
 
     /// <summary>
     ///  Specifies the Windows data interchange format, which WinForms does not directly use.
     /// </summary>
-    public static readonly string Dif = DifConstant;
+    public static readonly string Dif = DataFormatConstants.Dif;
 
     /// <summary>
     ///  Specifies the Tagged Image File Format (TIFF), which WinForms does not directly use.
     /// </summary>
-    public static readonly string Tiff = TiffConstant;
+    public static readonly string Tiff = DataFormatConstants.Tiff;
 
     /// <summary>
     ///  Specifies the standard Windows original equipment manufacturer (OEM) text format.
     /// </summary>
-    public static readonly string OemText = OemTextConstant;
+    public static readonly string OemText = DataFormatConstants.OemText;
 
     /// <summary>
     ///  Specifies the Windows palette format.
     /// </summary>
-    public static readonly string Palette = PaletteConstant;
+    public static readonly string Palette = DataFormatConstants.Palette;
 
     /// <summary>
     ///  Specifies the Windows pen data format, which consists of pen strokes for handwriting
     ///  software; WinForms does not use this format.
     /// </summary>
-    public static readonly string PenData = PenDataConstant;
+    public static readonly string PenData = DataFormatConstants.PenData;
 
     /// <summary>
     ///  Specifies the Resource Interchange File Format (RIFF) audio format, which WinForms does not directly use.
     /// </summary>
-    public static readonly string Riff = RiffConstant;
+    public static readonly string Riff = DataFormatConstants.Riff;
 
     /// <summary>
     ///  Specifies the wave audio format, which Win Forms does not directly use.
     /// </summary>
-    public static readonly string WaveAudio = WaveAudioConstant;
+    public static readonly string WaveAudio = DataFormatConstants.WaveAudio;
 
     /// <summary>
     ///  Specifies the Windows file drop format, which WinForms does not directly use.
     /// </summary>
-    public static readonly string FileDrop = FileDropConstant;
+    public static readonly string FileDrop = DataFormatConstants.FileDrop;
 
     /// <summary>
     ///  Specifies the Windows culture format, which WinForms does not directly use.
     /// </summary>
-    public static readonly string Locale = LocaleConstant;
+    public static readonly string Locale = DataFormatConstants.Locale;
 
     /// <summary>
     ///  Specifies text consisting of HTML data.
     /// </summary>
-    public static readonly string Html = HtmlConstant;
+    public static readonly string Html = DataFormatConstants.Html;
 
     /// <summary>
     ///  Specifies text consisting of Rich Text Format (RTF) data.
     /// </summary>
-    public static readonly string Rtf = RtfConstant;
+    public static readonly string Rtf = DataFormatConstants.Rtf;
 
     /// <summary>
     ///  Specifies a comma-separated value (CSV) format, which is a common interchange format
     ///  used by spreadsheets. This format is not used directly by WinForms.
     /// </summary>
-    public static readonly string CommaSeparatedValue = CsvConstant;
+    public static readonly string CommaSeparatedValue = DataFormatConstants.Csv;
 
     /// <summary>
     ///  Specifies the WinForms string class format, which WinForms uses to store string objects.
     /// </summary>
-    public static readonly string StringFormat = StringConstant;
+    public static readonly string StringFormat = DataFormatConstants.String;
 
     /// <summary>
     ///  Specifies a format that encapsulates any type of WinForms object.
     /// </summary>
-    public static readonly string Serializable = SerializableConstant;
+    public static readonly string Serializable = DataFormatConstants.Serializable;
 
     /// <summary>
     ///  Gets a <see cref="Format"/> with the Windows Clipboard numeric ID and name for the specified format.
@@ -153,164 +129,8 @@ public static partial class DataFormats
         return DataFormatsCore<Format>.GetOrAddFormat(format);
     }
 
-    internal static partial class DataFormatsCore<T> where T : IDataFormat<T>
-    {
-        private static List<T>? s_formatList;
-        private static T[]? s_predefinedFormatList;
-
-        private static readonly Lock s_internalSyncObject = new();
-
-        internal static T GetOrAddFormat(string format)
-        {
-            lock (s_internalSyncObject)
-            {
-                EnsurePredefined();
-
-                // It is much faster to do a case sensitive search here.
-                // So do the case sensitive compare first, then the expensive one.
-                if (TryFindFormat(s_predefinedFormatList, format, StringComparison.Ordinal, out var found)
-                    || TryFindFormat(s_formatList, format, StringComparison.Ordinal, out found)
-                    || TryFindFormat(s_predefinedFormatList, format, StringComparison.OrdinalIgnoreCase, out found)
-                    || TryFindFormat(s_formatList, format, StringComparison.OrdinalIgnoreCase, out found))
-                {
-                    return found;
-                }
-
-                // Need to add this format string
-                uint formatId = PInvoke.RegisterClipboardFormat(format);
-                if (formatId == 0)
-                {
-                    throw new Win32Exception(SR.RegisterCFFailed);
-                }
-
-                s_formatList ??= [];
-                T newFormat = T.Create(format, (int)formatId);
-                s_formatList.Add(newFormat);
-                return newFormat;
-            }
-
-            static bool TryFindFormat(
-                IReadOnlyList<T>? formats,
-                string name,
-                StringComparison comparison,
-                [NotNullWhen(true)] out T? format)
-            {
-                if (formats is not null)
-                {
-                    for (int i = 0; i < formats.Count; i++)
-                    {
-                        format = formats[i];
-                        if (string.Equals(format.Name, name, comparison))
-                        {
-                            return true;
-                        }
-                    }
-                }
-
-                format = default;
-                return false;
-            }
-        }
-    }
-
     /// <summary>
     ///  Gets a <see cref="Format"/> with the Windows Clipboard numeric ID and name for the specified ID.
     /// </summary>
     public static Format GetFormat(int id) => DataFormatsCore<Format>.GetOrAddFormat(id);
-
-    internal static partial class DataFormatsCore<T> where T : IDataFormat<T>
-    {
-        internal static unsafe T GetOrAddFormat(int id)
-        {
-            // Win32 uses an unsigned 16 bit type as a format ID, thus stripping off the leading bits.
-            // Registered format IDs are in the range 0xC000 through 0xFFFF, thus it's important
-            // to represent format as an unsigned type.
-            ushort shortId = (ushort)(id & 0xFFFF);
-
-            lock (s_internalSyncObject)
-            {
-                EnsurePredefined();
-
-                if (TryFindFormat(s_predefinedFormatList, shortId, out T? found)
-                    || TryFindFormat(s_formatList, shortId, out found))
-                {
-                    return found;
-                }
-
-                // The max length of the name of clipboard formats is equal to the max length
-                // of a Win32 Atom of 255 chars. An additional null terminator character is added,
-                // giving a required capacity of 256 chars.
-
-                string? name = null;
-                Span<char> buffer = stackalloc char[256];
-                fixed (char* pBuffer = buffer)
-                {
-                    int length = PInvoke.GetClipboardFormatName(shortId, pBuffer, 256);
-                    if (length != 0)
-                    {
-                        name = buffer[..length].ToString();
-                    }
-                }
-
-                // This can happen if windows adds a standard format that we don't know about,
-                // so we should play it safe.
-                name ??= $"Format{shortId}";
-
-                s_formatList ??= [];
-                T newFormat = T.Create(name, shortId);
-                s_formatList.Add(newFormat);
-                return newFormat;
-
-                static bool TryFindFormat(
-                    IReadOnlyList<T>? formats,
-                    int id,
-                    [NotNullWhen(true)] out T? format)
-                {
-                    if (formats is not null)
-                    {
-                        for (int i = 0; i < formats.Count; i++)
-                        {
-                            format = formats[i];
-                            if (format.Id == id)
-                            {
-                                return true;
-                            }
-                        }
-                    }
-
-                    format = default;
-                    return false;
-                }
-            }
-        }
-
-        /// <summary>
-        ///  Ensures that the Win32 predefined formats are setup in our format list.
-        ///  This is called anytime we need to search the list
-        /// </summary>
-        [MemberNotNull(nameof(s_predefinedFormatList))]
-        private static void EnsurePredefined()
-        {
-            s_predefinedFormatList ??=
-            [
-                // Text name                        Win32 format ID
-                T.Create(UnicodeTextConstant,       (int)CLIPBOARD_FORMAT.CF_UNICODETEXT),
-                T.Create(TextConstant,              (int)CLIPBOARD_FORMAT.CF_TEXT),
-                T.Create(BitmapConstant,            (int)CLIPBOARD_FORMAT.CF_BITMAP),
-                T.Create(WmfConstant,               (int)CLIPBOARD_FORMAT.CF_METAFILEPICT),
-                T.Create(EmfConstant,               (int)CLIPBOARD_FORMAT.CF_ENHMETAFILE),
-                T.Create(DifConstant,               (int)CLIPBOARD_FORMAT.CF_DIF),
-                T.Create(TiffConstant,              (int)CLIPBOARD_FORMAT.CF_TIFF),
-                T.Create(OemTextConstant,           (int)CLIPBOARD_FORMAT.CF_OEMTEXT),
-                T.Create(DibConstant,               (int)CLIPBOARD_FORMAT.CF_DIB),
-                T.Create(PaletteConstant,           (int)CLIPBOARD_FORMAT.CF_PALETTE),
-                T.Create(PenDataConstant,           (int)CLIPBOARD_FORMAT.CF_PENDATA),
-                T.Create(RiffConstant,              (int)CLIPBOARD_FORMAT.CF_RIFF),
-                T.Create(WaveAudioConstant,         (int)CLIPBOARD_FORMAT.CF_WAVE),
-                T.Create(SymbolicLinkConstant,      (int)CLIPBOARD_FORMAT.CF_SYLK),
-                T.Create(FileDropConstant,          (int)CLIPBOARD_FORMAT.CF_HDROP),
-                T.Create(LocaleConstant,            (int)CLIPBOARD_FORMAT.CF_LOCALE)
-            ];
-        }
-    }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.NativeToWinFormsAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.NativeToWinFormsAdapter.cs
@@ -107,11 +107,11 @@ public unsafe partial class DataObject
 
                 object? value = format switch
                 {
-                    DataFormatConstants.Text or DataFormatConstants.Rtf or DataFormatConstants.OemText =>
+                    DataFormatNames.Text or DataFormatNames.Rtf or DataFormatNames.OemText =>
                         ReadStringFromHGLOBAL(hglobal, unicode: false),
-                    DataFormatConstants.Html => ReadUtf8StringFromHGLOBAL(hglobal),
-                    DataFormatConstants.UnicodeText => ReadStringFromHGLOBAL(hglobal, unicode: true),
-                    DataFormatConstants.FileDrop => ReadFileListFromHDROP((HDROP)(nint)hglobal),
+                    DataFormatNames.Html => ReadUtf8StringFromHGLOBAL(hglobal),
+                    DataFormatNames.UnicodeText => ReadStringFromHGLOBAL(hglobal, unicode: true),
+                    DataFormatNames.FileDrop => ReadFileListFromHDROP((HDROP)(nint)hglobal),
                     CF_DEPRECATED_FILENAME => new string[] { ReadStringFromHGLOBAL(hglobal, unicode: false) },
                     CF_DEPRECATED_FILENAMEW => new string[] { ReadStringFromHGLOBAL(hglobal, unicode: true) },
                     _ => ReadObjectOrStreamFromHGLOBAL(hglobal, RestrictDeserializationToSafeTypes(format), resolver, legacyMode)
@@ -413,7 +413,7 @@ public unsafe partial class DataObject
             private static bool TryGetBitmapData(Com.IDataObject* dataObject, string format, [NotNullWhen(true)] out Bitmap? data)
             {
                 data = default;
-                if (format != DataFormatConstants.Bitmap)
+                if (format != DataFormatNames.Bitmap)
                 {
                     return false;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.NativeToWinFormsAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.NativeToWinFormsAdapter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
+using System.Private.Windows.Core.Ole;
 using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
@@ -106,11 +107,11 @@ public unsafe partial class DataObject
 
                 object? value = format switch
                 {
-                    DataFormats.TextConstant or DataFormats.RtfConstant or DataFormats.OemTextConstant =>
+                    DataFormatConstants.Text or DataFormatConstants.Rtf or DataFormatConstants.OemText =>
                         ReadStringFromHGLOBAL(hglobal, unicode: false),
-                    DataFormats.HtmlConstant => ReadUtf8StringFromHGLOBAL(hglobal),
-                    DataFormats.UnicodeTextConstant => ReadStringFromHGLOBAL(hglobal, unicode: true),
-                    DataFormats.FileDropConstant => ReadFileListFromHDROP((HDROP)(nint)hglobal),
+                    DataFormatConstants.Html => ReadUtf8StringFromHGLOBAL(hglobal),
+                    DataFormatConstants.UnicodeText => ReadStringFromHGLOBAL(hglobal, unicode: true),
+                    DataFormatConstants.FileDrop => ReadFileListFromHDROP((HDROP)(nint)hglobal),
                     CF_DEPRECATED_FILENAME => new string[] { ReadStringFromHGLOBAL(hglobal, unicode: false) },
                     CF_DEPRECATED_FILENAMEW => new string[] { ReadStringFromHGLOBAL(hglobal, unicode: true) },
                     _ => ReadObjectOrStreamFromHGLOBAL(hglobal, RestrictDeserializationToSafeTypes(format), resolver, legacyMode)
@@ -412,7 +413,7 @@ public unsafe partial class DataObject
             private static bool TryGetBitmapData(Com.IDataObject* dataObject, string format, [NotNullWhen(true)] out Bitmap? data)
             {
                 data = default;
-                if (format != DataFormats.BitmapConstant)
+                if (format != DataFormatConstants.Bitmap)
                 {
                     return false;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.WinFormsToNativeAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.WinFormsToNativeAdapter.cs
@@ -307,24 +307,24 @@ public unsafe partial class DataObject
             {
                 _ when data is Stream dataStream
                     => SaveStreamToHGLOBAL(ref medium.hGlobal, dataStream),
-                DataFormatConstants.Text or DataFormatConstants.Rtf or DataFormatConstants.OemText
+                DataFormatNames.Text or DataFormatNames.Rtf or DataFormatNames.OemText
                     => SaveStringToHGLOBAL(medium.hGlobal, data.ToString()!, unicode: false),
-                DataFormatConstants.Html
+                DataFormatNames.Html
                     => SaveHtmlToHGLOBAL(medium.hGlobal, data.ToString()!),
-                DataFormatConstants.UnicodeText
+                DataFormatNames.UnicodeText
                     => SaveStringToHGLOBAL(medium.hGlobal, data.ToString()!, unicode: true),
-                DataFormatConstants.FileDrop
+                DataFormatNames.FileDrop
                     => SaveFileListToHGLOBAL(medium.hGlobal, (string[])data),
                 CF_DEPRECATED_FILENAME
                     => SaveStringToHGLOBAL(medium.hGlobal, ((string[])data)[0], unicode: false),
                 CF_DEPRECATED_FILENAMEW
                     => SaveStringToHGLOBAL(medium.hGlobal, ((string[])data)[0], unicode: true),
-                DataFormatConstants.Dib when data is Image
+                DataFormatNames.Dib when data is Image
                     // GDI+ does not properly handle saving to DIB images. Since the clipboard will take
                     // an HBITMAP and publish a Dib, we don't need to support this.
                     => HRESULT.DV_E_TYMED,
 #pragma warning disable SYSLIB0050 // Type or member is obsolete
-                _ when format == DataFormatConstants.Serializable || data is ISerializable || data.GetType().IsSerializable
+                _ when format == DataFormatNames.Serializable || data is ISerializable || data.GetType().IsSerializable
 #pragma warning restore
                     => SaveObjectToHGLOBAL(ref medium.hGlobal, data, RestrictDeserializationToSafeTypes(format)),
                 _ => HRESULT.E_UNEXPECTED

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.WinFormsToNativeAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.WinFormsToNativeAdapter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
+using System.Private.Windows.Core.Ole;
 using System.Runtime.Serialization;
 using System.Text;
 using Windows.Win32.System.Com;
@@ -306,24 +307,24 @@ public unsafe partial class DataObject
             {
                 _ when data is Stream dataStream
                     => SaveStreamToHGLOBAL(ref medium.hGlobal, dataStream),
-                DataFormats.TextConstant or DataFormats.RtfConstant or DataFormats.OemTextConstant
+                DataFormatConstants.Text or DataFormatConstants.Rtf or DataFormatConstants.OemText
                     => SaveStringToHGLOBAL(medium.hGlobal, data.ToString()!, unicode: false),
-                DataFormats.HtmlConstant
+                DataFormatConstants.Html
                     => SaveHtmlToHGLOBAL(medium.hGlobal, data.ToString()!),
-                DataFormats.UnicodeTextConstant
+                DataFormatConstants.UnicodeText
                     => SaveStringToHGLOBAL(medium.hGlobal, data.ToString()!, unicode: true),
-                DataFormats.FileDropConstant
+                DataFormatConstants.FileDrop
                     => SaveFileListToHGLOBAL(medium.hGlobal, (string[])data),
                 CF_DEPRECATED_FILENAME
                     => SaveStringToHGLOBAL(medium.hGlobal, ((string[])data)[0], unicode: false),
                 CF_DEPRECATED_FILENAMEW
                     => SaveStringToHGLOBAL(medium.hGlobal, ((string[])data)[0], unicode: true),
-                DataFormats.DibConstant when data is Image
+                DataFormatConstants.Dib when data is Image
                     // GDI+ does not properly handle saving to DIB images. Since the clipboard will take
                     // an HBITMAP and publish a Dib, we don't need to support this.
                     => HRESULT.DV_E_TYMED,
 #pragma warning disable SYSLIB0050 // Type or member is obsolete
-                _ when format == DataFormats.SerializableConstant || data is ISerializable || data.GetType().IsSerializable
+                _ when format == DataFormatConstants.Serializable || data is ISerializable || data.GetType().IsSerializable
 #pragma warning restore
                     => SaveObjectToHGLOBAL(ref medium.hGlobal, data, RestrictDeserializationToSafeTypes(format)),
                 _ => HRESULT.E_UNEXPECTED

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
@@ -175,12 +175,12 @@ public unsafe partial class DataObject :
     ///  correspond to primitives or are pre-defined in the OS such as strings, bitmaps, and OLE types.
     /// </summary>
     private static bool IsRestrictedFormat(string format) => RestrictDeserializationToSafeTypes(format)
-        || format is DataFormatConstants.Text
-            or DataFormatConstants.UnicodeText
-            or DataFormatConstants.Rtf
-            or DataFormatConstants.Html
-            or DataFormatConstants.OemText
-            or DataFormatConstants.FileDrop
+        || format is DataFormatNames.Text
+            or DataFormatNames.UnicodeText
+            or DataFormatNames.Rtf
+            or DataFormatNames.Html
+            or DataFormatNames.OemText
+            or DataFormatNames.FileDrop
             or CF_DEPRECATED_FILENAME
             or CF_DEPRECATED_FILENAMEW;
 
@@ -196,21 +196,21 @@ public unsafe partial class DataObject :
     ///  </para>
     /// </remarks>
     private static bool RestrictDeserializationToSafeTypes(string format) =>
-        format is DataFormatConstants.String
+        format is DataFormatNames.String
             or BitmapFullName
-            or DataFormatConstants.Csv
-            or DataFormatConstants.Dib
-            or DataFormatConstants.Dif
-            or DataFormatConstants.Locale
-            or DataFormatConstants.PenData
-            or DataFormatConstants.Riff
-            or DataFormatConstants.SymbolicLink
-            or DataFormatConstants.Tiff
-            or DataFormatConstants.WaveAudio
-            or DataFormatConstants.Bitmap
-            or DataFormatConstants.Emf
-            or DataFormatConstants.Palette
-            or DataFormatConstants.Wmf;
+            or DataFormatNames.Csv
+            or DataFormatNames.Dib
+            or DataFormatNames.Dif
+            or DataFormatNames.Locale
+            or DataFormatNames.PenData
+            or DataFormatNames.Riff
+            or DataFormatNames.SymbolicLink
+            or DataFormatNames.Tiff
+            or DataFormatNames.WaveAudio
+            or DataFormatNames.Bitmap
+            or DataFormatNames.Emf
+            or DataFormatNames.Palette
+            or DataFormatNames.Wmf;
 
     #region IDataObject
     [Obsolete(
@@ -304,11 +304,11 @@ public unsafe partial class DataObject :
             ? _innerData.TryGetData(format, autoConvert, out data)
             : _innerData.TryGetData(format, resolver, autoConvert, out data);
 
-    public virtual bool ContainsAudio() => GetDataPresent(DataFormatConstants.WaveAudio, autoConvert: false);
+    public virtual bool ContainsAudio() => GetDataPresent(DataFormatNames.WaveAudio, autoConvert: false);
 
-    public virtual bool ContainsFileDropList() => GetDataPresent(DataFormatConstants.FileDrop, autoConvert: true);
+    public virtual bool ContainsFileDropList() => GetDataPresent(DataFormatNames.FileDrop, autoConvert: true);
 
-    public virtual bool ContainsImage() => GetDataPresent(DataFormatConstants.Bitmap, autoConvert: true);
+    public virtual bool ContainsImage() => GetDataPresent(DataFormatNames.Bitmap, autoConvert: true);
 
     public virtual bool ContainsText() => ContainsText(TextDataFormat.UnicodeText);
 
@@ -325,7 +325,7 @@ public unsafe partial class DataObject :
     public virtual StringCollection GetFileDropList()
     {
         StringCollection dropList = [];
-        if (GetData(DataFormatConstants.FileDrop, autoConvert: true) is string[] strings)
+        if (GetData(DataFormatNames.FileDrop, autoConvert: true) is string[] strings)
         {
             dropList.AddRange(strings);
         }
@@ -348,16 +348,16 @@ public unsafe partial class DataObject :
     public virtual void SetAudio(byte[] audioBytes) => SetAudio(new MemoryStream(audioBytes.OrThrowIfNull()));
 
     public virtual void SetAudio(Stream audioStream) =>
-        SetData(DataFormatConstants.WaveAudio, autoConvert: false, audioStream.OrThrowIfNull());
+        SetData(DataFormatNames.WaveAudio, autoConvert: false, audioStream.OrThrowIfNull());
 
     public virtual void SetFileDropList(StringCollection filePaths)
     {
         string[] strings = new string[filePaths.OrThrowIfNull().Count];
         filePaths.CopyTo(strings, 0);
-        SetData(DataFormatConstants.FileDrop, true, strings);
+        SetData(DataFormatNames.FileDrop, true, strings);
     }
 
-    public virtual void SetImage(Image image) => SetData(DataFormatConstants.Bitmap, true, image.OrThrowIfNull());
+    public virtual void SetImage(Image image) => SetData(DataFormatNames.Bitmap, true, image.OrThrowIfNull());
 
     public virtual void SetText(string textData) => SetText(textData, TextDataFormat.UnicodeText);
 
@@ -410,18 +410,18 @@ public unsafe partial class DataObject :
 
         static bool IsValidPredefinedFormatTypeCombination(string format) => format switch
         {
-            DataFormatConstants.Text
-                or DataFormatConstants.UnicodeText
-                or DataFormatConstants.String
-                or DataFormatConstants.Rtf
-                or DataFormatConstants.Html
-                or DataFormatConstants.OemText => typeof(string) == typeof(T),
+            DataFormatNames.Text
+                or DataFormatNames.UnicodeText
+                or DataFormatNames.String
+                or DataFormatNames.Rtf
+                or DataFormatNames.Html
+                or DataFormatNames.OemText => typeof(string) == typeof(T),
 
-            DataFormatConstants.FileDrop
+            DataFormatNames.FileDrop
                 or CF_DEPRECATED_FILENAME
                 or CF_DEPRECATED_FILENAMEW => typeof(string[]) == typeof(T),
 
-            DataFormatConstants.Bitmap or BitmapFullName =>
+            DataFormatNames.Bitmap or BitmapFullName =>
                 typeof(Bitmap) == typeof(T) || typeof(Image) == typeof(T),
             _ => true
         };
@@ -429,11 +429,11 @@ public unsafe partial class DataObject :
 
     private static string ConvertToDataFormats(TextDataFormat format) => format switch
     {
-        TextDataFormat.UnicodeText => DataFormatConstants.UnicodeText,
-        TextDataFormat.Rtf => DataFormatConstants.Rtf,
-        TextDataFormat.Html => DataFormatConstants.Html,
-        TextDataFormat.CommaSeparatedValue => DataFormatConstants.Csv,
-        _ => DataFormatConstants.UnicodeText,
+        TextDataFormat.UnicodeText => DataFormatNames.UnicodeText,
+        TextDataFormat.Rtf => DataFormatNames.Rtf,
+        TextDataFormat.Html => DataFormatNames.Html,
+        TextDataFormat.CommaSeparatedValue => DataFormatNames.Csv,
+        _ => DataFormatNames.UnicodeText,
     };
 
     /// <summary>
@@ -442,22 +442,22 @@ public unsafe partial class DataObject :
     private static string[]? GetMappedFormats(string format) => format switch
     {
         null => null,
-        DataFormatConstants.Text or DataFormatConstants.UnicodeText or DataFormatConstants.String =>
+        DataFormatNames.Text or DataFormatNames.UnicodeText or DataFormatNames.String =>
             [
-                DataFormatConstants.String,
-                DataFormatConstants.UnicodeText,
-                DataFormatConstants.Text
+                DataFormatNames.String,
+                DataFormatNames.UnicodeText,
+                DataFormatNames.Text
             ],
-        DataFormatConstants.FileDrop or CF_DEPRECATED_FILENAME or CF_DEPRECATED_FILENAMEW =>
+        DataFormatNames.FileDrop or CF_DEPRECATED_FILENAME or CF_DEPRECATED_FILENAMEW =>
             [
-                DataFormatConstants.FileDrop,
+                DataFormatNames.FileDrop,
                 CF_DEPRECATED_FILENAMEW,
                 CF_DEPRECATED_FILENAME
             ],
-        DataFormatConstants.Bitmap or BitmapFullName =>
+        DataFormatNames.Bitmap or BitmapFullName =>
             [
                 BitmapFullName,
-                DataFormatConstants.Bitmap
+                DataFormatNames.Bitmap
             ],
         _ => [format]
     };

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
@@ -10,6 +10,7 @@ using System.Runtime.InteropServices.ComTypes;
 using System.Text.Json;
 using Com = Windows.Win32.System.Com;
 using ComTypes = System.Runtime.InteropServices.ComTypes;
+using System.Private.Windows.Core.Ole;
 
 namespace System.Windows.Forms;
 
@@ -174,12 +175,12 @@ public unsafe partial class DataObject :
     ///  correspond to primitives or are pre-defined in the OS such as strings, bitmaps, and OLE types.
     /// </summary>
     private static bool IsRestrictedFormat(string format) => RestrictDeserializationToSafeTypes(format)
-        || format is DataFormats.TextConstant
-            or DataFormats.UnicodeTextConstant
-            or DataFormats.RtfConstant
-            or DataFormats.HtmlConstant
-            or DataFormats.OemTextConstant
-            or DataFormats.FileDropConstant
+        || format is DataFormatConstants.Text
+            or DataFormatConstants.UnicodeText
+            or DataFormatConstants.Rtf
+            or DataFormatConstants.Html
+            or DataFormatConstants.OemText
+            or DataFormatConstants.FileDrop
             or CF_DEPRECATED_FILENAME
             or CF_DEPRECATED_FILENAMEW;
 
@@ -195,21 +196,21 @@ public unsafe partial class DataObject :
     ///  </para>
     /// </remarks>
     private static bool RestrictDeserializationToSafeTypes(string format) =>
-        format is DataFormats.StringConstant
+        format is DataFormatConstants.String
             or BitmapFullName
-            or DataFormats.CsvConstant
-            or DataFormats.DibConstant
-            or DataFormats.DifConstant
-            or DataFormats.LocaleConstant
-            or DataFormats.PenDataConstant
-            or DataFormats.RiffConstant
-            or DataFormats.SymbolicLinkConstant
-            or DataFormats.TiffConstant
-            or DataFormats.WaveAudioConstant
-            or DataFormats.BitmapConstant
-            or DataFormats.EmfConstant
-            or DataFormats.PaletteConstant
-            or DataFormats.WmfConstant;
+            or DataFormatConstants.Csv
+            or DataFormatConstants.Dib
+            or DataFormatConstants.Dif
+            or DataFormatConstants.Locale
+            or DataFormatConstants.PenData
+            or DataFormatConstants.Riff
+            or DataFormatConstants.SymbolicLink
+            or DataFormatConstants.Tiff
+            or DataFormatConstants.WaveAudio
+            or DataFormatConstants.Bitmap
+            or DataFormatConstants.Emf
+            or DataFormatConstants.Palette
+            or DataFormatConstants.Wmf;
 
     #region IDataObject
     [Obsolete(
@@ -303,11 +304,11 @@ public unsafe partial class DataObject :
             ? _innerData.TryGetData(format, autoConvert, out data)
             : _innerData.TryGetData(format, resolver, autoConvert, out data);
 
-    public virtual bool ContainsAudio() => GetDataPresent(DataFormats.WaveAudioConstant, autoConvert: false);
+    public virtual bool ContainsAudio() => GetDataPresent(DataFormatConstants.WaveAudio, autoConvert: false);
 
-    public virtual bool ContainsFileDropList() => GetDataPresent(DataFormats.FileDropConstant, autoConvert: true);
+    public virtual bool ContainsFileDropList() => GetDataPresent(DataFormatConstants.FileDrop, autoConvert: true);
 
-    public virtual bool ContainsImage() => GetDataPresent(DataFormats.BitmapConstant, autoConvert: true);
+    public virtual bool ContainsImage() => GetDataPresent(DataFormatConstants.Bitmap, autoConvert: true);
 
     public virtual bool ContainsText() => ContainsText(TextDataFormat.UnicodeText);
 
@@ -324,7 +325,7 @@ public unsafe partial class DataObject :
     public virtual StringCollection GetFileDropList()
     {
         StringCollection dropList = [];
-        if (GetData(DataFormats.FileDropConstant, autoConvert: true) is string[] strings)
+        if (GetData(DataFormatConstants.FileDrop, autoConvert: true) is string[] strings)
         {
             dropList.AddRange(strings);
         }
@@ -347,16 +348,16 @@ public unsafe partial class DataObject :
     public virtual void SetAudio(byte[] audioBytes) => SetAudio(new MemoryStream(audioBytes.OrThrowIfNull()));
 
     public virtual void SetAudio(Stream audioStream) =>
-        SetData(DataFormats.WaveAudioConstant, autoConvert: false, audioStream.OrThrowIfNull());
+        SetData(DataFormatConstants.WaveAudio, autoConvert: false, audioStream.OrThrowIfNull());
 
     public virtual void SetFileDropList(StringCollection filePaths)
     {
         string[] strings = new string[filePaths.OrThrowIfNull().Count];
         filePaths.CopyTo(strings, 0);
-        SetData(DataFormats.FileDropConstant, true, strings);
+        SetData(DataFormatConstants.FileDrop, true, strings);
     }
 
-    public virtual void SetImage(Image image) => SetData(DataFormats.BitmapConstant, true, image.OrThrowIfNull());
+    public virtual void SetImage(Image image) => SetData(DataFormatConstants.Bitmap, true, image.OrThrowIfNull());
 
     public virtual void SetText(string textData) => SetText(textData, TextDataFormat.UnicodeText);
 
@@ -409,18 +410,18 @@ public unsafe partial class DataObject :
 
         static bool IsValidPredefinedFormatTypeCombination(string format) => format switch
         {
-            DataFormats.TextConstant
-                or DataFormats.UnicodeTextConstant
-                or DataFormats.StringConstant
-                or DataFormats.RtfConstant
-                or DataFormats.HtmlConstant
-                or DataFormats.OemTextConstant => typeof(string) == typeof(T),
+            DataFormatConstants.Text
+                or DataFormatConstants.UnicodeText
+                or DataFormatConstants.String
+                or DataFormatConstants.Rtf
+                or DataFormatConstants.Html
+                or DataFormatConstants.OemText => typeof(string) == typeof(T),
 
-            DataFormats.FileDropConstant
+            DataFormatConstants.FileDrop
                 or CF_DEPRECATED_FILENAME
                 or CF_DEPRECATED_FILENAMEW => typeof(string[]) == typeof(T),
 
-            DataFormats.BitmapConstant or BitmapFullName =>
+            DataFormatConstants.Bitmap or BitmapFullName =>
                 typeof(Bitmap) == typeof(T) || typeof(Image) == typeof(T),
             _ => true
         };
@@ -428,11 +429,11 @@ public unsafe partial class DataObject :
 
     private static string ConvertToDataFormats(TextDataFormat format) => format switch
     {
-        TextDataFormat.UnicodeText => DataFormats.UnicodeTextConstant,
-        TextDataFormat.Rtf => DataFormats.RtfConstant,
-        TextDataFormat.Html => DataFormats.HtmlConstant,
-        TextDataFormat.CommaSeparatedValue => DataFormats.CsvConstant,
-        _ => DataFormats.UnicodeTextConstant,
+        TextDataFormat.UnicodeText => DataFormatConstants.UnicodeText,
+        TextDataFormat.Rtf => DataFormatConstants.Rtf,
+        TextDataFormat.Html => DataFormatConstants.Html,
+        TextDataFormat.CommaSeparatedValue => DataFormatConstants.Csv,
+        _ => DataFormatConstants.UnicodeText,
     };
 
     /// <summary>
@@ -441,22 +442,22 @@ public unsafe partial class DataObject :
     private static string[]? GetMappedFormats(string format) => format switch
     {
         null => null,
-        DataFormats.TextConstant or DataFormats.UnicodeTextConstant or DataFormats.StringConstant =>
+        DataFormatConstants.Text or DataFormatConstants.UnicodeText or DataFormatConstants.String =>
             [
-                DataFormats.StringConstant,
-                DataFormats.UnicodeTextConstant,
-                DataFormats.TextConstant
+                DataFormatConstants.String,
+                DataFormatConstants.UnicodeText,
+                DataFormatConstants.Text
             ],
-        DataFormats.FileDropConstant or CF_DEPRECATED_FILENAME or CF_DEPRECATED_FILENAMEW =>
+        DataFormatConstants.FileDrop or CF_DEPRECATED_FILENAME or CF_DEPRECATED_FILENAMEW =>
             [
-                DataFormats.FileDropConstant,
+                DataFormatConstants.FileDrop,
                 CF_DEPRECATED_FILENAMEW,
                 CF_DEPRECATED_FILENAME
             ],
-        DataFormats.BitmapConstant or BitmapFullName =>
+        DataFormatConstants.Bitmap or BitmapFullName =>
             [
                 BitmapFullName,
-                DataFormats.BitmapConstant
+                DataFormatConstants.Bitmap
             ],
         _ => [format]
     };

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DragDropHelper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DragDropHelper.cs
@@ -160,7 +160,7 @@ internal static unsafe class DragDropHelper
         {
             ComTypes.FORMATETC formatEtc = new()
             {
-                cfFormat = (short)PInvoke.RegisterClipboardFormat(format),
+                cfFormat = (short)PInvokeCore.RegisterClipboardFormat(format),
                 dwAspect = ComTypes.DVASPECT.DVASPECT_CONTENT,
                 lindex = -1,
                 ptd = IntPtr.Zero,
@@ -265,7 +265,7 @@ internal static unsafe class DragDropHelper
 
         ComTypes.FORMATETC formatEtc = new()
         {
-            cfFormat = (short)PInvoke.RegisterClipboardFormat(format),
+            cfFormat = (short)PInvokeCore.RegisterClipboardFormat(format),
             dwAspect = ComTypes.DVASPECT.DVASPECT_CONTENT,
             lindex = -1,
             ptd = IntPtr.Zero,
@@ -421,7 +421,7 @@ internal static unsafe class DragDropHelper
 
         ComTypes.FORMATETC formatEtc = new()
         {
-            cfFormat = (short)PInvoke.RegisterClipboardFormat(PInvoke.CFSTR_DROPDESCRIPTION),
+            cfFormat = (short)PInvokeCore.RegisterClipboardFormat(PInvoke.CFSTR_DROPDESCRIPTION),
             dwAspect = ComTypes.DVASPECT.DVASPECT_CONTENT,
             lindex = -1,
             ptd = IntPtr.Zero,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/TextDataFormat.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/TextDataFormat.cs
@@ -11,7 +11,7 @@ namespace System.Windows.Forms;
 /// </summary>
 public enum TextDataFormat
 {
-    /// <inheritdoc cref="PrivateOle.TextDataFormat.Text"/>/>
+    /// <inheritdoc cref="PrivateOle.TextDataFormat.Text"/>
     Text = PrivateOle.TextDataFormat.Text,
 
     /// <inheritdoc cref="PrivateOle.TextDataFormat.UnicodeText"/>

--- a/src/System.Windows.Forms/tests/TestUtilities/DataObjectTestHelpers.cs
+++ b/src/System.Windows.Forms/tests/TestUtilities/DataObjectTestHelpers.cs
@@ -15,7 +15,7 @@ public static class DataObjectTestHelpers
     [
          DataFormats.Text,
          DataFormats.UnicodeText,
-         DataFormats.StringConstant,
+         "System.String",
          DataFormats.Rtf,
          DataFormats.Html,
          DataFormats.OemText,

--- a/src/System.Windows.Forms/tests/TestUtilities/DataObjectTestHelpers.cs
+++ b/src/System.Windows.Forms/tests/TestUtilities/DataObjectTestHelpers.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Private.Windows.Core.Ole;
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Forms.TestUtilities;
@@ -15,7 +16,7 @@ public static class DataObjectTestHelpers
     [
          DataFormats.Text,
          DataFormats.UnicodeText,
-         "System.String",
+         DataFormatNames.String,
          DataFormats.Rtf,
          DataFormats.Html,
          DataFormats.OemText,

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataFormatsTests.ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataFormatsTests.ClipboardTests.cs
@@ -12,8 +12,8 @@ public partial class DataFormatsTests
     {
         public static IEnumerable<object[]> GetFormat_Int_TestData()
         {
-            uint manuallyRegisteredFormatId = PInvoke.RegisterClipboardFormat("ManuallyRegisteredFormat");
-            uint longManuallyRegisteredFormatId = PInvoke.RegisterClipboardFormat(new string('a', 255));
+            uint manuallyRegisteredFormatId = PInvokeCore.RegisterClipboardFormat("ManuallyRegisteredFormat");
+            uint longManuallyRegisteredFormatId = PInvokeCore.RegisterClipboardFormat(new string('a', 255));
             yield return new object[] { (int)manuallyRegisteredFormatId, "ManuallyRegisteredFormat" };
             yield return new object[] { (int)longManuallyRegisteredFormatId, new string('a', 255) };
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectExtensionsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectExtensionsTests.cs
@@ -21,7 +21,7 @@ public class DataObjectExtensionsTests
         tryGetData2.Should().Throw<ArgumentNullException>();
         Action tryGetData3 = () => DataObjectExtensions.TryGetData<string>(dataObject: null!, DataFormats.Dib, autoConvert: true, out _);
         tryGetData3.Should().Throw<ArgumentNullException>();
-        Action tryGetData4 = () => DataObjectExtensions.TryGetData<string>(dataObject: null!, DataFormats.EmfConstant, autoConvert: false, out _);
+        Action tryGetData4 = () => DataObjectExtensions.TryGetData<string>(dataObject: null!, DataFormats.EnhancedMetafile, autoConvert: false, out _);
         tryGetData4.Should().Throw<ArgumentNullException>();
         Action tryGetData5 = () => DataObjectExtensions.TryGetData<string>(dataObject: null!, DataFormats.UnicodeText, Resolver, autoConvert: true, out _);
         tryGetData5.Should().Throw<ArgumentNullException>();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
@@ -1210,8 +1210,8 @@ public partial class DataObjectTests
     }
 
     [Theory]
-    [InlineData(DataFormats.SerializableConstant, null)]
-    [InlineData(DataFormats.SerializableConstant, "input")]
+    [InlineData("WindowsForms10PersistentObject", null)]
+    [InlineData("WindowsForms10PersistentObject", "input")]
     [InlineData("something custom", null)]
     [InlineData("something custom", "input")]
     private void DataObject_SetData_InvokeStringObject_Unbounded_GetReturnsExpected(string format, string input)
@@ -1363,10 +1363,10 @@ public partial class DataObjectTests
     [InlineData("something custom", false, null)]
     [InlineData("something custom", true, "input")]
     [InlineData("something custom", true, null)]
-    [InlineData(DataFormats.SerializableConstant, false, "input")]
-    [InlineData(DataFormats.SerializableConstant, false, null)]
-    [InlineData(DataFormats.SerializableConstant, true, "input")]
-    [InlineData(DataFormats.SerializableConstant, true, null)]
+    [InlineData("WindowsForms10PersistentObject", false, "input")]
+    [InlineData("WindowsForms10PersistentObject", false, null)]
+    [InlineData("WindowsForms10PersistentObject", true, "input")]
+    [InlineData("WindowsForms10PersistentObject", true, null)]
     private void DataObject_SetData_InvokeStringBoolObject_Unbounded(string format, bool autoConvert, string input)
     {
         DataObject dataObject = new();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Private.Windows;
+using System.Private.Windows.Core.Ole;
 using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
@@ -1210,8 +1211,8 @@ public partial class DataObjectTests
     }
 
     [Theory]
-    [InlineData("WindowsForms10PersistentObject", null)]
-    [InlineData("WindowsForms10PersistentObject", "input")]
+    [InlineData(DataFormatNames.Serializable, null)]
+    [InlineData(DataFormatNames.Serializable, "input")]
     [InlineData("something custom", null)]
     [InlineData("something custom", "input")]
     private void DataObject_SetData_InvokeStringObject_Unbounded_GetReturnsExpected(string format, string input)
@@ -1363,10 +1364,10 @@ public partial class DataObjectTests
     [InlineData("something custom", false, null)]
     [InlineData("something custom", true, "input")]
     [InlineData("something custom", true, null)]
-    [InlineData("WindowsForms10PersistentObject", false, "input")]
-    [InlineData("WindowsForms10PersistentObject", false, null)]
-    [InlineData("WindowsForms10PersistentObject", true, "input")]
-    [InlineData("WindowsForms10PersistentObject", true, null)]
+    [InlineData(DataFormatNames.Serializable, false, "input")]
+    [InlineData(DataFormatNames.Serializable, false, null)]
+    [InlineData(DataFormatNames.Serializable, true, "input")]
+    [InlineData(DataFormatNames.Serializable, true, null)]
     private void DataObject_SetData_InvokeStringBoolObject_Unbounded(string format, bool autoConvert, string input)
     {
         DataObject dataObject = new();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DragDropFormatTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DragDropFormatTests.cs
@@ -24,7 +24,7 @@ public unsafe class DragDropFormatTests
     {
         FORMATETC formatEtc = new()
         {
-            cfFormat = (short)PInvoke.RegisterClipboardFormat("InShellDragLoop"),
+            cfFormat = (short)PInvokeCore.RegisterClipboardFormat("InShellDragLoop"),
             dwAspect = DVASPECT.DVASPECT_CONTENT,
             lindex = -1,
             ptd = nint.Zero,
@@ -47,7 +47,7 @@ public unsafe class DragDropFormatTests
         IStream.Interface iStream = new ComManagedStream(memoryStream);
         formatEtc = new()
         {
-            cfFormat = (short)PInvoke.RegisterClipboardFormat("DragContext"),
+            cfFormat = (short)PInvokeCore.RegisterClipboardFormat("DragContext"),
             dwAspect = DVASPECT.DVASPECT_CONTENT,
             lindex = -1,
             ptd = nint.Zero,

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DragDropHelperTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DragDropHelperTests.cs
@@ -91,7 +91,7 @@ public class DragDropHelperTests
     {
         FORMATETC formatEtc = new()
         {
-            cfFormat = (short)PInvoke.RegisterClipboardFormat(format),
+            cfFormat = (short)PInvokeCore.RegisterClipboardFormat(format),
             dwAspect = DVASPECT.DVASPECT_CONTENT,
             lindex = -1,
             ptd = IntPtr.Zero,


### PR DESCRIPTION
Moves the refactored code to the Core assembly.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12805)