### PR TITLE
Tweak ValueStringBuilder to support interpolated strings

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/FontConverter.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/FontConverter.cs
@@ -33,10 +33,10 @@ public class FontConverter : TypeConverter
                 culture ??= CultureInfo.CurrentCulture;
 
                 ValueStringBuilder sb = default;
-                sb.Append(font.Name);
+                sb.AppendLiteral(font.Name);
                 sb.Append(culture.TextInfo.ListSeparator[0]);
                 sb.Append(' ');
-                sb.Append(font.Size.ToString(culture.NumberFormat));
+                sb.AppendLiteral(font.Size.ToString(culture.NumberFormat));
 
                 switch (font.Unit)
                 {
@@ -44,39 +44,39 @@ public class FontConverter : TypeConverter
                     // to GraphicsUnit.Display
                     // Don't know what to append for GraphicsUnit.Display
                     case GraphicsUnit.Display:
-                        sb.Append("display");
+                        sb.AppendLiteral("display");
                         break;
 
                     case GraphicsUnit.Document:
-                        sb.Append("doc");
+                        sb.AppendLiteral("doc");
                         break;
 
                     case GraphicsUnit.Point:
-                        sb.Append("pt");
+                        sb.AppendLiteral("pt");
                         break;
 
                     case GraphicsUnit.Inch:
-                        sb.Append("in");
+                        sb.AppendLiteral("in");
                         break;
 
                     case GraphicsUnit.Millimeter:
-                        sb.Append("mm");
+                        sb.AppendLiteral("mm");
                         break;
 
                     case GraphicsUnit.Pixel:
-                        sb.Append("px");
+                        sb.AppendLiteral("px");
                         break;
 
                     case GraphicsUnit.World:
-                        sb.Append("world");
+                        sb.AppendLiteral("world");
                         break;
                 }
 
                 if (font.Style != FontStyle.Regular)
                 {
                     sb.Append(culture.TextInfo.ListSeparator[0]);
-                    sb.Append(" style=");
-                    sb.Append(font.Style.ToString());
+                    sb.AppendLiteral(" style=");
+                    sb.AppendLiteral(font.Style.ToString());
                 }
 
                 return sb.ToString();

--- a/src/System.Private.Windows.Core/src/System/Text/ValueStringBuilder.cs
+++ b/src/System.Private.Windows.Core/src/System/Text/ValueStringBuilder.cs
@@ -12,11 +12,24 @@ namespace System.Text;
 /// <summary>
 ///  String builder struct that allows using stack space for small strings.
 /// </summary>
+[InterpolatedStringHandler]
 internal ref partial struct ValueStringBuilder
 {
+    private const int GuessedLengthPerHole = 11;
+    private const int MinimumArrayPoolLength = 256;
+
     private char[]? _arrayToReturnToPool;
+
     private Span<char> _chars;
     private int _pos;
+
+    public ValueStringBuilder(int literalLength, int formattedCount)
+    {
+        _arrayToReturnToPool = null;
+        _chars = ArrayPool<char>.Shared.Rent(
+            Math.Min(MinimumArrayPoolLength, literalLength + (GuessedLengthPerHole * formattedCount)));
+        _pos = 0;
+    }
 
     public ValueStringBuilder(Span<char> initialBuffer)
     {
@@ -90,9 +103,11 @@ internal ref partial struct ValueStringBuilder
         }
     }
 
-    public override string ToString()
+    public override readonly string ToString() => _chars[.._pos].ToString();
+
+    public string ToStringAndClear()
     {
-        string s = _chars[.._pos].ToString();
+        string s = ToString();
         Dispose();
         return s;
     }
@@ -185,8 +200,14 @@ internal ref partial struct ValueStringBuilder
         }
     }
 
