### PR TITLE
[release/8.0] Fix 12850 error provider exception in different dpi

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/DpiHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/DpiHelper.cs
@@ -354,6 +354,17 @@ internal static partial class DpiHelper
     }
 
     /// <summary>
+    ///  Get X, Y metrics at DPI, IF icon is not already that size, create and return a new one.
+    /// </summary>
+    internal static Icon ScaleSmallIconToDpi(Icon icon, int dpi)
+    {
+        int width = PInvoke.GetCurrentSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)dpi);
+        int height = PInvoke.GetCurrentSystemMetrics(SYSTEM_METRICS_INDEX.SM_CYSMICON, (uint)dpi);
+
+        return (icon.Width == width && icon.Height == height) ? icon : new(icon, width, height);
+    }
+
+    /// <summary>
     ///  Indicates whether the first (Parking)Window has been created. From that moment on,
     ///  we will not be able nor allowed to change the Process' DpiMode.
     /// </summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ErrorWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ErrorWindow.cs
@@ -484,7 +484,8 @@ public partial class ErrorProvider
             }
 
             double factor = ((double)currentDpi) / _parent._deviceDpi;
-            using Icon icon = _provider.Icon;
+            Icon icon = _provider.Icon;
+            _provider.CurrentDpi = currentDpi;
             _provider.Icon = new Icon(icon, (int)(icon.Width * factor), (int)(icon.Height * factor));
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.IconRegion.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.IconRegion.cs
@@ -15,9 +15,9 @@ public partial class ErrorProvider
         private Region? _region;
         private readonly Icon _icon;
 
