### PR TITLE
Add code coverage for TreeNodeConverter and TreeViewImageIndexConverter

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeConverterTests.cs
@@ -46,8 +46,7 @@ public class TreeNodeConverterTests
             else if (destinationType == typeof(string))
             {
                 result.Should().BeOfType<string>();
-                string text = (string)result!;
-                text.Should().Be("TreeNode: " + node.Text);
+                result.Should().Be("TreeNode: " + node.Text);
             }
         }
         else

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeConverterTests.cs
@@ -51,4 +51,73 @@ public class TreeNodeConverterTests
                 .Should().Throw<NotSupportedException>();
         }
     }
+
+    [Fact]
+    public void TreeNodeConverter_ConvertTo_InstanceDescriptor_NoChildNodes_ImageIndexMinusOne_Succeeds()
+    {
+        TreeNodeConverter converter = new();
+        TreeNode node = new("NoChildrenMinusOne")
+        {
+            ImageIndex = -1,
+            SelectedImageIndex = -1
+        };
+
+        object result = converter.ConvertTo(context: null, culture: null, value: node, typeof(InstanceDescriptor));
+        var descriptor = result.Should().BeOfType<InstanceDescriptor>().Subject;
+
+        // Cast Arguments to IList for indexing.
+        var args = (IList)descriptor.Arguments!;
+        args.Count.Should().Be(1);
+        args[0].Should().Be(node.Text);
+    }
+
+    [Fact]
+    public void TreeNodeConverter_ConvertTo_InstanceDescriptor_ChildNodes_NoImageIndex_Succeeds()
+    {
+        TreeNodeConverter converter = new();
+        TreeNode parentNode = new("ParentMinusOne") { ImageIndex = -1, SelectedImageIndex = -1 };
+        parentNode.Nodes.Add("Child1");
+        parentNode.Nodes.Add("Child2");
+
+        object result = converter.ConvertTo(context: null, culture: null, value: parentNode, typeof(InstanceDescriptor));
+        var descriptor = result.Should().BeOfType<InstanceDescriptor>().Subject;
+
+        // Cast Arguments to IList for indexing.
+        var args = (IList)descriptor.Arguments!;
+        args.Count.Should().Be(2);
+        args[0].Should().Be(parentNode.Text);
+
+        // The second argument should be an array of child nodes.
+        args[1].Should().BeOfType<TreeNode[]>();
+        var childNodes = (TreeNode[])args[1];
+        childNodes.Should().HaveCount(2);
+        childNodes.Select(n => n.Text).Should().ContainInOrder("Child1", "Child2");
+    }
+
+    [Fact]
+    public void TreeNodeConverter_ConvertTo_InstanceDescriptor_ChildNodes_WithImageIndex_Succeeds()
+    {
+        TreeNodeConverter converter = new();
+        TreeNode parentNode = new("ParentWithIndexes")
+        {
+            ImageIndex = 2,
+            SelectedImageIndex = 3
+        };
+        parentNode.Nodes.Add("ChildA");
+
+        object result = converter.ConvertTo(context: null, culture: null, value: parentNode, typeof(InstanceDescriptor));
+        var descriptor = result.Should().BeOfType<InstanceDescriptor>().Subject;
+
+        // Cast Arguments to IList for indexing.
+        var args = (IList)descriptor.Arguments!;
+        args.Count.Should().Be(4);
+        args[0].Should().Be(parentNode.Text);
+        args[1].Should().Be(parentNode.ImageIndex);
+        args[2].Should().Be(parentNode.SelectedImageIndex);
+
+        // The fourth argument should be an array of child nodes.
+        args[3].Should().BeOfType<TreeNode[]>();
+        var childNodes = (TreeNode[])args[3];
+        childNodes.Single().Text.Should().Be("ChildA");
+    }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeConverterTests.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System.ComponentModel.Design.Serialization;
 using System.Collections;
 
@@ -8,7 +10,7 @@ namespace System.Windows.Forms.Tests;
 
 public class TreeNodeConverterTests
 {
-    [WinFormsTheory]
+    [Theory]
     [InlineData(typeof(InstanceDescriptor), true)]
     [InlineData(typeof(string), true)]
     [InlineData(typeof(int), false)]
@@ -18,7 +20,7 @@ public class TreeNodeConverterTests
         converter.CanConvertTo(null, destinationType).Should().Be(expected);
     }
 
-    [WinFormsTheory]
+    [Theory]
     [InlineData(typeof(InstanceDescriptor), true)]
     [InlineData(typeof(string), true)]
     [InlineData(typeof(int), false)]
