### PR TITLE
Move TypeExtensionsTests

### DIFF
--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Private/Windows/Nrbf/CoreNrbfSerializerTests.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Private/Windows/Nrbf/CoreNrbfSerializerTests.cs
@@ -49,19 +49,13 @@ public class CoreNrbfSerializerTests
 #pragma warning restore SYSLIB0011
         }
 
-        bool result = CoreNrbfSerializer.TryWriteObject(stream, input);
-        result.Should().Be(expectedResult);
-
-        if (!expectedResult)
-        {
-            stream.Position.Should().Be(0);
-            return;
-        }
-
         stream.Position = 0;
-        SerializationRecord record = NrbfDecoder.Decode(stream);
-        CoreNrbfSerializer.TryGetObject(record, out object? value).Should().BeTrue();
-        value.Should().Be(input);
+        SerializationRecord record = NrbfDecoder.Decode(stream, leaveOpen: true);
+        CoreNrbfSerializer.TryGetObject(record, out object? value).Should().Be(expectedResult);
+        if (expectedResult)
+        {
+            value.Should().Be(input);
+        }
     }
 
     public static TheoryData<string, bool, Type?> TryBindToTypeData => new()

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Reflection/Metadata/TypeNameComparerTests.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Reflection/Metadata/TypeNameComparerTests.cs
@@ -7,7 +7,7 @@ public class TypeNameComparerTests
 {
     private class TestType { }
 
-    public static TheoryData<TypeName, Type> TypeNameComparerSuccess() => new()
+    public static TheoryData<TypeName, Type> TypeNameComparer_FullyQualified_Success() => new()
     {
         { TypeName.Parse(typeof(int).AssemblyQualifiedName), typeof(int) },
         { TypeName.Parse($"{typeof(int).FullName}, {typeof(int).Assembly.FullName}"), typeof(int) },
@@ -20,8 +20,8 @@ public class TypeNameComparerTests
     };
 
     [Theory]
-    [MemberData(nameof(TypeNameComparerSuccess))]
-    public void DictionaryLookupSucceeds(TypeName name, Type expected)
+    [MemberData(nameof(TypeNameComparer_FullyQualified_Success))]
+    public void DictionaryLookup_FullyQualified_Succeeds(TypeName name, Type expected)
     {
         Dictionary<TypeName, Type> types = new(TypeNameComparer.FullyQualifiedMatch)
         {
@@ -35,7 +35,7 @@ public class TypeNameComparerTests
         resolvedType.Should().Be(expected);
     }
 
-    public static TheoryData<TypeName> TypeNameComparerFail() =>
+    public static TheoryData<TypeName> TypeNameComparer_FullyQualified_Fail() =>
     [
         TypeName.Parse("System.Int32[], System.Private.CoreLib, Version=9.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"),
         TypeName.Parse("System.Int32, System.Private.CoreLib, Version=9.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"),
@@ -45,8 +45,10 @@ public class TypeNameComparerTests
     ];
 
     [Theory]
-    [MemberData(nameof(TypeNameComparerFail))]
-    public void DictionaryLookupVersionMismatch(TypeName name)
+    [MemberData(nameof(TypeNameComparer_FullyQualified_Fail))]
+    [MemberData(nameof(TypeNameComparer_FullNameMatch_Fail))]
+    [MemberData(nameof(TypeNameComparer_FullNameAndAssemblyNameMatch_Fail))]
+    public void DictionaryLookup_FullyQualified_VersionMismatch(TypeName name)
     {
         Dictionary<TypeName, Type> types = new(TypeNameComparer.FullyQualifiedMatch)
         {
@@ -60,7 +62,7 @@ public class TypeNameComparerTests
     }
 
     [Fact]
-    public void DictionaryLookupFails()
+    public void DictionaryLookup_FullyQualified_Fails()
     {
         Dictionary<TypeName, Type> types = new(TypeNameComparer.FullyQualifiedMatch)
         {
@@ -98,5 +100,111 @@ public class TypeNameComparerTests
         int hash = comparer.GetHashCode(TypeName.Parse(typeof(int).AssemblyQualifiedName));
         comparer.GetHashCode(TypeName.Parse(typeof(int).AssemblyQualifiedName)).Should().Be(hash);
         comparer.GetHashCode(TypeName.Parse($"{typeof(int).FullName}, {typeof(int).Assembly.FullName}")).Should().Be(hash);
+    }
+
+    public static TheoryData<TypeName, Type> TypeNameComparer_FullNameMatch_Success() => new()
+    {
+        { TypeName.Parse("System.Int32"), typeof(int) },
+        { TypeName.Parse("System.Int32[]"), typeof(int[]) },
+        { TypeName.Parse("System.Collections.Generic.List`1[[System.Int32]]"), typeof(List<int>) },
+        { TypeName.Parse(typeof(TestType).FullName), typeof(TestType) },
+    };
+
+    [Theory]
+    [MemberData(nameof(TypeNameComparer_FullNameMatch_Success))]
+    [MemberData(nameof(TypeNameComparer_FullNameAndAssemblyNameMatch_Success))]
+    [MemberData(nameof(TypeNameComparer_FullyQualified_Success))]
+    public void DictionaryLookup_FullNameMatch_Succeeds(TypeName name, Type expected)
+    {
+        var types = new Dictionary<TypeName, Type>(TypeNameComparer.FullNameMatch)
+        {
+            { TypeName.Parse(typeof(int).FullName), typeof(int) },
+            { TypeName.Parse(typeof(int[]).FullName), typeof(int[]) },
+            { TypeName.Parse(typeof(List<int>).FullName), typeof(List<int>) },
+            { TypeName.Parse(typeof(TestType).FullName), typeof(TestType) },
+        };
+
+        types.TryGetValue(name, out var resolvedType).Should().BeTrue();
+        resolvedType.Should().Be(expected);
+    }
+
+    public static TheoryData<TypeName> TypeNameComparer_FullNameMatch_Fail() =>
+    [
+        TypeName.Parse("UnknownType"),
+        TypeName.Parse("List`1[[UnknownType]]"),
+        TypeName.Parse("Int32"),
+        TypeName.Parse("Int32[]"),
+        TypeName.Parse("System.Collections.Generic.List`1[[Int32]]"),
+        TypeName.Parse(nameof(TestType))
+    ];
+
+    [Theory]
+    [MemberData(nameof(TypeNameComparer_FullNameMatch_Fail))]
+    public void DictionaryLookup_FullNameMatch_Fails(TypeName name)
+    {
+        var types = new Dictionary<TypeName, Type>(TypeNameComparer.FullNameMatch)
+        {
+            { TypeName.Parse(typeof(int).FullName), typeof(int) },
+            { TypeName.Parse(typeof(int[]).FullName), typeof(int[]) },
+            { TypeName.Parse(typeof(List<int>).FullName), typeof(List<int>) },
+            { TypeName.Parse(typeof(TestType).FullName), typeof(TestType) },
+        };
+
+        types.TryGetValue(name, out _).Should().BeFalse();
+    }
+
+    public static TheoryData<TypeName, Type> TypeNameComparer_FullNameAndAssemblyNameMatch_Success() => new()
+    {
+        { TypeName.Parse($"{typeof(int).FullName}, {typeof(int).Assembly.GetName().Name}"), typeof(int) },
+        { TypeName.Parse($"{typeof(int[]).FullName}, {typeof(int).Assembly.GetName().Name}"), typeof(int[]) },
+        { TypeName.Parse($"{typeof(List<int>).FullName}, {typeof(List<int>).Assembly.GetName().Name}"), typeof(List<int>) },
+        { TypeName.Parse($"{typeof(TestType).FullName}, {typeof(TestType).Assembly.GetName().Name}"), typeof(TestType) },
+    };
+
+    [Theory]
+    [MemberData(nameof(TypeNameComparer_FullNameAndAssemblyNameMatch_Success))]
+    [MemberData(nameof(TypeNameComparer_FullyQualified_Success))]
+    public void DictionaryLookup_FullNameAndAssemblyNameMatch_Succeeds(TypeName name, Type expected)
+    {
+        var types = new Dictionary<TypeName, Type>(TypeNameComparer.FullNameAndAssemblyNameMatch)
+        {
+            { TypeName.Parse($"{typeof(int).FullName}, {typeof(int).Assembly.GetName().Name}"), typeof(int) },
+            { TypeName.Parse($"{typeof(int[]).FullName}, {typeof(int).Assembly.GetName().Name}"), typeof(int[]) },
+            { TypeName.Parse($"{typeof(List<int>).FullName}, {typeof(List<int>).Assembly.GetName().Name}"), typeof(List<int>) },
+            { TypeName.Parse($"{typeof(TestType).FullName}, {typeof(TestType).Assembly.GetName().Name}"), typeof(TestType) },
+        };
+
+        types.TryGetValue(name, out var resolvedType).Should().BeTrue();
+        resolvedType.Should().Be(expected);
+    }
+
+    public static TheoryData<TypeName> TypeNameComparer_FullNameAndAssemblyNameMatch_Fail() => new()
+    {
+        // Different assembly name
+        TypeName.Parse($"{typeof(int).FullName}, SomeOtherAssembly"),
+        // Different full name
+        TypeName.Parse($"SomeNamespace.SomeType, {typeof(int).Assembly.GetName().Name}"),
+        // Different full name and assembly name
+        TypeName.Parse("SomeNamespace.SomeType, SomeOtherAssembly"),
+        // Missing assembly name
+        TypeName.Parse($"{typeof(int).FullName}"),
+        // Different type but same assembly name
+        TypeName.Parse($"System.String, {typeof(int).Assembly.GetName().Name}"),
+    };
+
+    [Theory]
+    [MemberData(nameof(TypeNameComparer_FullNameAndAssemblyNameMatch_Fail))]
+    [MemberData(nameof(TypeNameComparer_FullNameMatch_Fail))]
+    public void DictionaryLookup_FullNameAndAssemblyNameMatch_Fails(TypeName name)
+    {
+        var types = new Dictionary<TypeName, Type>(TypeNameComparer.FullNameAndAssemblyNameMatch)
+        {
+            { TypeName.Parse($"{typeof(int).FullName}, {typeof(int).Assembly.GetName().Name}"), typeof(int) },
+            { TypeName.Parse($"{typeof(int[]).FullName}, {typeof(int).Assembly.GetName().Name}"), typeof(int[]) },
+            { TypeName.Parse($"{typeof(List<int>).FullName}, {typeof(List<int>).Assembly.GetName().Name}"), typeof(List<int>) },
+            { TypeName.Parse($"{typeof(TestType).FullName}, {typeof(TestType).Assembly.GetName().Name}"), typeof(TestType) },
+        };
+
+        types.TryGetValue(name, out _).Should().BeFalse();
     }
 }

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/TypeExtensionsTests.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/TypeExtensionsTests.cs
@@ -1,13 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
-using System.Drawing;
 using System.Reflection.Metadata;
 using System.Runtime.CompilerServices;
 
-namespace System.Windows.Forms.Tests;
+namespace System.Tests;
 
 public class TypeExtensionsTests
 {
@@ -19,30 +16,25 @@ public class TypeExtensionsTests
         { typeof(int?), TypeName.Parse($"System.Int32, {Assemblies.Mscorlib}"), true },
         { typeof(int?[]), TypeName.Parse($"System.Nullable`1[[System.Int32, {Assemblies.Mscorlib}]][], {Assemblies.Mscorlib}"), true},
         { typeof(DayOfWeek), TypeName.Parse($"System.Nullable`1[[System.DayOfWeek, {Assemblies.Mscorlib}]], {Assemblies.Mscorlib}"), false },
-        { typeof(Bitmap), TypeName.Parse("System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), true },
         // Assembly version is incorrect.
-        { typeof(Bitmap), TypeName.Parse("System.Drawing.Bitmap, System.Drawing, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), true },
+        { typeof(int), TypeName.Parse("System.Int32, System.Private.CoreLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"), false },
         // Public key token is incorrect.
-        { typeof(Bitmap), TypeName.Parse("System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f1AAAAAAA"), false },
+        { typeof(int), TypeName.Parse(typeof(int).AssemblyQualifiedName!.Replace("7cec85d7bea7798e", "7cec00000ea7798e")), false },
         // Culture is incorrect.
-        { typeof(Bitmap), TypeName.Parse("System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=en-US, PublicKeyToken=b03f5f7f11d50a3a"), false },
+        { typeof(int), TypeName.Parse(typeof(int).AssemblyQualifiedName!.Replace("neutral", "en-US")), false },
         // Namespace name is incorrect.
-        { typeof(Bitmap), TypeName.Parse("System.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), false },
-        { typeof(Bitmap), TypeName.Parse("System.Drawing.MyBitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), false },
-        { typeof(Bitmap?[]), TypeName.Parse("System.Drawing.Bitmap[], System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), true },
-        { typeof(Dictionary<string, Bitmap>), TypeName.Parse($"System.Collections.Generic.Dictionary`2[[System.String, {Assemblies.Mscorlib}],[System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], {Assemblies.Mscorlib}"), true },
-        { typeof(Dictionary<string, Bitmap?>), TypeName.Parse($"System.Collections.Generic.Dictionary`2[[System.String, {Assemblies.Mscorlib}],[System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], {Assemblies.Mscorlib}"), true },
-        { typeof(NonForwardedType), TypeName.Parse("System.Windows.Forms.Tests.TypeExtensionsTests.NonForwardedType"), false },
+        { typeof(int), TypeName.Parse(typeof(int).AssemblyQualifiedName!.Replace("System.Int32", "Int32")), false },
+        { typeof(NonForwardedType), TypeName.Parse("System.Tests.TypeExtensionsTests.NonForwardedType"), false },
         // Namespace name is cased differently.
         { typeof(NonForwardedType), TypeName.Parse("System.Windows.Forms.Tests.TypeExtensionstests+NonForwardedType"), false },
         // Assembly information is missing.
-        { typeof(NonForwardedType), TypeName.Parse("System.Windows.Forms.Tests.TypeExtensionsTests+NonForwardedType"), false },
-        { typeof(NonForwardedType), TypeName.Parse("System.Windows.Forms.Tests.TypeExtensionsTests+NonForwardedType, System.Windows.Forms.Tests"), false },
+        { typeof(NonForwardedType), TypeName.Parse("System.Tests.TypeExtensionsTests+NonForwardedType"), false },
+        { typeof(NonForwardedType), TypeName.Parse("System.Tests.TypeExtensionsTests+NonForwardedType, System.Private.Windows.Core.Tests"), false },
         // Assembly name is cased differently.
-        { typeof(NonForwardedType), TypeName.Parse("System.Windows.Forms.Tests.TypeExtensionsTests+NonForwardedType, System.windows.Forms.Tests, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), true },
+        { typeof(NonForwardedType), TypeName.Parse("System.Tests.TypeExtensionsTests+NonForwardedType, System.private.Windows.Core.Tests, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), true },
         // Namespace name is incorrect.
         { typeof(NonForwardedType), TypeName.Parse("System.Windows.Forms.Tests.typeExtensionsTests+NonForwardedType, System.Windows.Forms.Tests"), false },
-        { typeof(ForwardedType), TypeName.Parse("System.Windows.Forms.Tests.TypeExtensionsTests+ForwardedType, Abc"), true },
+        { typeof(ForwardedType), TypeName.Parse($"{typeof(ForwardedType).FullName}, Abc"), true },
     };
 
     [Theory]
@@ -100,19 +92,19 @@ public class TypeExtensionsTests
     public void ForwardedTypeToTypeName()
     {
         TypeName name = typeof(ForwardedType).ToTypeName();
-        name.FullName.Should().Be("System.Windows.Forms.Tests.TypeExtensionsTests+ForwardedType");
+        name.FullName.Should().Be("System.Tests.TypeExtensionsTests+ForwardedType");
         name.AssemblyName!.FullName.Should().Be("Abc");
 
         name = typeof(ForwardedType[]).ToTypeName();
-        name.FullName.Should().Be("System.Windows.Forms.Tests.TypeExtensionsTests+ForwardedType[]");
+        name.FullName.Should().Be("System.Tests.TypeExtensionsTests+ForwardedType[]");
         name.AssemblyName!.FullName.Should().Be("Abc");
 
         name = typeof(ForwardedType?[]).ToTypeName();
-        name.FullName.Should().Be("System.Windows.Forms.Tests.TypeExtensionsTests+ForwardedType[]");
+        name.FullName.Should().Be("System.Tests.TypeExtensionsTests+ForwardedType[]");
         name.AssemblyName!.FullName.Should().Be("Abc");
 
         name = typeof(List<ForwardedType>).ToTypeName();
-        name.FullName.Should().Be($"System.Collections.Generic.List`1[[System.Windows.Forms.Tests.TypeExtensionsTests+ForwardedType, Abc]]");
+        name.FullName.Should().Be($"System.Collections.Generic.List`1[[System.Tests.TypeExtensionsTests+ForwardedType, Abc]]");
         name.AssemblyName!.FullName.Should().Be(Assemblies.Mscorlib);
 
         name = typeof(List<Dictionary<int, string>>).ToTypeName();


### PR DESCRIPTION
Move `TypeExtensionsTests` to Core test assembly. Add additional tests for other classes.

Will add more tests to `TypeExtensionsTests`- don't want to break history.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12890)