### PR TITLE
Refine type binding for deserialization

### DIFF
--- a/src/System.Private.Windows.Core/src/System/Private/Windows/JsonData.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/JsonData.cs
@@ -151,4 +151,7 @@ internal interface IJsonData
     /// </summary>
     [RequiresUnreferencedCode("Calls System.Text.Json.JsonSerializer.Deserialize<TValue>(ReadOnlySpan<Byte>, JsonSerializerOptions)")]
     object Deserialize();
+
+    [RequiresUnreferencedCode("Calls System.Text.Json.JsonSerializer.SerializeToUtf8Bytes<TValue>(TValue, JsonSerializerOptions)")]
+    internal static IJsonData Create<T>(T data) => new JsonData<T>() { JsonBytes = JsonSerializer.SerializeToUtf8Bytes(data) };
 }

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Nrbf/INrbfSerializer.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Nrbf/INrbfSerializer.cs
@@ -31,7 +31,7 @@ internal interface INrbfSerializer
     ///  <para>
     ///   This should only return <see langword="true"/> for types that are expected to be safe to deserialize. It is
     ///   used to indicate that we should consider the type "corrupted" and should not make a second attempt through
-    ///   the <see cref="BinaryFormatter"/>. It is also used as the "blessed" list of types that we'll auto-bind when
+    ///   the <see cref="BinaryFormatter"/>. It is also used as the allowed list of types that we'll auto-bind when
     ///   user type resolvers return <see langword="null"/>.
     ///  </para>
     ///  <para>

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/BinaryFormatUtilities.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/BinaryFormatUtilities.cs
@@ -76,6 +76,8 @@ internal static class BinaryFormatUtilities<TNrbfSerializer> where TNrbfSerializ
         ref readonly DataRequest request,
         [NotNullWhen(true)] out T? @object)
     {
+        Debug.Assert(request.TypedRequest || typeof(T) == typeof(object), "Untyped requests should always be asking for object");
+
         @object = default;
         object? value;
 
@@ -104,29 +106,37 @@ internal static class BinaryFormatUtilities<TNrbfSerializer> where TNrbfSerializ
         {
             // Allow falling through for unsupported Nrbf data (such as non-zero based arrays).
         }
+        finally
+        {
+            stream.Position = startPosition;
+        }
 
-        TypeBinder<TNrbfSerializer>? binder = null;
+        TypeBinder<TNrbfSerializer> binder = new(typeof(T), in request);
 
         if (record is not null)
         {
             // Try our implicit deserialization.
-            if (TNrbfSerializer.TryBindToType(record.TypeName, out Type? type)
-                && type.IsAssignableTo(typeof(T)))
+            if (TNrbfSerializer.TryBindToType(record.TypeName, out Type? type))
             {
+                if (request.TypedRequest
+                    // If we can't match the root exactly, then we fall back to the binder.
+                    && !(type == typeof(T) || binder.BindToType(record.TypeName).IsAssignableTo(typeof(T))))
+                {
+                    return false;
+                }
+
                 if (TNrbfSerializer.TryGetObject(record, out value))
                 {
                     @object = (T)value;
                     return true;
                 }
-                else if (TNrbfSerializer.IsFullySupportedType(typeof(T)))
+                else if (TNrbfSerializer.IsFullySupportedType(type))
                 {
                     // The serializer fully supports this type, but can't deserialize it.
                     // Don't let it fall through to the BinaryFormatter.
                     return false;
                 }
             }
-
-            binder = new(typeof(T), in request);
 
             if (type is null)
             {
@@ -139,11 +149,9 @@ internal static class BinaryFormatUtilities<TNrbfSerializer> where TNrbfSerializ
             }
 
             // JSON type info is nested, so this has to come after the JSON attempt.
-            if (request.TypedRequest)
+            if (request.TypedRequest && !typeof(T).Matches(record.TypeName, TypeNameComparison.AllButAssemblyVersion))
             {
-                if (!(typeof(T).Matches(record.TypeName, TypeNameComparison.AllButAssemblyVersion)
-                    || (binder.TryBindToType(record.TypeName, out Type? resolvedType)
-                        && resolvedType.IsAssignableTo(typeof(T)))))
+                if (!binder.BindToType(record.TypeName).IsAssignableTo(typeof(T)))
                 {
                     // Typed request where the root type is not what was requested.
                     // Untyped requests are allowed to deserialize any type.
@@ -181,9 +189,8 @@ internal static class BinaryFormatUtilities<TNrbfSerializer> where TNrbfSerializ
 
         // If we want to attempt our own general NRBF deserialization, we would do it here.
         // If we do, we should never fall back to the BinaryFormatter if the binder fails
-        // to bind the type.
+        // to bind a type.
 
-        stream.Position = startPosition;
         binder ??= new(typeof(T), in request);
 
 #pragma warning disable SYSLIB0011, SYSLIB0050 // Type or member is obsolete
@@ -202,6 +209,10 @@ internal static class BinaryFormatUtilities<TNrbfSerializer> where TNrbfSerializ
         {
             // Rethrow the inner exception to allow the exception to flow up through TryGetHGLOBALData.
             throw nse;
+        }
+        finally
+        {
+            stream.Position = startPosition;
         }
 #pragma warning restore CA2300
 #pragma warning restore CA2302

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/DataObjectCore.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/DataObjectCore.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.Json;
-
 namespace System.Private.Windows.Ole;
 
 internal static unsafe class DataObjectCore<TDataObject>
@@ -31,6 +29,6 @@ internal static unsafe class DataObjectCore<TDataObject>
             throw new ArgumentException(SR.ClipboardOrDragDrop_CannotJsonSerializeDataObject, nameof(data));
         }
 
-        return new JsonData<T>() { JsonBytes = JsonSerializer.SerializeToUtf8Bytes(data) };
+        return IJsonData.Create(data);
     }
 }

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Private/Windows/Ole/BinaryFormatUtilitiesTests.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Private/Windows/Ole/BinaryFormatUtilitiesTests.cs
@@ -5,7 +5,7 @@ using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Reflection.Metadata;
-using Utilities = System.Private.Windows.Ole.BinaryFormatUtilities<System.Private.Windows.Nrbf.CoreNrbfSerializer>;
+using BinaryFormatUtilities = System.Private.Windows.Ole.BinaryFormatUtilities<System.Private.Windows.Nrbf.CoreNrbfSerializer>;
 
 namespace System.Private.Windows.Ole.Tests;
 
@@ -13,7 +13,7 @@ public sealed partial class BinaryFormatUtilitiesTests : BinaryFormatUtilitesTes
 {
     protected override void WriteObjectToStream(MemoryStream stream, object data, string format)
     {
-        Utilities.WriteObjectToStream(stream, data, format);
+        BinaryFormatUtilities.WriteObjectToStream(stream, data, format);
     }
 
     protected override bool TryReadObjectFromStream<T>(
@@ -24,7 +24,7 @@ public sealed partial class BinaryFormatUtilitiesTests : BinaryFormatUtilitesTes
         [NotNullWhen(true)] out T? @object) where T : default
     {
         DataRequest request = new(format) { Resolver = resolver, TypedRequest = !untypedRequest };
-        return Utilities.TryReadObjectFromStream(stream, in request, out @object);
+        return BinaryFormatUtilities.TryReadObjectFromStream(stream, in request, out @object);
     }
 
     // Primitive types as defined by the NRBF spec.
@@ -172,9 +172,9 @@ public sealed partial class BinaryFormatUtilitiesTests : BinaryFormatUtilitesTes
     [Theory]
     [MemberData(nameof(PrimitiveObjects_TheoryData))]
     [MemberData(nameof(KnownObjects_TheoryData))]
-    public void RoundTrip_RestrictedFormat_Simple(object value)
+    public void RoundTrip_PredefinedFormat_Simple(object value)
     {
-        RoundTripObject_RestrictedFormat(value, out object? result).Should().BeTrue();
+        RoundTripObject_PredefinedFormat(value, out object? result).Should().BeTrue();
         result.Should().Be(value);
     }
 
@@ -182,15 +182,15 @@ public sealed partial class BinaryFormatUtilitiesTests : BinaryFormatUtilitesTes
     [MemberData(nameof(NotSupportedException_TestData))]
     public void RoundTrip_NotSupportedException(NotSupportedException value)
     {
-        RoundTripObject(value, out NotSupportedException? result).Should().BeTrue();
+        RoundTripObject(value, out object? result).Should().BeTrue();
         result.Should().BeEquivalentTo(value);
     }
 
     [Theory]
     [MemberData(nameof(NotSupportedException_TestData))]
-    public void RoundTrip_RestrictedFormat_NotSupportedException(NotSupportedException value)
+    public void RoundTrip_PredefinedFormat_NotSupportedException(NotSupportedException value)
     {
-        RoundTripObject_RestrictedFormat(value, out NotSupportedException? result).Should().BeTrue();
+        RoundTripObject_PredefinedFormat(value, out object? result).Should().BeTrue();
         result.Should().BeEquivalentTo(value);
     }
 
@@ -198,15 +198,15 @@ public sealed partial class BinaryFormatUtilitiesTests : BinaryFormatUtilitesTes
     public void RoundTrip_NotSupportedException_DataLoss()
     {
         NotSupportedException value = new("Error message", new ArgumentException());
-        RoundTripObject(value, out NotSupportedException? result).Should().BeTrue();
+        RoundTripObject(value, out object? result).Should().BeTrue();
         result.Should().BeEquivalentTo(new NotSupportedException("Error message", innerException: null));
     }
 
     [Fact]
-    public void RoundTrip_RestrictedFormat_NotSupportedException_DataLoss()
+    public void RoundTrip_PredefinedFormat_NotSupportedException_DataLoss()
     {
         NotSupportedException value = new("Error message", new ArgumentException());
-        RoundTripObject_RestrictedFormat(value, out NotSupportedException? result).Should().BeTrue();
+        RoundTripObject_PredefinedFormat(value, out object? result).Should().BeTrue();
         result.Should().BeEquivalentTo(new NotSupportedException("Error message", innerException: null));
     }
 
@@ -214,39 +214,116 @@ public sealed partial class BinaryFormatUtilitiesTests : BinaryFormatUtilitesTes
     [MemberData(nameof(PrimitiveListObjects_TheoryData))]
     public void RoundTrip_PrimitiveList(IList value)
     {
-        RoundTripObject(value, out IList? result).Should().BeTrue();
+        RoundTripObject(value, out object? result).Should().BeTrue();
         result.Should().BeEquivalentTo(value);
     }
 
     [Theory]
     [MemberData(nameof(PrimitiveListObjects_TheoryData))]
-    public void RoundTrip_RestrictedFormat_PrimitiveList(IList value)
+    public void RoundTrip_PredefinedFormat_PrimitiveList(IList value)
     {
-        RoundTripObject_RestrictedFormat(value, out IList? result).Should().BeTrue();
+        RoundTripObject_PredefinedFormat(value, out object? result).Should().BeTrue();
         result.Should().BeEquivalentTo(value);
     }
 
     [Theory]
     [MemberData(nameof(PrimitiveArrayObjects_TheoryData))]
-    public void RoundTrip_PrimitiveArray(Array value)
+    public void TryReadObjectFromStream_Primitives_BaseResolver(Array value)
     {
-        RoundTripObject(value, out Array? result).Should().BeTrue();
+        using MemoryStream stream = new();
+        BinaryFormatUtilities.WriteObjectToStream(stream, value, "test");
+        stream.Position = 0;
+
+        DataRequest request = new()
+        {
+            Format = "test",
+            TypedRequest = true,
+            Resolver = (TypeName typeName) => Type.GetType(typeName.FullName)
+        };
+
+        BinaryFormatUtilities.TryReadObjectFromStream(stream, in request, out Array? result).Should().BeTrue();
         result.Should().BeEquivalentTo(value);
+    }
+
+    [Theory]
+    [EnumData<DataType>]
+    public void TryReadObjectFromStream_IntArray_TypedToBaseFails(DataType dataType)
+    {
+        int[] array = [];
+        using MemoryStream stream = CreateStream(dataType, array);
+
+        DataRequest request = new()
+        {
+            Format = "test",
+            TypedRequest = true
+        };
+
+        Action action = () => BinaryFormatUtilities.TryReadObjectFromStream(stream, in request, out Array? _);
+        action.Should().Throw<NotSupportedException>();
+
+        action = () => BinaryFormatUtilities.TryReadObjectFromStream(stream, in request, out IEnumerable? _);
+        action.Should().Throw<NotSupportedException>();
+
+        action = () => BinaryFormatUtilities.TryReadObjectFromStream(stream, in request, out object? result3);
+        action.Should().Throw<NotSupportedException>();
+    }
+
+    [Theory]
+    [EnumData<DataType>]
+    public void TryReadObjectFromStream_IntArray_UntypedSucceeds(DataType dataType)
+    {
+        int[] array = [];
+        using MemoryStream stream = CreateStream(dataType, array);
+
+        DataRequest request = new()
+        {
+            Format = "test",
+            TypedRequest = false
+        };
+
+        BinaryFormatUtilities.TryReadObjectFromStream(stream, in request, out object? result).Should().BeTrue();
+        result.Should().BeEquivalentTo(array);
+    }
+
+    [Theory]
+    [EnumData<DataType>]
+    public void TryReadObjectFromStream_IntArray_TypedToBaseSucceeds(DataType dataType)
+    {
+        int[] array = [];
+        using MemoryStream stream = CreateStream(dataType, array);
+
+        DataRequest request = new()
+        {
+            Format = "test",
+            TypedRequest = true,
+            Resolver = (TypeName typeName) => typeof(int[]).Matches(typeName, TypeNameComparison.TypeFullName)
+                ? typeof(int[])
+                : throw new NotSupportedException()
+        };
+
+        BinaryFormatUtilities.TryReadObjectFromStream(stream, in request, out Array? result).Should().BeTrue();
+        result.Should().BeEquivalentTo(array);
+
+        BinaryFormatUtilities.TryReadObjectFromStream(stream, in request, out IEnumerable? result2).Should().BeTrue();
+        result2.Should().BeEquivalentTo(array);
+
+        BinaryFormatUtilities.TryReadObjectFromStream(stream, in request, out object? result3).Should().BeTrue();
+        result3.Should().BeEquivalentTo(array);
     }
 
     [Theory]
     [MemberData(nameof(PrimitiveArrayListObjects_TheoryData))]
     public void RoundTrip_PrimitiveArrayList(ArrayList value)
     {
-        RoundTripObject(value, out ArrayList? result).Should().BeTrue();
+        RoundTripObject(value, out object? result).Should().BeTrue();
         result.Should().BeEquivalentTo(value);
     }
 
     [Theory]
     [MemberData(nameof(PrimitiveArrayListObjects_TheoryData))]
-    public void RoundTrip_RestrictedFormat_PrimitiveArrayList(ArrayList value)
+    public void RoundTrip_PredefinedFormat_PrimitiveArrayList(ArrayList value)
     {
-        RoundTripObject_RestrictedFormat(value, out ArrayList? result).Should().BeTrue();
+        RoundTripObject_PredefinedFormat(value, out object? result).Should().BeTrue();
         result.Should().BeEquivalentTo(value);
     }
 
@@ -254,15 +331,15 @@ public sealed partial class BinaryFormatUtilitiesTests : BinaryFormatUtilitesTes
     [MemberData(nameof(PrimitiveTypeHashtables_TheoryData))]
     public void RoundTrip_PrimitiveHashtable(Hashtable value)
     {
-        RoundTripObject(value, out Hashtable? result).Should().BeTrue();
+        RoundTripObject(value, out object? result).Should().BeTrue();
         result.Should().BeEquivalentTo(value);
     }
 
     [Theory]
     [MemberData(nameof(PrimitiveTypeHashtables_TheoryData))]
-    public void RoundTrip_RestrictedFormat_PrimitiveHashtable(Hashtable value)
+    public void RoundTrip_PredefinedFormat_PrimitiveHashtable(Hashtable value)
     {
-        RoundTripObject_RestrictedFormat(value, out Hashtable? result).Should().BeTrue();
+        RoundTripObject_PredefinedFormat(value, out object? result).Should().BeTrue();
         result.Should().BeEquivalentTo(value);
     }
 
@@ -271,7 +348,7 @@ public sealed partial class BinaryFormatUtilitiesTests : BinaryFormatUtilitesTes
     public void RoundTrip_Unsupported(IList value)
     {
         Action writer = () => WriteObjectToStream(value);
-        Action reader = () => TryReadObjectFromStream(out IList? _);
+        Action reader = () => TryReadObjectFromStream(out object? _);
 
         writer.Should().Throw<NotSupportedException>();
 
@@ -283,7 +360,7 @@ public sealed partial class BinaryFormatUtilitiesTests : BinaryFormatUtilitesTes
 
                 using BinaryFormatterInClipboardDragDropScope clipboardDragDropScope = new(enable: true);
                 WriteObjectToStream(value);
-                TryReadObjectFromStream(out IList? result).Should().BeTrue();
+                TryReadObjectFromStream(out object? result).Should().BeTrue();
                 result.Should().BeEquivalentTo(value);
             }
 
@@ -296,7 +373,7 @@ public sealed partial class BinaryFormatUtilitiesTests : BinaryFormatUtilitesTes
 
     [Theory]
     [MemberData(nameof(Lists_UnsupportedTestData))]
-    public void RoundTrip_RestrictedFormat_Unsupported(IList value)
+    public void RoundTrip_PredefinedFormat_Unsupported(IList value)
     {
         Action writer = () => WriteObjectToStream(value, restrictSerialization: true);
         writer.Should().Throw<NotSupportedException>();
@@ -318,7 +395,7 @@ public sealed partial class BinaryFormatUtilitiesTests : BinaryFormatUtilitesTes
 
         // Can read offset array with the BinaryFormatter.
         using ClipboardBinaryFormatterFullCompatScope scope = new();
-        RoundTripObject(value, out uint[,]? result).Should().BeTrue();
+        RoundTripObject(value, out object? result).Should().BeTrue();
         result.Should().NotBeNull();
         Assert.Equal(value, result);
     }
@@ -371,31 +448,209 @@ public sealed partial class BinaryFormatUtilitiesTests : BinaryFormatUtilitesTes
         }
     }
 
