### PR TITLE
Scale errorProvider Icon to DeviceDPI

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
@@ -422,6 +422,16 @@ internal static partial class ScaleHelper
     }
 
     /// <summary>
+    ///  Get X, Y metrics at DPI, IF icon is not already that size, create and return a new one.
+    /// </summary>
+    internal static Icon ScaleSmallIconToDpi(Icon icon, int dpi)
+    {
+        return new(icon,
+            PInvoke.GetCurrentSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)dpi),
+            PInvoke.GetCurrentSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)dpi));
+    }
+
+    /// <summary>
     ///  Sets the requested DPI mode. If the current OS does not support the requested mode,
     /// </summary>
     /// <returns><see langword="true"/> if the mode was successfully set.</returns>

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
@@ -426,9 +426,10 @@ internal static partial class ScaleHelper
     /// </summary>
     internal static Icon ScaleSmallIconToDpi(Icon icon, int dpi)
     {
-        return new(icon,
-            PInvoke.GetCurrentSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)dpi),
-            PInvoke.GetCurrentSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)dpi));
+        int width = PInvoke.GetCurrentSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)dpi);
+        int height = PInvoke.GetCurrentSystemMetrics(SYSTEM_METRICS_INDEX.SM_CYSMICON, (uint)dpi);
+
+        return (icon.Width == width && icon.Height == height) ? icon : new(icon, width, height);
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.ErrorWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.ErrorWindow.cs
@@ -455,7 +455,7 @@ public partial class ErrorProvider
             }
 
             double factor = ((double)currentDpi) / _parent._deviceDpi;
-            using Icon icon = _provider.Icon;
+            Icon icon = _provider.Icon;
             _provider.CurrentDpi = currentDpi;
             _provider.Icon = new Icon(icon, (int)(icon.Width * factor), (int)(icon.Height * factor));
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.ErrorWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.ErrorWindow.cs
@@ -457,6 +457,8 @@ public partial class ErrorProvider
             double factor = ((double)currentDpi) / _parent._deviceDpi;
             using Icon icon = _provider.Icon;
             _provider.Icon = new Icon(icon, (int)(icon.Width * factor), (int)(icon.Height * factor));
+            _provider.DisposeRegion();
+            _provider._currentDpi = currentDpi;
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.ErrorWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.ErrorWindow.cs
@@ -456,9 +456,8 @@ public partial class ErrorProvider
 
             double factor = ((double)currentDpi) / _parent._deviceDpi;
             using Icon icon = _provider.Icon;
-            _provider.Icon = new Icon(icon, (int)(icon.Width * factor), (int)(icon.Height * factor));
-            _provider.DisposeRegion();
             _provider._currentDpi = currentDpi;
+            _provider.Icon = new Icon(icon, (int)(icon.Width * factor), (int)(icon.Height * factor));
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.ErrorWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.ErrorWindow.cs
@@ -456,7 +456,7 @@ public partial class ErrorProvider
 
             double factor = ((double)currentDpi) / _parent._deviceDpi;
             using Icon icon = _provider.Icon;
-            _provider._currentDpi = currentDpi;
+            _provider.CurrentDpi = currentDpi;
             _provider.Icon = new Icon(icon, (int)(icon.Width * factor), (int)(icon.Height * factor));
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.IconRegion.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.IconRegion.cs
@@ -17,7 +17,7 @@ public partial class ErrorProvider
 
         public IconRegion(Icon icon)
         {
-            _icon = new Icon(icon, ScaleHelper.LogicalSmallSystemIconSize);
+            _icon = icon;
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.IconRegion.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.IconRegion.cs
@@ -15,11 +15,9 @@ public partial class ErrorProvider
         private Region? _region;
         private readonly Icon _icon;
 
-        public IconRegion(int currentDpi, Icon icon)
+        public IconRegion(Icon icon, int currentDpi)
         {
-            _icon = new(icon,
-                PInvoke.GetCurrentSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)currentDpi),
-                PInvoke.GetCurrentSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)currentDpi));
+            _icon = ScaleHelper.ScaleSmallIconToDpi(icon, currentDpi);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.IconRegion.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.IconRegion.cs
@@ -15,9 +15,11 @@ public partial class ErrorProvider
         private Region? _region;
         private readonly Icon _icon;
 
