### PR TITLE
Prevent Toolbar tooltips from appearing directly under cursor hotspot

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
@@ -4505,6 +4505,7 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
         if (_currentlyActiveTooltipItem is not null && !GetToolStripState(STATE_DRAGGING) && Cursor.Current is { } currentCursor)
         {
             Point cursorLocation = Cursor.Position;
+            cursorLocation.X += currentCursor.HotSpot.X + 1;
             cursorLocation.Y += Cursor.Size.Height - currentCursor.HotSpot.Y;
 
             cursorLocation = WindowsFormsUtils.ConstrainToScreenBounds(new Rectangle(cursorLocation, s_onePixel)).Location;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
@@ -4505,6 +4505,7 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
         if (_currentlyActiveTooltipItem is not null && !GetToolStripState(STATE_DRAGGING) && Cursor.Current is { } currentCursor)
         {
             Point cursorLocation = Cursor.Position;
+            // This prevents ToolStrip tooltips from appearing directly under the cursor HotSpot. Thus, the user can click the ToolStripItem.
             cursorLocation.X += currentCursor.HotSpot.X + 1;
             cursorLocation.Y += Cursor.Size.Height - currentCursor.HotSpot.Y;
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12958


## Proposed changes

- This positions the `ToolTip` so that it is offset by 1px from the cursor's HotSpot X value.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- This prevents `ToolStrip` tooltips from appearing directly under cursor HotSpot. Thus, the user is able to click the `ToolStripItem`.

## Regression? 

- No

## Risk

-

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manually tested.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- <!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12959)