-    [Fact]
-    public void RoundTripOfType_intNullable()
+    [Theory]
+    [EnumData<DataType>]
+    public void TryReadObjectFromStream_TypeDoesNotMatch(DataType dataType)
     {
-        RoundTripOfType(101, NotSupportedResolver, out int? result).Should().BeTrue();
+        List<int> value = [1, 2, 3];
+        using MemoryStream stream = CreateStream(dataType, value);
+
+        // Typed with no resolver
+        DataRequest request = new()
+        {
+            Format = "test",
+            TypedRequest = true,
+        };
+
+        Action action = () => BinaryFormatUtilities.TryReadObjectFromStream(stream, ref request, out BaseClass? _);
+        action.Should().Throw<NotSupportedException>();
+    }
+
+    [Theory]
+    [EnumData<DataType>]
+    public void TryReadObjectFromStream_Class_DerivedAsBase(DataType dataType)
+    {
+        using BinaryFormatterScope scope = new(enable: dataType == DataType.BinaryFormat);
+        using BinaryFormatterInClipboardDragDropScope clipboardScope = new(enable: dataType == DataType.BinaryFormat);
+
+        using MemoryStream stream = CreateStream(dataType, new DerivedClass());
+
+        // Typed with no resolver
+        DataRequest request = new()
+        {
+            Format = "test",
+            TypedRequest = true,
+        };
+
+        Action action = () => BinaryFormatUtilities.TryReadObjectFromStream(stream, ref request, out BaseClass? result);
+        action.Should().Throw<NotSupportedException>();
+
+        // Typed with resolver
+        request = new()
+        {
+            Format = "test",
+            TypedRequest = true,
+            Resolver = (TypeName typeName) => typeName.FullName == typeof(DerivedClass).FullName
+                ? typeof(DerivedClass)
+                : throw new NotSupportedException()
+        };
+
+        BinaryFormatUtilities.TryReadObjectFromStream(stream, ref request, out BaseClass? result).Should().BeTrue();
+        result.Should().NotBeNull();
+    }
+
+    [Serializable]
+    public class BaseClass { }
+
+    [Serializable]
+    public class DerivedClass : BaseClass { }
+
+    [Theory]
+    [EnumData<DataType>]
+    public void TryReadObjectFromStream_Struct_AsNullable(DataType dataType)
+    {
+        using BinaryFormatterScope scope = new(enable: dataType == DataType.BinaryFormat);
+        using BinaryFormatterInClipboardDragDropScope clipboardScope = new(enable: dataType == DataType.BinaryFormat);
+
+        using MemoryStream stream = CreateStream(dataType, default(MyStruct));
+
+        // Typed with no resolver
+        DataRequest request = new()
+        {
+            Format = "test",
+            TypedRequest = true,
+        };
+
+        Action action = () => BinaryFormatUtilities.TryReadObjectFromStream(stream, ref request, out MyStruct? result);
+        action.Should().Throw<NotSupportedException>();
+
+        // Typed with resolver
+        request = new()
+        {
+            Format = "test",
+            TypedRequest = true,
+            Resolver = (TypeName typeName) => typeName.FullName == typeof(MyStruct).FullName
+                ? typeof(MyStruct?)
+                : throw new NotSupportedException()
+        };
+
+        BinaryFormatUtilities.TryReadObjectFromStream(stream, ref request, out MyStruct? result).Should().BeTrue();
+        result.Should().NotBeNull();
+    }
+
+    [Serializable]
+    public struct MyStruct { }
+
+    [Theory]
+    [EnumData<DataType>]
+    public void TryReadObjectFromStream_Int_AsNullableInt(DataType dataType)
+    {
+        using MemoryStream stream = CreateStream(dataType, 101);
+
+        // No resolver does not succeed
+        DataRequest request = new()
+        {
+            Format = "test",
+            TypedRequest = true,
+        };
+
+        Action action = () => BinaryFormatUtilities.TryReadObjectFromStream(stream, ref request, out int? result).Should().BeTrue();
+        action.Should().Throw<NotSupportedException>();
+
+        stream.Position.Should().Be(0);
+
+        // If we say no, we mean no.
+        request = new()
+        {
+            Format = "test",
+            TypedRequest = true,
+            Resolver = NotSupportedResolver
+        };
+
+        // Auto rebinding from int to int? adds signficant logic complexity with little real value.
+        action = () => BinaryFormatUtilities.TryReadObjectFromStream(stream, ref request, out int? result);
+        action.Should().Throw<NotSupportedException>();
+
+        stream.Position.Should().Be(0);
+
+        // Let's redirect.
+        request = new()
+        {
+            Format = "test",
+            TypedRequest = true,
+            Resolver = (TypeName typeName) => typeName.FullName == typeof(int).FullName
+                ? typeof(int?)
+                : throw new NotSupportedException()
+        };
+
+        BinaryFormatUtilities.TryReadObjectFromStream(stream, ref request, out int? result).Should().BeTrue();
         result.Should().Be(101);
+
+        request = new()
+        {
+            Format = "test",
+            TypedRequest = false
+        };
+    }
+
+    [Theory]
+    [EnumData<DataType>]
+    public void TryReadObjectFromStream_Int_AsFloat(DataType dataType)
+    {
+        using MemoryStream stream = CreateStream(dataType, 101);
+
+        // If we say no, we mean no.
+        DataRequest request = new()
+        {
+            Format = "test",
+            TypedRequest = true,
+            Resolver = NotSupportedResolver
+        };
+
+        Action action = () => BinaryFormatUtilities.TryReadObjectFromStream(stream, ref request, out float result);
+        action.Should().Throw<NotSupportedException>();
+
+        stream.Position.Should().Be(0);
+
+        // Let's redirect.
+        request = new()
+        {
+            Format = "test",
+            TypedRequest = true,
+            Resolver = (TypeName typeName) => typeName.FullName == typeof(int).FullName
+                ? typeof(float)
+                : throw new NotSupportedException()
+        };
+
+        action = () =>
+        {
+            BinaryFormatUtilities.TryReadObjectFromStream(stream, ref request, out float result).Should().BeTrue();
+            result.Should().Be(101);
+        };
+
+        if (dataType == DataType.BinaryFormat)
+        {
+            action.Should().Throw<InvalidCastException>();
+        }
+        else
+        {
+            // This is one of the side-effects of using JSON. The data is very basic. A 101 value can be converted to
+            // float without a problem.
+            action.Should().NotThrow();
+        }
     }
 
     [Fact]