-        public IconRegion(Icon icon)
+        public IconRegion(int currentDpi, Icon icon)
         {
-            _icon = icon;
+            _icon = new(icon,
+                PInvoke.GetCurrentSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)currentDpi),
+                PInvoke.GetCurrentSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)currentDpi));
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.cs
@@ -549,10 +549,7 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
                 {
                     // Error provider uses small Icon.
                     using Icon defaultIcon = new(typeof(ErrorProvider), "Error");
-                    int currentDpi = (int)PInvoke.GetDpiForSystem();
-                    t_defaultIcon = new(defaultIcon,
-                        PInvoke.GetCurrentSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)currentDpi),
-                        PInvoke.GetCurrentSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)currentDpi));
+                    t_defaultIcon = ScaleHelper.ScaleSmallIconToDpi(defaultIcon, (int)PInvoke.GetDpiForSystem());
                 }
             }
 
@@ -589,7 +586,7 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
     /// <summary>
     ///  Create the icon region on demand.
     /// </summary>
-    internal IconRegion Region => _region ??= new IconRegion(_currentDpi, Icon);
+    internal IconRegion Region => _region ??= new IconRegion(Icon, _currentDpi);
 
     /// <summary>
     ///  Begin bulk member initialization - deferring binding to data source until EndInit is reached

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.cs
@@ -309,7 +309,7 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
         {
             if (_parentControl is not null && _parentControl.BindingContext is not null && value is not null && !string.IsNullOrEmpty(_dataMember))
             {
-                // Let's check if the datamember exists in the new data source
+                // Let's check if the data member exists in the new data source
                 try
                 {
                     _errorManager = _parentControl.BindingContext[value, _dataMember];
@@ -589,8 +589,20 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
     {
         get
         {
-            Icon scaledIcon = new(Icon, ScaleHelper.ScaleToDpi(DefaultIcon.Size, _parentControl!.DeviceDpi));
-            _region ??= new IconRegion(scaledIcon);
+            // Error provider uses small Icon.
+            int currentDpi = (int)PInvoke.GetDpiForSystem();
+            if (_parentControl is not null)
+            {
+                currentDpi = _parentControl.DeviceDpi;
+            }
+
+            _region = new IconRegion(new(Icon.OrThrowIfNull(),
+                OsVersion.IsWindows10_1607OrGreater()
+                    ? new(
+                        PInvoke.GetSystemMetricsForDpi(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)currentDpi),
+                        PInvoke.GetSystemMetricsForDpi(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)currentDpi))
+                    : new(16, 16)));
+
             return _region;
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.cs
@@ -547,10 +547,8 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
                 if (t_defaultIcon is null)
                 {
                     // Error provider uses small Icon.
-                    int width = PInvokeCore.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON);
-                    int height = PInvokeCore.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CYSMICON);
                     using Icon defaultIcon = new(typeof(ErrorProvider), "Error");
-                    t_defaultIcon = new Icon(defaultIcon, width, height);
+                    t_defaultIcon = new Icon(defaultIcon, ScaleHelper.LogicalSmallSystemIconSize);
                 }
             }
 
@@ -587,7 +585,15 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
     /// <summary>
     ///  Create the icon region on demand.
     /// </summary>
-    internal IconRegion Region => _region ??= new IconRegion(Icon);
+    internal IconRegion Region
+    {
+        get
+        {
+            Icon scaledIcon = new(Icon, ScaleHelper.ScaleToDpi(DefaultIcon.Size, _parentControl!.DeviceDpi));
+            _region ??= new IconRegion(scaledIcon);
+            return _region;
+        }
+    }
 
     /// <summary>
     ///  Begin bulk member initialization - deferring binding to data source until EndInit is reached

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.cs
@@ -549,7 +549,6 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
                 {
                     // Error provider uses small Icon.
                     using Icon defaultIcon = new(typeof(ErrorProvider), "Error");
-                    // t_defaultIcon = new(defaultIcon, ScaleHelper.SystemIconSize);
                     int currentDpi = (int)PInvoke.GetDpiForSystem();
                     t_defaultIcon = new(defaultIcon,
                         OsVersion.IsWindows10_1607OrGreater()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.cs
@@ -589,19 +589,19 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
     {
         get
         {
-            // Error provider uses small Icon.
-            int currentDpi = (int)PInvoke.GetDpiForSystem();
+            Icon icon = new Icon(Icon.OrThrowIfNull(), Icon.Size);
             if (_parentControl is not null)
             {
-                currentDpi = _parentControl.DeviceDpi;
+                int currentDpi = _parentControl.DeviceDpi;
+                icon = new(Icon.OrThrowIfNull(),
+                    OsVersion.IsWindows10_1607OrGreater()
+                        ? new(
+                            PInvoke.GetSystemMetricsForDpi(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)currentDpi),
+                            PInvoke.GetSystemMetricsForDpi(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)currentDpi))
+                        : new(16, 16));
             }
 
-            _region = new IconRegion(new(Icon.OrThrowIfNull(),
-                OsVersion.IsWindows10_1607OrGreater()
-                    ? new(
-                        PInvoke.GetSystemMetricsForDpi(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)currentDpi),
-                        PInvoke.GetSystemMetricsForDpi(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)currentDpi))
-                    : new(16, 16)));
+            _region = new IconRegion(icon);
 
             return _region;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.cs
