### PR TITLE
Add unit test for NotifyIconActionList

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/NotifyIconDesignerActionListTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/NotifyIconDesignerActionListTests.cs
@@ -28,7 +28,7 @@ public sealed class NotifyIconActionListTests : IDisposable
     }
 
     [Fact]
-    public void Constructor_ShouldInitializeDesigner() => _actionList.Should().NotBeNull();
+    public void Constructor_ShouldInitializeActionList() => _actionList.Should().NotBeNull();
 
     [Fact]
     public void ChooseIcon_ShouldNotBeNull()

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/NotifyIconDesignerActionListTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/NotifyIconDesignerActionListTests.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.ComponentModel.Design;
+
+namespace System.Windows.Forms.Design.Tests;
+
+public sealed class NotifyIconActionListTests : IDisposable
+{
+    private readonly NotifyIconDesigner _designer;
+    private readonly NotifyIcon _notifyIcon;
+    private readonly NotifyIconActionList _actionList;
+
+    public NotifyIconActionListTests()
+    {
+        _designer = new();
+        _notifyIcon = new();
+        _designer.Initialize(_notifyIcon);
+        _actionList = new(_designer);
+    }
+
+    public void Dispose()
+    {
+        _designer.Dispose();
+        _notifyIcon.Dispose();
+    }
+
+    [Fact]
+    public void Constructor_ShouldInitializeDesigner() => _actionList.Should().NotBeNull();
+
+    [Fact]
+    public void ChooseIcon_ShouldNotBeNull()
+    {
+        Action act = _actionList.ChooseIcon;
+        act.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void GetSortedActionItems_ShouldReturnCorrectItems()
+    {
+        DesignerActionItemCollection items = _actionList.GetSortedActionItems();
+
+        items.Should().NotBeNull();
+        items.Count.Should().Be(1);
+        items[0].Should().BeOfType<DesignerActionMethodItem>();
+        DesignerActionMethodItem methodItem = (DesignerActionMethodItem)items[0];
+        methodItem.MemberName.Should().Be(nameof(NotifyIconActionList.ChooseIcon));
+        methodItem.DisplayName.Should().Be(SR.ChooseIconDisplayName);
+        methodItem.IncludeAsDesignerVerb.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related https://github.com/dotnet/winforms/issues/10773


## Proposed changes

- Add unit test NotifyIconDesignerActionListTests.cs for public properties and methods of the NotifyIconDesignerActionList.
- Enable nullability in NotifyIconDesignerActionListTests.cs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12813)