-    public void RoundTripOfType_RestrictedFormat_intNullable()
-    {
-        RoundTripOfType_RestrictedFormat(101, out int? result).Should().BeTrue();
-        result.Should().Be(101);
-    }
-
-    [Fact]
-    public void RoundTripOfType_RestrictedFormat_intNullableArray_NotSupportedResolver()
+    public void RoundTripOfType_PredefinedFormat_intNullableArray_NotSupportedResolver()
     {
         int?[] value = [101, null, 303];
 
         using ClipboardBinaryFormatterFullCompatScope scope = new();
         WriteObjectToStream(value);
-        Action read = () => ReadRestrictedObjectFromStream<int?[]>(NotSupportedResolver, out _);
+        Action read = () => ReadPredefinedObjectFromStream<int?[]>(NotSupportedResolver, out _);
 
         // nullable struct requires a custom resolver.
-        // RestrictedTypeDeserializationException
+        // PredefinedTypeDeserializationException
         read.Should().Throw<Exception>();
     }
 
@@ -407,9 +662,8 @@ public sealed partial class BinaryFormatUtilitiesTests : BinaryFormatUtilitesTes
         using ClipboardBinaryFormatterFullCompatScope scope = new();
         WriteObjectToStream(value);
 
-        // This will return false as the type is serialized as mscorlib. When it tries to validate the type, it
-        // will attempt to resolve as it doesn't match and return false.
-        TryReadObjectFromStream<int?[]>(NotSupportedResolver, out _).Should().BeFalse();
+        Action action = () => TryReadObjectFromStream<int?[]>(NotSupportedResolver, out _);
+        action.Should().Throw<NotSupportedException>();
     }
 
     [Theory]