@@ -29,19 +31,22 @@ public class TreeNodeConverterTests
 
         if (canConvert)
         {
-            object result = converter.ConvertTo(null, null, node, destinationType);
+            object? result = converter.ConvertTo(null, null, node, destinationType);
+            result.Should().NotBeNull();
+
             if (destinationType == typeof(InstanceDescriptor))
             {
-                result.Should().BeOfType<InstanceDescriptor>();
-                var descriptor = (InstanceDescriptor)result;
-                IList arguments = descriptor.Arguments as IList;
+                var descriptor = result as InstanceDescriptor;
+                descriptor.Should().NotBeNull();
+
+                var arguments = descriptor!.Arguments as IList;
                 arguments.Should().NotBeNull();
-                arguments[0].Should().Be(node.Text);
+                arguments![0].Should().Be(node.Text);
             }
             else if (destinationType == typeof(string))
             {
                 result.Should().BeOfType<string>();
-                string text = (string)result;
+                string text = (string)result!;
                 text.Should().Be("TreeNode: " + node.Text);
             }
         }
@@ -62,8 +67,8 @@ public class TreeNodeConverterTests
             SelectedImageIndex = -1
         };
 
-        object result = converter.ConvertTo(context: null, culture: null, value: node, typeof(InstanceDescriptor));
-        var descriptor = result.Should().BeOfType<InstanceDescriptor>().Subject;
+        object? result = converter.ConvertTo(context: null, culture: null, value: node, typeof(InstanceDescriptor));
+        InstanceDescriptor descriptor = result.Should().BeOfType<InstanceDescriptor>().Subject;
 
         // Cast Arguments to IList for indexing.
         var args = (IList)descriptor.Arguments!;
@@ -79,8 +84,8 @@ public class TreeNodeConverterTests
         parentNode.Nodes.Add("Child1");
         parentNode.Nodes.Add("Child2");
 
-        object result = converter.ConvertTo(context: null, culture: null, value: parentNode, typeof(InstanceDescriptor));
-        var descriptor = result.Should().BeOfType<InstanceDescriptor>().Subject;
+        object? result = converter.ConvertTo(context: null, culture: null, value: parentNode, typeof(InstanceDescriptor));
+        InstanceDescriptor descriptor = result.Should().BeOfType<InstanceDescriptor>().Subject;
 
         // Cast Arguments to IList for indexing.
         var args = (IList)descriptor.Arguments!;
@@ -89,7 +94,7 @@ public class TreeNodeConverterTests
 
         // The second argument should be an array of child nodes.
         args[1].Should().BeOfType<TreeNode[]>();
-        var childNodes = (TreeNode[])args[1];
+        var childNodes = (TreeNode[])args[1]!;
         childNodes.Should().HaveCount(2);
         childNodes.Select(n => n.Text).Should().ContainInOrder("Child1", "Child2");
     }
@@ -103,10 +108,11 @@ public class TreeNodeConverterTests
             ImageIndex = 2,
             SelectedImageIndex = 3
         };
+
         parentNode.Nodes.Add("ChildA");
 
-        object result = converter.ConvertTo(context: null, culture: null, value: parentNode, typeof(InstanceDescriptor));
-        var descriptor = result.Should().BeOfType<InstanceDescriptor>().Subject;
+        object? result = converter.ConvertTo(context: null, culture: null, value: parentNode, typeof(InstanceDescriptor));
+        InstanceDescriptor descriptor = result.Should().BeOfType<InstanceDescriptor>().Subject;
 
         // Cast Arguments to IList for indexing.
         var args = (IList)descriptor.Arguments!;
@@ -117,7 +123,7 @@ public class TreeNodeConverterTests
 
         // The fourth argument should be an array of child nodes.
         args[3].Should().BeOfType<TreeNode[]>();
-        var childNodes = (TreeNode[])args[3];
+        var childNodes = (TreeNode[])args[3]!;
         childNodes.Single().Text.Should().Be("ChildA");
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeConverterTests.cs
@@ -37,10 +37,8 @@ public class TreeNodeConverterTests
             if (destinationType == typeof(InstanceDescriptor))
             {
                 var descriptor = result as InstanceDescriptor;
-                descriptor.Should().NotBeNull();
 
                 var arguments = descriptor!.Arguments as IList;
-                arguments.Should().NotBeNull();
                 arguments![0].Should().Be(node.Text);
             }
             else if (destinationType == typeof(string))

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewImageIndexConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewImageIndexConverterTests.cs
@@ -87,7 +87,6 @@ public class TreeViewImageIndexConverterTests
 
         using TreeView treeView = new TreeView { ImageList = imageList };
         PropertyDescriptor? propertyDescriptor = TypeDescriptor.GetProperties(treeView)["ImageList"];
