### PR TITLE
Fix ToolStrip's ToolTip issues 

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
@@ -3286,7 +3286,7 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
     {
         base.OnLostFocus(e);
         ClearAllSelections();
-        ToolTip.Hide(this);
+        ToolTip.RemoveAll();
     }
 
     protected internal override void OnLeave(EventArgs e)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12818,#12819

## Proposed changes

- 
- when `ToolStrip` loses focus, remove all tooltips.
- 

<!--  

## Customer Impact

- 
- 
-->

## Regression? 

- No

## Risk

- low



## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

https://github.com/user-attachments/assets/81d5b97d-b10e-4579-9690-c841e4768f83

https://github.com/user-attachments/assets/3314d249-9d70-43e9-a561-f792a3e293d1

### After

https://github.com/user-attachments/assets/f9fe6f0e-86a4-4d90-a48c-4cf28b4da4b9




## Test methodology <!-- How did you ensure quality? -->

- 
- Manually 
- 
<!-- 
## Accessibility testing 
 -->



## Test environment(s)
.Net 10.0.0-alpha.1.25072.13

<!-- Mention language, UI scaling, or anything else that might be relevant -->
