### PR TITLE
React to compiler analyzer warning/error

### DIFF
--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Core/Nrbf/SerializationRecordExtensions.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Core/Nrbf/SerializationRecordExtensions.cs
@@ -349,7 +349,7 @@ internal static class SerializationRecordExtensions
                 || !classInfo.HasMember("_size")
                 || classInfo.GetRawValue("_size") is not int size
                 || !classInfo.TypeName.IsConstructedGenericType
-                || classInfo.TypeName.GetGenericTypeDefinition().Name != typeof(List<>).Name
+                || classInfo.TypeName.GetGenericTypeDefinition().Name != nameof(List<>)
                 || classInfo.TypeName.GetGenericArguments().Length != 1
                 || classInfo.GetRawValue("_items") is not ArrayRecord arrayRecord
                 || !IsPrimitiveArrayRecord(arrayRecord))


### PR DESCRIPTION
src\System.Private.Windows.Core\src\System\Private\Windows\Core\Nrbf\SerializationRecordExtensions.cs(352,74): error IDE0082: 'typeof' can be converted to 'nameof' (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0082) [D:\a\_work\1\vmr\src\winforms\src\System.Private.Windows.Core\src\System.Private.Windows.Core.csproj::TargetFramework=net10.0]

Noticed in https://dev.azure.com/dnceng-public/public/_build/results?buildId=927853&view=logs&jobId=4c84be64-8e15-55fe-7f7c-5d9633177e7b&j=4c84be64-8e15-55fe-7f7c-5d9633177e7b&t=d42f7fa6-7dc2-51df-d615-9cb71676e73c
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12837)