@@ -549,13 +803,15 @@ public sealed partial class BinaryFormatUtilitiesTests : BinaryFormatUtilitesTes
         action.Should().Throw<NotSupportedException>();
     }
 
-    [Fact]
-    public void Sample_GetData_UseBinaryFormatter()
+    [Theory]
+    [EnumData<DataType>]
+    public void TryReadObjectFromStream_MyClass(DataType dataType)
     {
-        MyClass1 value = new(value: 1);
+        using BinaryFormatterScope scope = new(enable: dataType == DataType.BinaryFormat);
+        using BinaryFormatterInClipboardDragDropScope clipboardScope = new(enable: dataType == DataType.BinaryFormat);
 
-        using ClipboardBinaryFormatterFullCompatScope scope = new();
-        WriteObjectToStream(value);
+        MyClass1 value = new(value: 1);
+        using MemoryStream stream = CreateStream(dataType, value);
 
         DataRequest request = new()
         {
@@ -563,24 +819,50 @@ public sealed partial class BinaryFormatUtilitiesTests : BinaryFormatUtilitesTes
             TypedRequest = false
         };
 
-        Stream.Position = 0;
-        Utilities.TryReadObjectFromStream<MyClass1>(Stream, in request, out var result).Should().BeTrue();
+        // Untyped requests must be object
+        BinaryFormatUtilities.TryReadObjectFromStream(stream, in request, out object? result).Should().BeTrue();
         result.Should().BeEquivalentTo(value);
-    }
 