+    /// <summary>
+    ///  Append a string to the builder. If the string is <see langword="null"/>, this method does nothing.
+    /// </summary>
+    /// <devdoc>
+    ///  Name must be AppendLiteral to work with interpolated strings.
+    /// </devdoc>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Append(string? s)
+    public void AppendLiteral(string? s)
     {
         if (s is null)
         {
@@ -217,6 +238,24 @@ internal ref partial struct ValueStringBuilder
         s.CopyTo(_chars[pos..]);
         _pos += s.Length;
     }
+
+    public void AppendFormatted<TFormattable>(TFormattable value) where TFormattable : ISpanFormattable
+    {
+        int charsWritten;
+
+        // This must be cast inline to avoid boxing.
+        while (!((ISpanFormattable)value).TryFormat(_chars[_pos..], out charsWritten, format: default, provider: default))
+        {
+            Grow(1);
+        }
+
+        _pos += charsWritten;
+        return;
+    }
+
+    public void AppendFormatted(string? value) => Append(value.AsSpan());
+
+    public void AppendFormatted(object? value) => AppendLiteral(value?.ToString());
 
     public void Append(char c, int count)
     {
@@ -261,19 +300,6 @@ internal ref partial struct ValueStringBuilder
 
         value.CopyTo(_chars[_pos..]);
         _pos += value.Length;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Span<char> AppendSpan(int length)
-    {
-        int origPos = _pos;
-        if (origPos > _chars.Length - length)
-        {
-            Grow(length);
-        }
-
-        _pos = origPos + length;
-        return _chars.Slice(origPos, length);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/System.Private.Windows.Core/src/System/TypeExtensions.cs
+++ b/src/System.Private.Windows.Core/src/System/TypeExtensions.cs
@@ -4,6 +4,7 @@
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace System;
 
@@ -250,7 +251,7 @@ internal static class TypeExtensions
             assemblyName = type.Assembly.FullName;
         }
 
-        return TypeName.Parse($"{GetTypeFullName(type)}, {assemblyName}");
+        return ToTypeName($"{GetTypeFullName(type)}, {assemblyName}");
 
         static string GetTypeFullName(Type type)
         {
@@ -285,4 +286,12 @@ internal static class TypeExtensions
         type.IsGenericType && !type.IsGenericTypeDefinition && type.GetGenericTypeDefinition() == typeof(Nullable<>)
             ? type.GetGenericArguments()[0]
             : type;
+
+    public static TypeName ToTypeName(ref ValueStringBuilder builder)
+    {
+        using (builder)
+        {
+            return TypeName.Parse(builder.AsSpan());
+        }
+    }
 }

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Text/ValueStringBuilderTests.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Text/ValueStringBuilderTests.cs
@@ -1,0 +1,81 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Text;
+
+public class ValueStringBuilderTests
+{
+    [Fact]
+    public void Append_ShouldAppendSingleString()
+    {
+        using ValueStringBuilder builder = new(10);
+        builder.Append("Hello");
+        builder.ToString().Should().Be("Hello");
+    }
+
+    [Fact]
+    public void Append_ShouldAppendMultipleStrings()
+    {
+        using ValueStringBuilder builder = new(10);
+        builder.Append("Hello");
+        builder.Append(", ");
+        builder.Append("world!");
+        builder.ToString().Should().Be("Hello, world!");
+    }
+
+    [Fact]
+    public void Append_Char_ShouldAppendCharacters()
+    {
+        using ValueStringBuilder builder = new(10);
+        builder.Append('A');
+        builder.Append('B');
+        builder.Append('C');
+        builder.ToString().Should().Be("ABC");
+    }
+
+    [Fact]
+    public void Insert_ShouldInsertStringAtIndex()
+    {
+        using ValueStringBuilder builder = new(10);
+        builder.Append("Hello world!");
+        builder.Insert(6, "beautiful ");
+        builder.ToString().Should().Be("Hello beautiful world!");
+    }
+
+    [Fact]
+    public void Length_ShouldReturnCorrectValue()
+    {
+        using ValueStringBuilder builder = new(10);
+        builder.Append("12345");
+        builder.Length.Should().Be(5);
+    }
+
+    [Fact]
+    public void Capacity_ShouldIncreaseWhenExceeded()
+    {
+        using ValueStringBuilder builder = new(10);
+        builder.Append("This is a long string that exceeds the initial capacity.");
+        builder.Capacity.Should().BeGreaterThan(10);
+        builder.ToString().Should().Be("This is a long string that exceeds the initial capacity.");
+    }
+
+    [Theory]
+    [InlineData(10)]
+    [InlineData(100)]
+    public void AsHandler_Int(int value)
+    {
+        string result = TestFormat($"Hello, {value}!");
+        result.Should().Be($"Hello, {value}!");
+    }
+
+    [Theory]
+    [InlineData(DayOfWeek.Monday)]
+    [InlineData(DayOfWeek.Friday)]
+    public void AsHandler_Enum(DayOfWeek value)
+    {
+        string result = TestFormat($"Hello, it's {value}!");
+        result.Should().Be($"Hello, it's {value}!");
+    }
+
+    private static string TestFormat(ref ValueStringBuilder builder) => builder.ToStringAndClear();
+}


### PR DESCRIPTION
Tweak ValueStringBuilder to allow it to be used as an interpolated string handler

One small usage in TypeExtensions. I'm going to be doing a larger change based on this as a follow-up.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12876)