@@ -547,7 +547,7 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
                 if (t_defaultIcon is null)
                 {
                     // Error provider uses small Icon.
-                    using Icon defaultIcon = new(typeof(ErrorProvider), "Error");
+                    Icon defaultIcon = new(typeof(ErrorProvider), "Error");
                     t_defaultIcon = ScaleHelper.ScaleSmallIconToDpi(defaultIcon, ScaleHelper.InitialSystemDpi);
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.cs
@@ -551,11 +551,8 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
                     using Icon defaultIcon = new(typeof(ErrorProvider), "Error");
                     int currentDpi = (int)PInvoke.GetDpiForSystem();
                     t_defaultIcon = new(defaultIcon,
-                        OsVersion.IsWindows10_1607OrGreater()
-                            ? new(
-                                PInvoke.GetSystemMetricsForDpi(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)currentDpi),
-                                PInvoke.GetSystemMetricsForDpi(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)currentDpi))
-                            : new(16, 16));
+                        PInvoke.GetCurrentSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)currentDpi),
+                        PInvoke.GetCurrentSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)currentDpi));
                 }
             }
 
@@ -602,14 +599,11 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
         }
     }
 
-    private Icon ScaleIcon(int dpi)
+    private Icon ScaleIcon(int currentDpi)
     {
         return new(Icon,
-            OsVersion.IsWindows10_1607OrGreater()
-                ? new Size(
-                    PInvoke.GetSystemMetricsForDpi(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)dpi),
-                    PInvoke.GetSystemMetricsForDpi(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)dpi))
-                : new Size(16, 16));
+            PInvoke.GetCurrentSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)currentDpi),
+            PInvoke.GetCurrentSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)currentDpi));
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.cs
@@ -24,7 +24,7 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
 {
     private readonly Dictionary<Control, ControlItem> _items = [];
     private readonly Dictionary<Control, ErrorWindow> _windows = [];
-    private Icon _icon = DefaultIcon;
+    private Icon? _icon;
     private IconRegion? _region;
     private int _itemIdCounter;
     private int _blinkRate;
@@ -548,7 +548,7 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
                 {
                     // Error provider uses small Icon.
                     using Icon defaultIcon = new(typeof(ErrorProvider), "Error");
-                    t_defaultIcon = ScaleHelper.ScaleSmallIconToDpi(defaultIcon, (int)PInvoke.GetDpiForSystem());
+                    t_defaultIcon = ScaleHelper.ScaleSmallIconToDpi(defaultIcon, ScaleHelper.InitialSystemDpi);
                 }
             }
 