-    [Fact]
-    public void Sample_GetData_UseNrbfDeserialize()
-    {
-        MyClass1 value = new(value: 1);
+        request = new()
+        {
+            Format = "test",
+            TypedRequest = true
+        };
 
-        using BinaryFormatterScope scope = new(enable: true);
-        using BinaryFormatterInClipboardDragDropScope clipboardScope = new(enable: true);
-        WriteObjectToStream(value);
+        Action action = () => BinaryFormatUtilities.TryReadObjectFromStream(stream, in request, out MyClass1? result);
 
-        // This works because GetData falls back to the BinaryFormatter deserializer, NRBF deserializer fails because it requires a resolver.
-        Stream.Position = 0;
-        TryReadObjectFromStream(Stream, untypedRequest: true, "test", resolver: null, out MyClass1? result).Should().BeTrue();
-        result.Should().BeEquivalentTo(value);
+        if (dataType == DataType.BinaryFormat)
+        {
+            action.Should().Throw<NotSupportedException>();
+        }
+        else
+        {
+            action.Should().NotThrow();
+        }
+
+        request = new()
+        {
+            Format = "test",
+            TypedRequest = true,
+            Resolver = (TypeName typeName) =>
+            {
+                if (typeof(MyClass1).Matches(typeName))
+                {
+                    return typeof(MyClass1);
+                }
+
+                if (typeof(MyClass2).Matches(typeName))
+                {
+                    return typeof(MyClass2);
+                }
+
+                // Let implicit handling work for other types.
+                return null;
+            }
+        };
+
+        BinaryFormatUtilities.TryReadObjectFromStream(stream, in request, out MyClass1? result2).Should().BeTrue();
+        result2.Should().BeEquivalentTo(value);
     }
 
     [Theory]
