### PR TITLE
Add code coverage for ToolStripCollectionEditor.cs file

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripCollectionEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripCollectionEditorTests.cs
@@ -1,0 +1,144 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Collections;
+using System.ComponentModel;
+using System.ComponentModel.Design;
+
+namespace System.Windows.Forms.Design.Tests;
+
+public class ToolStripCollectionEditorTests
+{
+    private readonly ToolStripCollectionEditor _editor;
+    private readonly MockServiceProvider _serviceProvider;
+    private readonly MockTypeDescriptorContext _context;
+
+    public ToolStripCollectionEditorTests()
+    {
+        _editor = new();
+        _serviceProvider = new();
+        _context = new();
+    }
+
+    [Fact]
+    public void ToolStripCollectionEditor_EditValue_NullProvider_ReturnsNull()
+    {
+        object? result = _editor.EditValue(context: null, provider: null, value: new object());
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToolStripCollectionEditor_EditValue_WithProvider_ReturnsExpected()
+    {
+        object? result = _editor.EditValue(_context, _serviceProvider, new object());
+
+        result.Should().NotBeNull();
+    }
+
+    private class MockServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType)
+        {
+            if (serviceType == typeof(ISelectionService))
+            {
+                return new MockSelectionService();
+            }
+
+            if (serviceType == typeof(IDesignerHost))
+            {
+                return new MockDesignerHost();
+            }
+
+            return null;
+        }
+    }
+
+    private class MockSelectionService : ISelectionService
+    {
+        public event EventHandler? SelectionChanged;
+        public event EventHandler? SelectionChanging;
+
+        public ICollection GetSelectedComponents() => Array.Empty<object>();
+
+        public bool GetComponentSelected(object component) => false;
+
+        public object? PrimarySelection => null;
+
+        public int SelectionCount => 0;
+
+        public void SetSelectedComponents(ICollection? components) { }
+
+        public void SetSelectedComponents(ICollection? components, SelectionTypes selectionType) { }
+    }
+
+    private class MockDesignerHost : IDesignerHost
+    {
+        public IContainer Container => new Container();
+
+        public bool InTransaction => false;
+
+        public IComponent? RootComponent => null;
+
+        public string TransactionDescription => string.Empty;
+
+        public bool Loading => false;
+
+        public string RootComponentClassName => string.Empty;
+
+        public void Activate() { }
+
+        public IComponent CreateComponent(Type componentClass) => throw new NotImplementedException();
+
+        public IComponent CreateComponent(Type componentClass, string name) => throw new NotImplementedException();
+
+        public DesignerTransaction CreateTransaction() => throw new NotImplementedException();
+
+        public DesignerTransaction CreateTransaction(string description) => throw new NotImplementedException();
+
+        public void DestroyComponent(IComponent component) { }
+
+        public IDesigner? GetDesigner(IComponent component) => null;
+
+        public Type GetType(string typeName) => throw new NotImplementedException();
+
+        public void AddService(Type serviceType, ServiceCreatorCallback callback) { }
+
+        public void AddService(Type serviceType, ServiceCreatorCallback callback, bool promote) { }
+
+        public void AddService(Type serviceType, object serviceInstance) { }
+
+        public void AddService(Type serviceType, object serviceInstance, bool promote) { }
+
+        public void RemoveService(Type serviceType) { }
+
+        public void RemoveService(Type serviceType, bool promote) { }
+
+        public object? GetService(Type serviceType) => null;
+
+        public event EventHandler? Activated;
+        public event EventHandler? Deactivated;
+        public event EventHandler? LoadComplete;
+        public event DesignerTransactionCloseEventHandler? TransactionClosed;
+        public event DesignerTransactionCloseEventHandler? TransactionClosing;
+        public event EventHandler? TransactionOpened;
+        public event EventHandler? TransactionOpening;
+    }
+
+    private class MockTypeDescriptorContext : ITypeDescriptorContext
+    {
+        public IContainer? Container => null;
+
+        public object? Instance => null;
+
+        public PropertyDescriptor? PropertyDescriptor => null;
+
+        public bool OnComponentChanging() => true;
+
+        public void OnComponentChanged() { }
+
+        public object? GetService(Type serviceType) => null;
+    }
+}

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripCollectionEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripCollectionEditorTests.cs
@@ -12,14 +12,10 @@ namespace System.Windows.Forms.Design.Tests;
 public class ToolStripCollectionEditorTests
 {
     private readonly ToolStripCollectionEditor _editor;
-    private readonly MockServiceProvider _serviceProvider;
-    private readonly MockTypeDescriptorContext _context;
 
     public ToolStripCollectionEditorTests()
     {
         _editor = new();
-        _serviceProvider = new();
-        _context = new();
     }
 
     [Fact]
@@ -33,7 +29,7 @@ public class ToolStripCollectionEditorTests
     [Fact]
     public void ToolStripCollectionEditor_EditValue_WithProvider_ReturnsExpected()
     {
-        object? result = _editor.EditValue(_context, _serviceProvider, new object());
+        object? result = _editor.EditValue(new MockTypeDescriptorContext(), new MockServiceProvider(), new object());
 
         result.Should().NotBeNull();
     }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripCollectionEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripCollectionEditorTests.cs
@@ -25,7 +25,7 @@ public class ToolStripCollectionEditorTests
     [Fact]
     public void ToolStripCollectionEditor_EditValue_NullProvider_ReturnsNull()
     {
-        object? result = _editor.EditValue(context: null, provider: null, value: new object());
+        object? result = _editor.EditValue(context: null, provider: null!, value: new object());
 
         result.Should().BeNull();
     }
@@ -58,8 +58,17 @@ public class ToolStripCollectionEditorTests
 
     private class MockSelectionService : ISelectionService
     {
-        public event EventHandler? SelectionChanged;
-        public event EventHandler? SelectionChanging;
+        public event EventHandler? SelectionChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler? SelectionChanging
+        {
+            add { }
+            remove { }
+        }
 
         public ICollection GetSelectedComponents() => Array.Empty<object>();
 
@@ -80,7 +89,7 @@ public class ToolStripCollectionEditorTests
 
         public bool InTransaction => false;
 
-        public IComponent? RootComponent => null;
+        public IComponent RootComponent => null!;
 
         public string TransactionDescription => string.Empty;
 
@@ -118,13 +127,47 @@ public class ToolStripCollectionEditorTests
 
         public object? GetService(Type serviceType) => null;
 
-        public event EventHandler? Activated;
-        public event EventHandler? Deactivated;
-        public event EventHandler? LoadComplete;
-        public event DesignerTransactionCloseEventHandler? TransactionClosed;
-        public event DesignerTransactionCloseEventHandler? TransactionClosing;
-        public event EventHandler? TransactionOpened;
-        public event EventHandler? TransactionOpening;
+        public event EventHandler? Activated
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler? Deactivated
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler? LoadComplete
+        {
+            add { }
+            remove { }
+        }
+
+        public event DesignerTransactionCloseEventHandler? TransactionClosed
+        {
+            add { }
+            remove { }
+        }
+
+        public event DesignerTransactionCloseEventHandler? TransactionClosing
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler? TransactionOpened
+        {
+            add { }
+            remove { }
+        }
+
+        public event EventHandler? TransactionOpening
+        {
+            add { }
+            remove { }
+        }
     }
 
     private class MockTypeDescriptorContext : ITypeDescriptorContext

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripCollectionEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripCollectionEditorTests.cs
@@ -19,6 +19,20 @@ public class ToolStripCollectionEditorTests
     }
 
     [Fact]
+    public void ToolStripCollectionEditor_CreateCollectionForm_DoesNotThrowException()
+    {
+        Action act = () => _editor.TestAccessor().Dynamic.CreateCollectionForm();
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ToolStripCollectionEditor_HelpTopic_ReturnsExpectedValue()
+    {
+        string helpTopic = _editor.TestAccessor().Dynamic.HelpTopic;
+        helpTopic.Should().Be("net.ComponentModel.ToolStripCollectionEditor");
+    }
+
+    [Fact]
     public void ToolStripCollectionEditor_EditValue_NullProvider_ReturnsNull()
     {
         object? result = _editor.EditValue(context: null, provider: null!, value: new object());


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773


## Proposed changes

- Add unit test file: ToolStripCollectionEditorTests.cs for public methods of the ToolStripCollectionEditor.cs.
- Enable nullability in ToolStripCollectionEditorTests.cs.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12962)