### PR TITLE
Added a condition to check if `_altCheckBox.Focused` before navigating to the next control. This ensures that the `Alt` checkbox is not skipped when using the right arrow key.

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ShortcutKeysEditor.ShortcutKeysUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ShortcutKeysEditor.ShortcutKeysUI.cs
@@ -286,7 +286,7 @@ public partial class ShortcutKeysEditor
                 case Keys.Right:
                     if ((keyModifiers & (Keys.Control | Keys.Alt)) == 0)
                     {
-                        if (_shiftCheckBox.Focused)
+                        if (_altCheckBox.Focused)
                         {
                             _keyComboBox.Focus();
                             return true;


### PR DESCRIPTION
Fixes #12733

## Root Cause

- The issue occurred because the navigation logic using the right arrow key did not account for the `Alt` checkbox being focused. This caused the focus to skip over the `Alt` checkbox and move directly to the Key combo box.

## Proposed changes

- Added a condition to check if `_altCheckBox.Focused` before navigating to the next control. This ensures that the `Alt` checkbox is not skipped when using the right arrow key.

## Customer Impact

- Users will now be able to navigate to and interact with the `Alt` checkbox using the right arrow key, improving accessibility and user experience.

## Regression?

- No

## Risk

- Minimal

## Screenshots

### Before

![before](https://github.com/user-attachments/assets/a62dd0d1-6099-423e-819f-ee52e1fcfd6d)

### After

![after](https://github.com/user-attachments/assets/878af87b-93a3-42fb-8f48-f89c26156c6a)

## Test methodology

- Manual

## Test environment(s)

- 10.0.100-alpha.1.25064.3
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12820)