@@ -592,8 +874,8 @@ public sealed partial class BinaryFormatUtilitiesTests : BinaryFormatUtilitesTes
         using ClipboardBinaryFormatterFullCompatScope scope = new();
         WriteObjectToStream(value);
 
-        // RestrictedTypeDeserializationException will be swallowed up the call stack, when reading HGLOBAL.
-        // Fails to resolve MyClass2 or both MyClass1 and MyClass2 in the case of restricted formats.
+        // PredefinedTypeDeserializationException will be swallowed up the call stack, when reading HGLOBAL.
+        // Fails to resolve MyClass2 or both MyClass1 and MyClass2 in the case of Predefined formats.
         Action read = () => ReadObjectFromStream<MyClass1>(restrictDeserialization, resolver: null, out _);
         read.Should().Throw<Exception>();
     }
@@ -625,7 +907,7 @@ public sealed partial class BinaryFormatUtilitiesTests : BinaryFormatUtilitesTes
     }
 
     [Fact]
-    public void Sample_TryGetData_RestrictedFormat_UseBinaryFormatter()
+    public void Sample_TryGetData_PredefinedFormat_UseBinaryFormatter()
     {
         MyClass1 value = new(value: 1);
 
@@ -637,7 +919,7 @@ public sealed partial class BinaryFormatUtilitiesTests : BinaryFormatUtilitesTes
     }
 
     [Fact]
