### PR TITLE
Chart control requires the SQLClient at runtime

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/WinformsControlsTest.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/WinformsControlsTest.csproj
@@ -94,6 +94,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Data.SqlClient" />
     <PackageReference Include="System.Management" />
     <PackageReference Include="System.Windows.Forms.DataVisualization" />
   </ItemGroup>


### PR DESCRIPTION
Chart control in the winforms interactive test requires the SQL Client dependency at runtime. We are getting 4.9.0 version, which is the latest by default.

Fixes https://github.com/dotnet/winforms/issues/12940
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12946)