### PR TITLE
Fix internal build break

### DIFF
--- a/eng/pipelines/build-PR.yml
+++ b/eng/pipelines/build-PR.yml
@@ -129,6 +129,7 @@ jobs:
         $(_InternalRuntimeDownloadArgs)
         /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\PackSignPublish-${{ parameters.targetArchitecture }}.binlog
       displayName: Pack, Sign, and Publish
+      condition: eq('${{ parameters.targetArchitecture }}', 'x64')
 
     # Upload code coverage data
     - script: $(Build.SourcesDirectory)/.dotnet/dotnet msbuild -restore

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -132,6 +132,7 @@ jobs:
       $(_InternalRuntimeDownloadArgs)
       /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\PackSignPublish-${{ parameters.targetArchitecture }}.binlog
     displayName: Pack, Sign, and Publish
+    condition: eq('${{ parameters.targetArchitecture }}', 'x64')
 
   # Upload code coverage data
   - script: $(Build.SourcesDirectory)/.dotnet/dotnet msbuild -restore


### PR DESCRIPTION
After a dependency flow PR from arcade https://github.com/dotnet/winforms/pull/12873 our internal builds started to fail on the publising stage. https://dev.azure.com/dnceng/internal/_build/results?buildId=2637287&view=results

This stage reads the "BAR manifest"  - a list of our nuget packages that looks like this:
```
 <Package Id="Microsoft.Dotnet.WinForms.ProjectTemplates" Version="10.0.0-preview.2.25106.1" NonShipping="true" Visibility="External"/>
 <Package Id="Microsoft.Private.Winforms" Version="10.0.0-preview.2.25106.1" NonShipping="true" Visibility="External"/>
 <Package Id="System.Drawing.Common" Version="10.0.0-preview.2.25106.1" DotNetReleaseShipping="true" Visibility="External"/>
 <Package Id="System.Private.Windows.Core.TestUtilities" Version="10.0.0-preview.2.25106.1" NonShipping="true" Visibility="External"/>
```

"BAR manifest" is generated on the "Pack Sign and Publish" step. Before the PR from arcade, this step was generating manifest named `AssetManifest\Windows_NT-AnyCPU.xml` for each architecture, overriding the previously written one in place. Then the publish step would process that manifest. After the arcade PR  we are generating 3 manifests, one for each architecture. 
Windows_Arm64.xml
Windows_x64.xml
Windows_x86.xml
probably because of this change https://github.com/dotnet/arcade/commit/232c6280beb21ce21e305134572639a7f80de058

We need only a single manifest and a single set of the nugets, thus we should run the publishing step only for x64.

I don't know why build-PR script has the "Pack, Sign. publish" step because it does not actually run ("Skipping step due to condition evaluation.") I think this step can only run in AzDO (looking at publish.proj in arcade) I'm open to removing this step.