-    public void Sample_TryGetData_RestrictedFormat_UseNrbfDeserializer()
+    public void Sample_TryGetData_PredefinedFormat_UseNrbfDeserializer()
     {
         MyClass1 value = new(value: 1);
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
@@ -720,8 +720,8 @@ public class ClipboardTests
             Clipboard.SetData("TestData", expected);
         }
 
-        Clipboard.TryGetData("TestData", out int? data).Should().BeTrue();
-        data.Should().Be(expected);
+        Clipboard.TryGetData("TestData", out int? data).Should().BeFalse();
+        data.HasValue.Should().BeFalse();
     }
 
     [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Ole/BinaryFormatUtilitiesTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Ole/BinaryFormatUtilitiesTests.cs
@@ -8,7 +8,7 @@ using System.Drawing;
 using System.Private.Windows.Ole;
 using System.Private.Windows.Ole.Tests;
 using System.Reflection.Metadata;
-using Utilities = System.Private.Windows.Ole.BinaryFormatUtilities<System.Windows.Forms.Nrbf.WinFormsNrbfSerializer>;
+using BinaryFormatUtilities = System.Private.Windows.Ole.BinaryFormatUtilities<System.Windows.Forms.Nrbf.WinFormsNrbfSerializer>;
 
 namespace System.Windows.Forms.Ole;
 
@@ -22,12 +22,12 @@ public sealed class BinaryFormatUtilitiesTests : BinaryFormatUtilitesTestsBase
         [NotNullWhen(true)] out T? @object) where T : default
     {
         DataRequest request = new(format) { Resolver = resolver, TypedRequest = !untypedRequest };
-        return Utilities.TryReadObjectFromStream(stream, in request, out @object);
+        return BinaryFormatUtilities.TryReadObjectFromStream(stream, in request, out @object);
     }
 
     protected override void WriteObjectToStream(MemoryStream stream, object data, string format)
     {
-        Utilities.WriteObjectToStream(stream, data, format);
+        BinaryFormatUtilities.WriteObjectToStream(stream, data, format);
     }
 
     [Fact]
@@ -38,22 +38,15 @@ public sealed class BinaryFormatUtilitiesTests : BinaryFormatUtilitesTestsBase
         sourceList.Images.Add(image);
         using ImageListStreamer value = sourceList.ImageStream!;
 
-        RoundTripObject(value, out ImageListStreamer? result).Should().BeTrue();
-        result.Should().BeOfType<ImageListStreamer>();
-        using ImageList newList = new();
-        newList.ImageStream = result;
-        newList.Images.Count.Should().Be(1);
-    }
+        using MemoryStream stream = CreateStream(DataType.BinaryFormat, value);
 
