### PR TITLE
Ensure `ComManagedStream` seekable wrapper stream has position of 0

### DIFF
--- a/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/ComManagedStream.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/ComManagedStream.cs
@@ -19,6 +19,7 @@ internal sealed unsafe class ComManagedStream : IStream.Interface, IManagedWrapp
             // Copy to a memory stream so we can seek
             MemoryStream memoryStream = new();
             stream.CopyTo(memoryStream);
+            memoryStream.Seek(0, SeekOrigin.Begin);
             _dataStream = memoryStream;
         }
         else

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/Windows/Win32/System/Com/ComManagedStreamTests.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/Windows/Win32/System/Com/ComManagedStreamTests.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Windows.Win32.System.Com.Tests;
+
+public class ComManagedStreamTests
+{
+    [Fact]
+    public void Ctor_NonSeekableStream_WrapsWithSeekableStreamAtPositionZero()
+    {
+        using TestStream nonSeekableStream = new(canSeek: false, numBytes: 4);
+        ComManagedStream comManagedStream = new(nonSeekableStream, makeSeekable: true);
+        comManagedStream.GetDataStream().CanSeek.Should().Be(true);
+        comManagedStream.GetDataStream().Position.Should().Be(0);
+    }
+
+    [Fact]
+    public void Ctor_SeekableStream_UsesOriginalStream()
+    {
+        using TestStream seekableStream = new(canSeek: true, numBytes: 4);
+        ComManagedStream comManagedStream = new(seekableStream, makeSeekable: true);
+        comManagedStream.GetDataStream().Should().BeSameAs(seekableStream);
+    }
+
+    private class TestStream : MemoryStream
+    {
+        private readonly bool _canSeek;
+
+        public override bool CanSeek => _canSeek;
+
+        public TestStream(bool canSeek, int numBytes) : base(new byte[numBytes])
+        {
+            _canSeek = canSeek;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12951

## Proposed changes

- `ComManagedStream` will ensure that the stream wrapping a non-seekable source stream has a position of 0 at the end of its constructor.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- `Image.FromStream` with a non-seekable stream should no longer throw an exception when loading `.emf` and `.wmf` images.

## Regression? 

- Yes

## Risk

- Risk seems relatively low, in particular because this constructor created a stream with a position of 0 in .NET Framework and .NET Core 3.1. It seems unlikely that consumers are relying on a non-zero position.

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

- Added unit tests ensuring that the stream returned by `ComManagedStream.GetDataStream()` has the expected state. 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12953)