### PR TITLE
Fixes Exception being thrown when the space key is pressed on a CheckBoxCell

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCell.cs
@@ -3671,7 +3671,9 @@ public abstract partial class DataGridViewCell : DataGridViewElement, ICloneable
             cellStyle,
             advancedBorderStyle,
             paintParts);
-        dataGridView.OnCellPainting(dgvcpe);
+
+        dataGridView?.OnCellPainting(dgvcpe);
+
         if (dgvcpe.Handled)
         {
             return;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCheckBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCheckBoxCell.cs
@@ -839,9 +839,9 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
                 e.Handled = true;
             }
 
-                NotifyMSAAClient(ColumnIndex, rowIndex);
-            }
+            NotifyMSAAClient(ColumnIndex, rowIndex);
         }
+    }
 
     protected override void OnLeave(int rowIndex, bool throughMouseClick)
     {
@@ -1007,6 +1007,11 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
     {
         ArgumentNullException.ThrowIfNull(cellStyle);
 
+        if (DataGridView is null)
+        {
+            return;
+        }
+
         PaintPrivate(
             graphics,
             clipBounds,
@@ -1046,11 +1051,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
         bool computeErrorIconBounds,
         bool paint)
     {
-        if(DataGridView is null)
         // Parameter checking.
-        {
-            return Rectangle.Empty;
-        }
 
         // One bit and one bit only should be turned on
         Debug.Assert(paint || computeContentBounds || computeErrorIconBounds);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCheckBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCheckBoxCell.cs
@@ -839,9 +839,9 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
                 e.Handled = true;
             }
 
-            NotifyMSAAClient(ColumnIndex, rowIndex);
+                NotifyMSAAClient(ColumnIndex, rowIndex);
+            }
         }
-    }
 
     protected override void OnLeave(int rowIndex, bool throughMouseClick)
     {
@@ -967,9 +967,12 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
 
     private void NotifyMSAAClient(int columnIndex, int rowIndex)
     {
-        Debug.Assert(DataGridView is not null);
-        Debug.Assert((columnIndex >= 0) && (columnIndex < DataGridView.Columns.Count));
-        Debug.Assert((rowIndex >= 0) && (rowIndex < DataGridView.Rows.Count));
+        if (DataGridView is null ||
+            columnIndex < 0 || columnIndex >= DataGridView.Columns.Count ||
+            rowIndex < 0 || rowIndex >= DataGridView.Rows.Count)
+        {
+            return;
+        }
 
         int visibleRowIndex = DataGridView.Rows.GetRowCount(DataGridViewElementStates.Visible, 0, rowIndex);
         int visibleColumnIndex = DataGridView.Columns.ColumnIndexToActualDisplayIndex(columnIndex, DataGridViewElementStates.Visible);
@@ -1043,7 +1046,11 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
         bool computeErrorIconBounds,
         bool paint)
     {
+        if(DataGridView is null)
         // Parameter checking.
+        {
+            return Rectangle.Empty;
+        }
 
         // One bit and one bit only should be turned on
         Debug.Assert(paint || computeContentBounds || computeErrorIconBounds);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewRow.cs
@@ -786,9 +786,13 @@ public partial class DataGridViewRow : DataGridViewBand
 
     private void BuildInheritedRowStyle(int rowIndex, DataGridViewCellStyle inheritedRowStyle)
     {
+        if (DataGridView is null)
+        {
+            return;
+        }
+
         Debug.Assert(inheritedRowStyle is not null);
         Debug.Assert(rowIndex >= 0);
-        Debug.Assert(DataGridView is not null);
 
         DataGridViewCellStyle? rowStyle = null;
         if (HasDefaultCellStyle)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewRowHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewRowHeaderCell.cs
@@ -652,8 +652,6 @@ public partial class DataGridViewRowHeaderCell : DataGridViewHeaderCell
 
         bool cellSelected = (dataGridViewElementState & DataGridViewElementStates.Selected) != 0;
 
-        Debug.Assert(DataGridView is not null);
-
         if (DataGridView is null)
         {
             return Rectangle.Empty;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewRowHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewRowHeaderCell.cs
@@ -653,6 +653,12 @@ public partial class DataGridViewRowHeaderCell : DataGridViewHeaderCell
         bool cellSelected = (dataGridViewElementState & DataGridViewElementStates.Selected) != 0;
 
         Debug.Assert(DataGridView is not null);
+
+        if (DataGridView is null)
+        {
+            return Rectangle.Empty;
+        }
+
         if (DataGridView.ApplyVisualStylesToHeaderCells)
         {
             if (cellStyle.Padding != Padding.Empty)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewTextBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewTextBoxCell.cs
@@ -610,6 +610,11 @@ public partial class DataGridViewTextBoxCell : DataGridViewCell
     {
         ArgumentNullException.ThrowIfNull(cellStyle);
 
+        if (DataGridView is null)
+        {
+            return;
+        }
+
         PaintPrivate(
             graphics,
             clipBounds,
@@ -649,11 +654,6 @@ public partial class DataGridViewTextBoxCell : DataGridViewCell
         bool computeErrorIconBounds,
         bool paint)
     {
-        if (DataGridView is null)
-        {
-            return Rectangle.Empty;
-        }
-
         // Parameter checking. One bit and one bit only should be turned on.
         Debug.Assert(paint || computeContentBounds || computeErrorIconBounds);
         Debug.Assert(!paint || !computeContentBounds || !computeErrorIconBounds);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewTextBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewTextBoxCell.cs
@@ -649,6 +649,11 @@ public partial class DataGridViewTextBoxCell : DataGridViewCell
         bool computeErrorIconBounds,
         bool paint)
     {
+        if (DataGridView is null)
+        {
+            return Rectangle.Empty;
+        }
+
         // Parameter checking. One bit and one bit only should be turned on.
         Debug.Assert(paint || computeContentBounds || computeErrorIconBounds);
         Debug.Assert(!paint || !computeContentBounds || !computeErrorIconBounds);


### PR DESCRIPTION
Fixes #12752

## Root Cause

- The issue occurs because the `NotifyMSAAClient` method is called without checking if the `DataGridView` instance is `null`. This leads to a potential `NullReferenceException`.

## Proposed changes

- Add a `null` check for the `DataGridView` instance before calling the `NotifyMSAAClient` method.

## Customer Impact

- Prevents runtime crashes when the `DataGridView` is `null`.

## Regression?

- No

## Risk

- Minimal

## Screenshots

### Before

![before](https://github.com/user-attachments/assets/90a054d1-ff22-49a4-8cb3-9c4ddac9b0fb)

### After

![after](https://github.com/user-attachments/assets/b832b743-a8b8-47ed-bd40-31bf3249454b)

## Test methodology

- Manual testing

## Test environment(s)

- `10.0.100-alpha.1.25064.3`