### PR TITLE
React to NuGet package pruning warnings

### DIFF
--- a/src/System.Private.Windows.Core/src/System.Private.Windows.Core.csproj
+++ b/src/System.Private.Windows.Core/src/System.Private.Windows.Core.csproj
@@ -30,7 +30,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWin32" PrivateAssets="all" />
     <PackageReference Include="System.Formats.Nrbf" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Private.Windows.GdiPlus/System.Private.Windows.GdiPlus.csproj
+++ b/src/System.Private.Windows.GdiPlus/System.Private.Windows.GdiPlus.csproj
@@ -32,7 +32,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWin32" PrivateAssets="all" />
     <PackageReference Include="System.Formats.Nrbf" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms.Primitives/src/System.Windows.Forms.Primitives.csproj
+++ b/src/System.Windows.Forms.Primitives/src/System.Windows.Forms.Primitives.csproj
@@ -45,7 +45,6 @@
     <PackageReference Include="System.Configuration.ConfigurationManager" />
     <PackageReference Include="System.Resources.Extensions" />
     <PackageReference Include="System.Windows.Extensions" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/src/System.Windows.Forms.csproj
+++ b/src/System.Windows.Forms/src/System.Windows.Forms.csproj
@@ -39,7 +39,6 @@
     <PackageReference Include="System.Configuration.ConfigurationManager" />
     <PackageReference Include="System.Resources.Extensions" />
     <PackageReference Include="System.Windows.Extensions" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/sdk/pull/46829

NuGet added a new feature that automatically prunes package and project references that are provided by the shared framework that is targeted.

Resolve the warnings that got emitted when building the repository in non-source-only mode.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12955)