-        propertyDescriptor.Should().NotBeNull();
         TypeDescriptorContext context = new(treeView, propertyDescriptor!);
 
         TreeViewImageIndexConverter converter = new();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewImageIndexConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewImageIndexConverterTests.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System.ComponentModel;
 using System.Drawing;
 using static System.ComponentModel.TypeConverter;
@@ -21,7 +23,7 @@ public class TreeViewImageIndexConverterTests
     {
         TreeViewImageIndexConverter converter = new();
 
-        Assert.Throws<ArgumentNullException>("destinationType", () => converter.ConvertTo(context: null, culture: null, new object(), destinationType: null));
+        Assert.Throws<ArgumentNullException>("destinationType", () => converter.ConvertTo(context: null, culture: null, new object(), destinationType: (Type)null!));
     }
 
     public static IEnumerable<object[]> TreeViewImageIndexConverter_ConvertFrom_special_string_to_int_ReturnsExpected_TestData()
@@ -32,13 +34,13 @@ public class TreeViewImageIndexConverterTests
         yield return new object[] { SR.toStringNone, ImageList.Indexer.NoneIndex };
     }
 
-    [WinFormsTheory]
+    [Theory]
     [MemberData(nameof(TreeViewImageIndexConverter_ConvertFrom_special_string_to_int_ReturnsExpected_TestData))]
     public void TreeViewImageIndexConverter_ConvertFrom_special_string_to_int_ReturnsExpected(object value, object expected)
     {
         TreeViewImageIndexConverter converter = new();
 
-        object result = converter.ConvertFrom(context: null, culture: null, value);
+        object? result = converter.ConvertFrom(context: null, culture: null, value);
 
         Assert.Equal(expected, result);
     }
@@ -51,13 +53,13 @@ public class TreeViewImageIndexConverterTests
         yield return new object[] { ImageList.Indexer.NoneIndex, SR.toStringNone };
     }
 
-    [WinFormsTheory]
+    [Theory]
     [MemberData(nameof(TreeViewImageIndexConverter_ConvertTo_special_int_to_string_ReturnsExpected_TestData))]
     public void TreeViewImageIndexConverter_ConvertTo_special_int_to_string_ReturnsExpected(object value, object expected)
     {
         TreeViewImageIndexConverter converter = new();
 
-        object result = converter.ConvertTo(context: null, culture: null, value, destinationType: typeof(string));
+        object? result = converter.ConvertTo(context: null, culture: null, value, destinationType: typeof(string));
 
         Assert.Equal(expected, result);
     }
@@ -84,10 +86,11 @@ public class TreeViewImageIndexConverterTests
         imageList.Images.Add(image2);
 
         using TreeView treeView = new TreeView { ImageList = imageList };
-        var propertyDescriptor = TypeDescriptor.GetProperties(treeView)["ImageList"];
-        var context = new TypeDescriptorContext(treeView, propertyDescriptor);
+        PropertyDescriptor? propertyDescriptor = TypeDescriptor.GetProperties(treeView)["ImageList"];
+        propertyDescriptor.Should().NotBeNull();
+        TypeDescriptorContext context = new(treeView, propertyDescriptor!);
 
-        var converter = new TreeViewImageIndexConverter();
+        TreeViewImageIndexConverter converter = new();
         var result = converter.GetStandardValues(context);
 
         result.Count.Should().Be(imageList.Images.Count + 2);
@@ -105,11 +108,11 @@ public class TreeViewImageIndexConverterTests
             _propertyDescriptor = propertyDescriptor;
         }
 
-        public IContainer Container => null;
+        public IContainer? Container => null;
         public object Instance => _instance;
         public PropertyDescriptor PropertyDescriptor => _propertyDescriptor;
         public bool OnComponentChanging() => true;
         public void OnComponentChanged() { }
-        public object GetService(Type serviceType) => null;
+        public object? GetService(Type serviceType) => null;
     }
 }


### PR DESCRIPTION
related https://github.com/dotnet/winforms/issues/10453

## Proposed changes

- Add unit tests for TreeNodeConverter to test its ConvertTo method
- Add unit tests for TreeViewImageIndexConverter to test its GetStandardValues method


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12908)