### PR TITLE
Fix for Double clicking on a ToolStripButton to open a dialog causes stack overflow

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
@@ -2286,32 +2286,34 @@ public abstract partial class ToolStripItem :
 
     internal void FireEventInteractive(EventArgs e, ToolStripItemEventType met)
     {
-        if (Enabled)
+        if (!Enabled)
         {
-            switch (met)
-            {
-                case ToolStripItemEventType.MouseMove:
-                    HandleMouseMove((MouseEventArgs)e);
-                    break;
-                case ToolStripItemEventType.MouseHover:
-                    HandleMouseHover(e);
-                    break;
-                case ToolStripItemEventType.MouseUp:
-                    HandleMouseUp((MouseEventArgs)e);
-                    break;
-                case ToolStripItemEventType.MouseDown:
-                    HandleMouseDown((MouseEventArgs)e);
-                    break;
-                case ToolStripItemEventType.Click:
-                    HandleClick(e);
-                    break;
-                case ToolStripItemEventType.DoubleClick:
-                    HandleDoubleClick(e);
-                    break;
-                default:
-                    Debug.Assert(false, "Invalid event type.");
-                    break;
-            }
+            return;
+        }
+
+        switch (met)
+        {
+            case ToolStripItemEventType.MouseMove:
+                HandleMouseMove((MouseEventArgs)e);
+                break;
+            case ToolStripItemEventType.MouseHover:
+                HandleMouseHover(e);
+                break;
+            case ToolStripItemEventType.MouseUp:
+                HandleMouseUp((MouseEventArgs)e);
+                break;
+            case ToolStripItemEventType.MouseDown:
+                HandleMouseDown((MouseEventArgs)e);
+                break;
+            case ToolStripItemEventType.Click:
+                HandleClick(e);
+                break;
+            case ToolStripItemEventType.DoubleClick:
+                HandleDoubleClick(e);
+                break;
+            default:
+                Debug.Assert(false, "Invalid event type.");
+                break;
         }
     }
 
@@ -2554,14 +2556,14 @@ public abstract partial class ToolStripItem :
 
     private void HandleMouseUp(MouseEventArgs e)
     {
-        bool fireMouseUp = (ParentInternal?.LastMouseDownedItem == this);
+        bool fireMouseUp = ParentInternal?.LastMouseDownedItem == this;
 
         if (!fireMouseUp && !MouseDownAndUpMustBeInSameItem)
         {
-            // in the case of menus, you can mouse down on one item and mouse up
-            // on another. We do need to be careful
-            // that the mouse has actually moved from when a dropdown has been opened -
-            // otherwise we may accidentally click what's underneath the mouse at the time
+            // In the case of menus, you can mouse down on one item and mouse up
+            // on another. We do need to be careful that the mouse has actually
+            // moved from when a dropdown has been opened - otherwise we may
+            // accidentally click what's underneath the mouse at the time
             // the dropdown is opened.
             fireMouseUp = ParentInternal is not null && ParentInternal.ShouldSelectItem();
         }
@@ -2579,7 +2581,7 @@ public abstract partial class ToolStripItem :
                     long deltaTicks = newTime - _lastClickTime;
                     _lastClickTime = newTime;
                     // use >= for cases where the delta is so fast DateTime cannot pick up the delta.
-                    Debug.Assert(deltaTicks >= 0, "why are deltaticks less than zero? thats some mighty fast clicking");
+                    Debug.Assert(deltaTicks >= 0, "why are delta ticks less than zero? that's some mighty fast clicking");
                     // if we've seen a mouse up less than the double click time ago, we should fire.
                     if (deltaTicks >= 0 && deltaTicks < DoubleClickTicks)
                     {

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/OpenFileDialogTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/OpenFileDialogTests.cs
@@ -14,7 +14,7 @@ public class OpenFileDialogTests : ControlTestBase
 
     // Regression test for https://github.com/dotnet/winforms/issues/8108
     [WinFormsFact]
-    public void OpenFileDialogTests_OpenWithNonExistingInitDirectory_Success()
+    public void OpenWithNonExistingInitDirectory_Success()
     {
         using DialogHostForm dialogOwnerForm = new();
         using OpenFileDialog dialog = new();
@@ -23,7 +23,7 @@ public class OpenFileDialogTests : ControlTestBase
     }
 
     [WinFormsFact]
-    public void OpenFileDialogTests_OpenWithExistingInitDirectory_Success()
+    public void OpenWithExistingInitDirectory_Success()
     {
         using DialogHostForm dialogOwnerForm = new();
         using OpenFileDialog dialog = new();
@@ -33,7 +33,7 @@ public class OpenFileDialogTests : ControlTestBase
 
     // Regression test for https://github.com/dotnet/winforms/issues/8414
     [WinFormsFact]
-    public void OpenFileDialogTests_ResultWithMultiselect()
+    public void ShowDialog_ResultWithMultiselect()
     {
         using var tempFile = TempFile.Create(0);
         using AcceptDialogForm dialogOwnerForm = new();


### PR DESCRIPTION
Fixes https://github.com/dotnet/winforms/issues/12847

`ShowDialog` for `OpenFileDialog` waits while it populates the folders view, if at this moment we receive another `ShowDialog` call for the same dialog, we would attempt to subclass the same OpenFileDialog window again and start calling our own WinProc recursevely.

Fix: handle the repeated call to ShowDialog gracefully by returning "Cancel"
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12942)