### PR TITLE
Add unit tests for ToolStripMenuItemCodeDomSerializer

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripMenuItemCodeDomSerializerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripMenuItemCodeDomSerializerTests.cs
@@ -1,0 +1,84 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using Moq;
+using System.ComponentModel;
+using System.ComponentModel.Design.Serialization;
+
+namespace System.Windows.Forms.Design.Tests;
+
+public class ToolStripMenuItemCodeDomSerializerTests : IDisposable
+{
+    private readonly Mock<IDesignerSerializationManager> _mockManager;
+    private readonly Mock<CodeDomSerializer> _mockBaseSerializer;
+    private readonly ToolStripMenuItemCodeDomSerializer _serializer;
+
+    public ToolStripMenuItemCodeDomSerializerTests()
+    {
+        _mockManager = new();
+        _mockBaseSerializer = new();
+
+        _mockManager.Setup(m => m.GetSerializer(typeof(Component), typeof(CodeDomSerializer)))
+                    .Returns(_mockBaseSerializer.Object);
+
+        _serializer = new();
+    }
+
+    public void Dispose()
+    {
+        _mockManager.Reset();
+        _mockBaseSerializer.Reset();
+    }
+
+    [Fact]
+    public void Deserialize_CallsBaseSerializer()
+    {
+        object codeObject = new();
+        var result = _serializer.Deserialize(_mockManager.Object, codeObject);
+
+        _mockBaseSerializer.Verify(s => s.Deserialize(_mockManager.Object, codeObject), Times.Once);
+    }
+
+    [Fact]
+    public void Serialize_DoesNotSerializeDummyItem()
+    {
+        _mockManager.Setup(m => m.GetSerializer(typeof(ImageList).BaseType, typeof(CodeDomSerializer)))
+                    .Returns(_mockBaseSerializer.Object);
+
+        ToolStripMenuItem dummyItem = new();
+        Mock<ToolStrip> mockParent = new();
+        mockParent.Setup(p => p.Site).Returns((ISite?)null);
+        dummyItem.TestAccessor().Dynamic.Parent = mockParent.Object;
+
+        var result = _serializer.Serialize(_mockManager.Object, dummyItem);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Serialize_CallsBaseSerializerForNonDummyItem()
+    {
+        _mockManager.Setup(m => m.GetSerializer(typeof(ImageList).BaseType, typeof(CodeDomSerializer)))
+                    .Returns(_mockBaseSerializer.Object);
+
+        ToolStripMenuItem nonDummyItem = new();
+        ToolStripDropDown dropDown = new();
+        dropDown.Items.Add(nonDummyItem);
+
+        Mock<ISite> mockSite = new();
+        dropDown.Site = mockSite.Object;
+
+        Mock<ISite> mockMenuItemSite = new();
+        nonDummyItem.Site = mockMenuItemSite.Object;
+
+        _mockBaseSerializer.Setup(s => s.Serialize(_mockManager.Object, nonDummyItem))
+                           .Returns(new object());
+
+        var result = _serializer.Serialize(_mockManager.Object, nonDummyItem);
+
+        result.Should().NotBeNull();
+        _mockBaseSerializer.Verify(s => s.Serialize(_mockManager.Object, nonDummyItem), Times.Once);
+    }
+}

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripMenuItemCodeDomSerializerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripMenuItemCodeDomSerializerTests.cs
@@ -9,7 +9,7 @@ using System.ComponentModel.Design.Serialization;
 
 namespace System.Windows.Forms.Design.Tests;
 
-public class ToolStripMenuItemCodeDomSerializerTests : IDisposable
+public class ToolStripMenuItemCodeDomSerializerTests
 {
     private readonly Mock<IDesignerSerializationManager> _mockManager;
     private readonly Mock<CodeDomSerializer> _mockBaseSerializer;
@@ -26,17 +26,11 @@ public class ToolStripMenuItemCodeDomSerializerTests : IDisposable
         _serializer = new();
     }
 
-    public void Dispose()
-    {
-        _mockManager.Reset();
-        _mockBaseSerializer.Reset();
-    }
-
     [Fact]
     public void Deserialize_CallsBaseSerializer()
     {
         object codeObject = new();
-        var result = _serializer.Deserialize(_mockManager.Object, codeObject);
+        object? result = _serializer.Deserialize(_mockManager.Object, codeObject);
 
         _mockBaseSerializer.Verify(s => s.Deserialize(_mockManager.Object, codeObject), Times.Once);
     }
@@ -52,7 +46,7 @@ public class ToolStripMenuItemCodeDomSerializerTests : IDisposable
         mockParent.Setup(p => p.Site).Returns((ISite?)null);
         dummyItem.TestAccessor().Dynamic.Parent = mockParent.Object;
 
-        var result = _serializer.Serialize(_mockManager.Object, dummyItem);
+        object? result = _serializer.Serialize(_mockManager.Object, dummyItem);
 
         result.Should().BeNull();
     }
@@ -76,7 +70,7 @@ public class ToolStripMenuItemCodeDomSerializerTests : IDisposable
         _mockBaseSerializer.Setup(s => s.Serialize(_mockManager.Object, nonDummyItem))
                            .Returns(new object());
 
-        var result = _serializer.Serialize(_mockManager.Object, nonDummyItem);
+        object? result = _serializer.Serialize(_mockManager.Object, nonDummyItem);
 
         result.Should().NotBeNull();
         _mockBaseSerializer.Verify(s => s.Serialize(_mockManager.Object, nonDummyItem), Times.Once);


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773


## Proposed changes

- Add unit test ToolStripMenuItemCodeDomSerializerTests.cs for public method of the ToolStripMenuItemCodeDomSerializer.
- Enable nullability in ToolStripMenuItemCodeDomSerializerTests.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12883)