### PR TITLE
Disable test "RadioButtonRenderer_DrawRadioButton_OverloadWithHandle" in X86

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RadioButtonRendererTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RadioButtonRendererTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
+using System.Runtime.InteropServices;
 using System.Windows.Forms.Metafiles;
 using System.Windows.Forms.VisualStyles;
 
@@ -99,10 +100,18 @@ public class RadioButtonRendererTests : AbstractButtonBaseTests
         RadioButtonRenderer.DrawRadioButton(graphics, point, bounds, control.Text, SystemFonts.DefaultFont, textFormat, false, rBState);
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/12935")]
     [WinFormsTheory]
     [BoolData]
     public void RadioButtonRenderer_DrawRadioButton_OverloadWithHandle(bool focus)
     {
+        // Skip verification of focus = true in X86
+        // due to the active issue https://github.com/dotnet/winforms/issues/12935
+        if (RuntimeInformation.ProcessArchitecture == Architecture.X86 && focus)
+        {
+            return;
+        }
+
         using Form form = new Form();
         using RadioButton control = (RadioButton)CreateButton();
         form.Controls.Add(control);


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related #12935

## Proposed changes
- Add judgment to skip test `RadioButtonRenderer_DrawRadioButton_OverloadWithHandle` in x86
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12936)