@@ -566,10 +566,7 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
     [SRDescription(nameof(SR.ErrorProviderIconDescr))]
     public Icon Icon
     {
-        get
-        {
-            return _icon;
-        }
+        get => _icon ??= DefaultIcon;
         set
         {
             _icon = value.OrThrowIfNull();
@@ -589,20 +586,8 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
     /// </summary>
     private int CurrentDpi
     {
-        get
-        {
-            if (_currentDpi != 0)
-            {
-                return _currentDpi;
-            }
-
-            _currentDpi = _parentControl?.DeviceDpi ?? (int)PInvoke.GetDpiForSystem();
-            return _currentDpi;
-        }
-        set
-        {
-            _currentDpi = value;
-        }
+        get => _currentDpi != 0 ? _currentDpi : _parentControl?.DeviceDpi ?? ScaleHelper.InitialSystemDpi;
+        set => _currentDpi = value;
     }
 
     /// <summary>
@@ -783,7 +768,7 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
     [SRDescription(nameof(SR.ErrorProviderIconPaddingDescr))]
     public int GetIconPadding(Control control) => EnsureControlItem(control).IconPadding;
 
-    private void ResetIcon() => Icon = DefaultIcon;
+    private void ResetIcon() => _icon = null;
 
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     protected virtual void OnRightToLeftChanged(EventArgs e)
@@ -836,5 +821,5 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
         EnsureControlItem(control).IconPadding = padding;
     }
 
-    private bool ShouldSerializeIcon() => Icon != DefaultIcon;
+    private bool ShouldSerializeIcon() => _icon is not null && _icon != DefaultIcon;
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.cs
@@ -30,7 +30,7 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
     private int _blinkRate;
     private ErrorBlinkStyle _blinkStyle;
     private ErrorProviderStates _state = ErrorProviderStates.ShowIcon;
-    private int _currentDpi = (int)PInvoke.GetDpiForSystem();
+    private int _currentDpi;
     private bool ShowIcon
     {
         get => _state.HasFlag(ErrorProviderStates.ShowIcon);
@@ -82,7 +82,6 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
         : this()
     {
         ArgumentNullException.ThrowIfNull(container);
-
         container.Add(this);
     }
 
@@ -584,9 +583,32 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
     }
 
     /// <summary>
+    ///  Gets or sets the DPI at which the current error is displayed.
+    ///  If currentDpi is not set, it defaults to _parentControl.DeviceDpi
+    ///  or the system DPI.
+    /// </summary>
+    private int CurrentDpi
+    {
+        get
+        {
+            if (_currentDpi != 0)
+            {
+                return _currentDpi;
+            }
+
+            _currentDpi = _parentControl?.DeviceDpi ?? (int)PInvoke.GetDpiForSystem();
+            return _currentDpi;
+        }
+        set
+        {
+            _currentDpi = value;
+        }
+    }
+
+    /// <summary>
     ///  Create the icon region on demand.
     /// </summary>
-    internal IconRegion Region => _region ??= new IconRegion(Icon, _currentDpi);
+    internal IconRegion Region => _region ??= new IconRegion(Icon, CurrentDpi);
 
     /// <summary>
     ///  Begin bulk member initialization - deferring binding to data source until EndInit is reached

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.cs
@@ -24,13 +24,13 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
 {
     private readonly Dictionary<Control, ControlItem> _items = [];
     private readonly Dictionary<Control, ErrorWindow> _windows = [];
-    private bool _initialLoad = true;
     private Icon _icon = DefaultIcon;
     private IconRegion? _region;
     private int _itemIdCounter;
     private int _blinkRate;
     private ErrorBlinkStyle _blinkStyle;
     private ErrorProviderStates _state = ErrorProviderStates.ShowIcon;
+    private int _currentDpi = (int)PInvoke.GetDpiForSystem();
     private bool ShowIcon
     {
         get => _state.HasFlag(ErrorProviderStates.ShowIcon);
@@ -589,22 +589,7 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
     /// <summary>
     ///  Create the icon region on demand.
     /// </summary>
-    internal IconRegion Region
-    {
-        get
-        {
-            int currentDpi = _parentControl?.DeviceDpi ?? (int)PInvoke.GetDpiForSystem();
-            Icon icon = _initialLoad || _parentControl is not null ? ScaleIcon(currentDpi) : new Icon(Icon.OrThrowIfNull(), Icon.Size);
-            return _region = new IconRegion(icon);
-        }
-    }
-
-    private Icon ScaleIcon(int currentDpi)
-    {
-        return new(Icon,
-            PInvoke.GetCurrentSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)currentDpi),
-            PInvoke.GetCurrentSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)currentDpi));
-    }
+    internal IconRegion Region => _region ??= new IconRegion(_currentDpi, Icon);
 
     /// <summary>
     ///  Begin bulk member initialization - deferring binding to data source until EndInit is reached
@@ -715,7 +700,6 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
     /// </summary>
     private void DisposeRegion()
     {
-        _initialLoad = false;
         if (_region is not null)
         {
             _region.Dispose();


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12939

## Proposed changes

- Scale errorProvider Icon to DeviceDPI

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The icon of errorProvider can be scaled well on HDPI screen

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
The icon of errorProvider is not scaled well on HDPI screen with SystemAware and PerMoniterV2 modes

![BeforeChange](https://github.com/user-attachments/assets/bf20fcc8-bc09-44f3-b9c4-9fb1beb4751c)

### After
The icon of errorProvider can be scaled well on HDPI screen

![AfterChange](https://github.com/user-attachments/assets/c757eb70-9bee-4114-a2a5-55dc7a34fb2b)


## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-preview.2.25111.15


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12947)