-    [Fact]
-    public void RoundTrip_RestrictedFormat_ImageList()
-    {
-        using ImageList sourceList = new();
-        using Bitmap image = new(10, 10);
-        sourceList.Images.Add(image);
-        using ImageListStreamer value = sourceList.ImageStream!;
+        DataRequest request = new()
+        {
+            Format = "test",
+            TypedRequest = true
+        };
 
-        RoundTripObject_RestrictedFormat(value, out ImageListStreamer? result).Should().BeTrue();
+        BinaryFormatUtilities.TryReadObjectFromStream(stream, in request, out ImageListStreamer? result).Should().BeTrue();
         using ImageList newList = new();
         newList.ImageStream = result;
         newList.Images.Count.Should().Be(1);
@@ -63,42 +56,16 @@ public sealed class BinaryFormatUtilitiesTests : BinaryFormatUtilitesTestsBase
     public void RoundTrip_Bitmap()
     {
         using Bitmap value = new(10, 10);
-        RoundTripObject(value, out Bitmap? result).Should().BeTrue();
+        using MemoryStream stream = CreateStream(DataType.BinaryFormat, value);
+
+        DataRequest request = new()
+        {
+            Format = "test",
+            TypedRequest = true
+        };
+
+        BinaryFormatUtilities.TryReadObjectFromStream(stream, in request, out Bitmap? result).Should().BeTrue();
         result.Should().BeOfType<Bitmap>().Which.Size.Should().Be(value.Size);
-    }
-
-    [Fact]
-    public void RoundTrip_RestrictedFormat_Bitmap()
-    {
-        using Bitmap value = new(10, 10);
-        RoundTripObject_RestrictedFormat(value, out Bitmap? result).Should().BeTrue();
-        result.Should().BeOfType<Bitmap>().Which.Size.Should().Be(value.Size);
-    }
-
-    [Fact]
-    public void RoundTripOfType_AsUnmatchingType_Simple()
-    {
-        List<int> value = [1, 2, 3];
-        RoundTripOfType(value, out Control? result).Should().BeFalse();
-        result.Should().BeNull();
-    }
-
-    [Fact]
-    public void RoundTripOfType_RestrictedFormat_AsUnmatchingType_Simple()
-    {
-        Rectangle value = new(1, 1, 2, 2);
-
-        // We are setting up an invalid content scenario, Rectangle type can't be read as a restricted format,
-        // but in this case requested type will not match the payload type.
-        WriteObjectToStream(value);
-        Stream.Position = 0;
-        ReadRestrictedObjectFromStream(NotSupportedResolver, out Control? result).Should().BeFalse();
-        result.Should().BeNull();
-
-        using ClipboardBinaryFormatterFullCompatScope scope = new();
-        Stream.Position = 0;
-        ReadRestrictedObjectFromStream(NotSupportedResolver, out Control? result2).Should().BeFalse();
-        result2.Should().BeNull();
     }
 
     private static Type FontResolver(TypeName typeName)
@@ -141,7 +108,7 @@ public sealed class BinaryFormatUtilitiesTests : BinaryFormatUtilitesTestsBase
         // Clipboard.SetData("TestData", new Font("Microsoft Sans Serif", 10));
         // And the resulting stream was saved as a string
         // string text = Convert.ToBase64String(stream.ToArray());
-        string font =
+        string fontData =
             "AAEAAAD/////AQAAAAAAAAAMAgAAAFFTeXN0ZW0uRHJhd2luZywgVmVyc2lvbj00LjAuMC4wLCBDdWx0dXJl"
             + "PW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWIwM2Y1ZjdmMTFkNTBhM2EFAQAAABNTeXN0ZW0uRHJhd2luZy5G"
             + "b250BAAAAAROYW1lBFNpemUFU3R5bGUEVW5pdAEABAQLGFN5c3RlbS5EcmF3aW5nLkZvbnRTdHlsZQIAAAAb"
@@ -149,65 +116,52 @@ public sealed class BinaryFormatUtilitiesTests : BinaryFormatUtilitesTestsBase
             + "IEEF/P///xhTeXN0ZW0uRHJhd2luZy5Gb250U3R5bGUBAAAAB3ZhbHVlX18ACAIAAAAAAAAABfv///8bU3lz"
             + "dGVtLkRyYXdpbmcuR3JhcGhpY3NVbml0AQAAAAd2YWx1ZV9fAAgCAAAAAwAAAAs=";
 
-        byte[] bytes = Convert.FromBase64String(font);
+        byte[] bytes = Convert.FromBase64String(fontData);
         using MemoryStream stream = new(bytes);
+        stream.Position = 0;
 
-        DataRequest request = new("test")
+        DataRequest request = new()
         {
+            Format = "test",
             TypedRequest = false
         };
 
-        // Default deserialization with the NRBF deserializer.
-        using (BinaryFormatterInClipboardDragDropScope binaryFormatScope = new(enable: true))
-        {
-            // GetData case.
-            stream.Position = 0;
+        // Untyped BinaryFormatter disabled
+        Action action = () => BinaryFormatUtilities.TryReadObjectFromStream(
+            stream,
+            in request,
+            out object? _);
 
-            Action getData = () => Utilities.TryReadObjectFromStream<object>(
-               stream,
-               in request,
-               out _);
+        action.Should().Throw<NotSupportedException>();
 
-            getData.Should().Throw<NotSupportedException>();
-
-            Action tryGetData = () => TryGetData(stream);
-            tryGetData.Should().Throw<NotSupportedException>();
-        }
-
-        // Deserialize using the binary formatter.
+        // Untyped BinaryFormatter enabled
         using ClipboardBinaryFormatterFullCompatScope scope = new();
 
-        // GetData case.
-        stream.Position = 0;
-        Utilities.TryReadObjectFromStream(
+        BinaryFormatUtilities.TryReadObjectFromStream(
            stream,
            in request,
-           out Font? result).Should().BeTrue();
+           out object? result).Should().BeTrue();
 
         result.Should().NotBeNull();
-        result!.Name.Should().Be("Microsoft Sans Serif");
-        result.Size.Should().Be(10);
+        Font? font = result.Should().BeOfType<Font>().Subject;
+        font.Name.Should().Be("Microsoft Sans Serif");
+        font.Size.Should().Be(10);
 
-        TryGetData(stream);
-
-        static void TryGetData(MemoryStream stream)
+        // Typed with resolver
+        request = new()
         {
-            // TryGetData<Font> case.
-            stream.Position = 0;
+            Format = "test",
+            Resolver = FontResolver,
+            TypedRequest = true
+        };
 
-            DataRequest request = new("test")
-            {
-                Resolver = FontResolver,
-            };
+        BinaryFormatUtilities.TryReadObjectFromStream(
+            stream,
+            in request,
+            out font).Should().BeTrue();
 
-            Utilities.TryReadObjectFromStream(
-                stream,
-                in request,
-                out Font? result).Should().BeTrue();
-
-            result.Should().NotBeNull();
-            result!.Name.Should().Be("Microsoft Sans Serif");
-            result.Size.Should().Be(10);
-        }
+        font.Should().NotBeNull();
+        font!.Name.Should().Be("Microsoft Sans Serif");
+        font.Size.Should().Be(10);
     }
 }


### PR DESCRIPTION
This change refines deserialization binding behavior for the BinaryFormatUtilites class.

- Untyped requests must be requesting the object type (as the outer APIs all do)
- Removes delegate in TypeBinder
- TypeBinder returns typeof(object) for untyped requests
- TypeBinder does not fall back to implicit INrbfSerializer binding when missing a resolver
- Move JsonSerializer serialization to static interface
- Reorder TryGetObjectFromJson to fail out appropriately when binding the root type
- Reset the stream position in TryReadObjectFromStream
- Create the binder up front in TryReadObjectFromStream to normalize usage
- Don't allow implicit nullable conversion without an explicit binder
- Write a number of new tests

Plan is to continue to write tests with further test cleanup
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12950)