-        public IconRegion(Icon icon)
+        public IconRegion(Icon icon, int currentDpi)
         {
-            _icon = new Icon(icon, DefaultIcon.Size);
+            _icon = DpiHelper.ScaleSmallIconToDpi(icon, currentDpi);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.IconRegion.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.IconRegion.cs
@@ -17,7 +17,7 @@ public partial class ErrorProvider
 
         public IconRegion(Icon icon)
         {
-            _icon = icon;
+            _icon = new Icon(icon, ScaleHelper.LogicalSmallSystemIconSize);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.IconRegion.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.IconRegion.cs
@@ -17,7 +17,7 @@ public partial class ErrorProvider
 
         public IconRegion(Icon icon)
         {
-            _icon = new Icon(icon, ScaleHelper.LogicalSmallSystemIconSize);
+            _icon = new Icon(icon, DefaultIcon.Size);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
@@ -25,7 +25,7 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
 {
     private readonly Dictionary<Control, ControlItem> _items = new();
     private readonly Dictionary<Control, ErrorWindow> _windows = new();
-    private Icon _icon;
+    private Icon? _icon;
     private IconRegion? _region;
     private int _itemIdCounter;
     private int _blinkRate;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
@@ -552,10 +552,13 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
                 if (t_defaultIcon is null)
                 {
                     // Error provider uses small Icon.
-                    int width = PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON);
-                    int height = PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CYSMICON);
+                    Size LogicalSmallSystemIconSize = OsVersion.IsWindows10_1607OrGreater()
+                        ? new(
+                            PInvoke.GetSystemMetricsForDpi(SYSTEM_METRICS_INDEX.SM_CXSMICON, 96),
+                            PInvoke.GetSystemMetricsForDpi(SYSTEM_METRICS_INDEX.SM_CXSMICON, 96))
+                        : new(16, 16);
                     using Icon defaultIcon = new(typeof(ErrorProvider), "Error");
-                    t_defaultIcon = new Icon(defaultIcon, width, height);
+                    t_defaultIcon = new Icon(defaultIcon, LogicalSmallSystemIconSize);
                 }
             }
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ErrorProviderTest.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ErrorProviderTest.Designer.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Drawing;
+
 namespace WinformsControlsTest;
 
 partial class ErrorProviderTest
@@ -32,16 +34,47 @@ partial class ErrorProviderTest
     private void InitializeComponent()
     {
         this.components = new System.ComponentModel.Container();
+
         this.textBox1 = new System.Windows.Forms.TextBox();
-        this.errorProvider1 = new System.Windows.Forms.ErrorProvider(this.components);
-        this.submitButton = new System.Windows.Forms.Button();
+        this.label1_2 = new System.Windows.Forms.Label();
         this.label1 = new System.Windows.Forms.Label();
+        this.errorProvider1 = new System.Windows.Forms.ErrorProvider(this.components);
+
+        this.textBox2 = new System.Windows.Forms.TextBox();
+        this.label2_1 = new System.Windows.Forms.Label();
+        this.label2 = new System.Windows.Forms.Label();
+        this.errorProvider2 = new System.Windows.Forms.ErrorProvider(this.components);
+        this.errorProvider2.Icon = SystemIcons.Shield;
+
+        this.submitButton = new System.Windows.Forms.Button();
+
         ((System.ComponentModel.ISupportInitialize)(this.errorProvider1)).BeginInit();
+        ((System.ComponentModel.ISupportInitialize)(this.errorProvider2)).BeginInit();
+
         this.SuspendLayout();
+        //
+        // label1
+        //
+        this.label1.AutoSize = true;
+        this.label1.Font = new System.Drawing.Font("Calibri", 12F, FontStyle.Bold);
+        this.label1.Location = new System.Drawing.Point(19, 26);
+        this.label1.Name = "label1";
+        this.label1.Size = new System.Drawing.Size(155, 15);
+        this.label1.TabIndex = 2;
+        this.label1.Text = "ErrorProvider with standard icon";
+        // 
+        // label1_2
+        // 
+        this.label1_2.AutoSize = true;
+        this.label1_2.Location = new System.Drawing.Point(19, 41);
+        this.label1_2.Name = "label1_2";
+        this.label1_2.Size = new System.Drawing.Size(155, 15);
+        this.label1_2.TabIndex = 2;
+        this.label1_2.Text = "Type from 5 to 10 characters";
         // 
         // textBox1
         // 
-        this.textBox1.Location = new System.Drawing.Point(35, 60);
+        this.textBox1.Location = new System.Drawing.Point(19, 60);
         this.textBox1.Name = "textBox1";
         this.textBox1.Size = new System.Drawing.Size(120, 23);
         this.textBox1.TabIndex = 0;
@@ -49,46 +82,76 @@ partial class ErrorProviderTest
         // errorProvider1
         // 
         this.errorProvider1.ContainerControl = this;
+        //
+        // label2
+        //
+        this.label2.AutoSize = true;
+        this.label2.Font = new System.Drawing.Font("Calibri", 12F, FontStyle.Bold);
+        this.label2.Location = new System.Drawing.Point(19, 100);
+        this.label2.Name = "label2";
+        this.label2.Size = new System.Drawing.Size(155, 15);
+        this.label2.TabIndex = 2;
+        this.label2.Text = "ErrorProvider with multi-resolution icon";
+        // 
+        // label2_1
+        // 
+        this.label2_1.AutoSize = true;
+        this.label2_1.Location = new System.Drawing.Point(19, 115);
+        this.label2_1.Name = "label2_1";
+        this.label2_1.Size = new System.Drawing.Size(155, 23);
+        this.label2_1.TabIndex = 2;
+        this.label2_1.Text = "Type from 5 to 20 characters";
+        // 
+        // textBox2
+        // 
+        this.textBox2.Location = new System.Drawing.Point(19, 135);
+        this.textBox2.Name = "textBox2";
+        this.textBox2.Size = new System.Drawing.Size(120, 23);
+        this.textBox2.TabIndex = 0;
+        // 
+        // errorProvider2
+        // 
+        this.errorProvider2.ContainerControl = this;
         // 
         // submitButton
         // 
-        this.submitButton.Location = new System.Drawing.Point(35, 109);
+        this.submitButton.Location = new System.Drawing.Point(19, 180);
         this.submitButton.Name = "submitButton";
         this.submitButton.Size = new System.Drawing.Size(120, 27);
         this.submitButton.TabIndex = 1;
-        this.submitButton.Text = "Submit";
+        this.submitButton.Text = "Validate";
         this.submitButton.UseVisualStyleBackColor = true;
         this.submitButton.Click += new System.EventHandler(this.submitButton_Click);
-        // 
-        // label1
-        // 
-        this.label1.AutoSize = true;
-        this.label1.Location = new System.Drawing.Point(19, 26);
-        this.label1.Name = "label1";
-        this.label1.Size = new System.Drawing.Size(155, 15);
-        this.label1.TabIndex = 2;
-        this.label1.Text = "Type from 5 to 10 characters";
         // 
         // Form1
         // 
         this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
         this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-        this.ClientSize = new System.Drawing.Size(194, 165);
+        this.ClientSize = new System.Drawing.Size(290, 230);
         this.Controls.Add(this.label1);
-        this.Controls.Add(this.submitButton);
+        this.Controls.Add(this.label1_2);
         this.Controls.Add(this.textBox1);
+        this.Controls.Add(this.label2);
+        this.Controls.Add(this.label2_1);
+        this.Controls.Add(this.textBox2);
+        this.Controls.Add(this.submitButton);
         this.Name = "Form1";
         this.Text = "Form1";
         ((System.ComponentModel.ISupportInitialize)(this.errorProvider1)).EndInit();
+        ((System.ComponentModel.ISupportInitialize)(this.errorProvider2)).EndInit();
         this.ResumeLayout(false);
         this.PerformLayout();
-
     }
 
     #endregion
 
     private System.Windows.Forms.TextBox textBox1;
+    private System.Windows.Forms.TextBox textBox2;
     private System.Windows.Forms.ErrorProvider errorProvider1;
+    private System.Windows.Forms.ErrorProvider errorProvider2;
     private System.Windows.Forms.Button submitButton;
+    private System.Windows.Forms.Label label1_2;
     private System.Windows.Forms.Label label1;
+    private System.Windows.Forms.Label label2_1;
+    private System.Windows.Forms.Label label2;
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ErrorProviderTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ErrorProviderTest.cs
@@ -14,7 +14,7 @@ public partial class ErrorProviderTest : Form
     {
         if (textBox1.TextLength < 5 || textBox1.TextLength > 10)
         {
-            errorProvider1.SetError(textBox1, "The length of the testbox is invalid!");
+            errorProvider1.SetError(textBox1, "The length of the textbox is invalid!");
         }
         else
         {
@@ -24,7 +24,7 @@ public partial class ErrorProviderTest : Form
 
         if (textBox2.TextLength < 5 || textBox2.TextLength > 20)
         {
-            errorProvider2.SetError(textBox2, "The length of the testbox is invalid!");
+            errorProvider2.SetError(textBox2, "The length of the textbox is invalid!");
         }
         else
         {

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ErrorProviderTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ErrorProviderTest.cs
@@ -21,5 +21,15 @@ public partial class ErrorProviderTest : Form
             errorProvider1.Clear();
             MessageBox.Show("All right!", "OK", MessageBoxButtons.OK, MessageBoxIcon.Information);
         }
+
+        if (textBox2.TextLength < 5 || textBox2.TextLength > 20)
+        {
+            errorProvider2.SetError(textBox2, "The length of the testbox is invalid!");
+        }
+        else
+        {
+            errorProvider2.Clear();
+            MessageBox.Show("All right!", "OK", MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Back port pr #10850 and pr #12947 to release8.0
Fixes #12850 and #12939

## Bug Description

The PR #8486 removed `new Icon(icon, 16 ,16)` from `IconRegion` constructor, that causes the released icon object to be directly referenced, so there is an exception `Cannot access a disposed object. Object name: 'Icon' `.

Backport #10850 fixes the above problem, but the PR always scaled `IconRegion` to 100% DPI, so it causes issue #12939: _The icon of errorProvider is not scaled well on HDPI screen_, so backport #12947 to scale the ErrorProvider's `IconRegion` according to the current device DPI.

## Customer Impact

- ErrorProvider exception when shown a second time after being dragged on another monitor with different DPI. This regression was reported by the customer.

## Regression? 

- Yes, it's fine in dotnet 7. This is due to #8486

## Risk

- Low - the fix only change ErrorProvider icon's display size when it run in HDPI screen.

## Testing

- Manual testing with the user-provided project.
- Automation regression test

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12915)