### PR TITLE
Disable package validation while building inside Visual Studio

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,11 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == 'true'">
+    <!-- There is no need to validate packages while iterating inside VS. -->
+    <EnablePackageValidation>false</EnablePackageValidation>
+  </PropertyGroup>
+
   <!--
     Set assembly version to align with major and minor version, as for the patches and revisions should be manually
     updated per assembly if it is serviced.


### PR DESCRIPTION
There is no need to do this when iterating inside VS.

Put in a conditional property group so we can easily add other settings that we may want to do for faster iteration when doing dev work.

Fixes #12817
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12825)