### PR TITLE
Add code coverage for ToolStripCustomTypeDescriptor

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripCustomTypeDescriptorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripCustomTypeDescriptorTests.cs
@@ -27,6 +27,26 @@ public class ToolStripCustomTypeDescriptorTests
         _descriptor.GetPropertyOwner(null).Should().Be(_toolStrip);
 
     [Fact]
+    public void GetProperties_ReturnsCachedCollection()
+    {
+        PropertyDescriptorCollection properties1 = _descriptor.GetProperties();
+        PropertyDescriptorCollection properties2 = _descriptor.GetProperties();
+
+        properties1.Should().BeSameAs(properties2);
+    }
+
+    [Fact]
+    public void GetProperties_WithAttributes_ReturnsCachedCollection()
+    {
+        Attribute[] attributes = [new BrowsableAttribute(true)];
+
+        PropertyDescriptorCollection properties1 = _descriptor.GetProperties(attributes);
+        PropertyDescriptorCollection properties2 = _descriptor.GetProperties(attributes);
+
+        properties1.Should().BeSameAs(properties2);
+    }
+
+    [Fact]
     public void GetProperties_RemovesItemsProperty() =>
         _descriptor.GetProperties().Cast<PropertyDescriptor>().Should().NotContain(p => p.Name == "Items");
 
@@ -35,6 +55,21 @@ public class ToolStripCustomTypeDescriptorTests
     {
         Attribute[] attributes = [new BrowsableAttribute(true)];
 
+        _descriptor.GetProperties(attributes).Cast<PropertyDescriptor>().Should().NotContain(p => p.Name == "Items");
+    }
+
+    [Fact]
+    public void GetProperties_RemovesItemsProperty_WhenCollectionIsNotNull()
+    {
+        _descriptor.GetProperties();
+        _descriptor.GetProperties().Cast<PropertyDescriptor>().Should().NotContain(p => p.Name == "Items");
+    }
+
+    [Fact]
+    public void GetProperties_WithAttributes_RemovesItemsProperty_WhenCollectionIsNotNull()
+    {
+        Attribute[] attributes = [new BrowsableAttribute(true)];
+        _descriptor.GetProperties(attributes);
         _descriptor.GetProperties(attributes).Cast<PropertyDescriptor>().Should().NotContain(p => p.Name == "Items");
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripCustomTypeDescriptorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripCustomTypeDescriptorTests.cs
@@ -18,7 +18,8 @@ public class ToolStripCustomTypeDescriptorTests : IDisposable
         _descriptor = new(_toolStrip);
     }
 
-    public void Dispose() => _toolStrip.Dispose();
+    public void Dispose()
+        => _toolStrip.Dispose();
 
     [Fact]
     public void Constructor_InitializesInstance()
@@ -28,8 +29,8 @@ public class ToolStripCustomTypeDescriptorTests : IDisposable
     }
 
     [Fact]
-    public void GetPropertyOwner_ReturnsInstance() =>
-        _descriptor.GetPropertyOwner(null).Should().Be(_toolStrip);
+    public void GetPropertyOwner_ReturnsInstance()
+        => _descriptor.GetPropertyOwner(null).Should().Be(_toolStrip);
 
     [Fact]
     public void GetProperties_ReturnsCachedCollection()
@@ -52,8 +53,8 @@ public class ToolStripCustomTypeDescriptorTests : IDisposable
     }
 
     [Fact]
-    public void GetProperties_RemovesItemsProperty() =>
-        _descriptor.GetProperties().Cast<PropertyDescriptor>().Should().NotContain(p => p.Name == "Items");
+    public void GetProperties_RemovesItemsProperty()
+        => _descriptor.GetProperties().Cast<PropertyDescriptor>().Should().NotContain(p => p.Name == "Items");
 
     [Fact]
     public void GetProperties_WithAttributes_RemovesItemsProperty()

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripCustomTypeDescriptorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripCustomTypeDescriptorTests.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.ComponentModel;
+
+namespace System.Windows.Forms.Design.Tests;
+
+public class ToolStripCustomTypeDescriptorTests
+{
+    private readonly ToolStrip _toolStrip;
+    private readonly ToolStripCustomTypeDescriptor _descriptor;
+
+    public ToolStripCustomTypeDescriptorTests()
+    {
+        _toolStrip = new();
+        _descriptor = new(_toolStrip);
+    }
+
+    [Fact]
+    public void Constructor_InitializesInstance() =>
+        _descriptor.GetPropertyOwner(null).Should().Be(_toolStrip);
+
+    [Fact]
+    public void GetPropertyOwner_ReturnsInstance() =>
+        _descriptor.GetPropertyOwner(null).Should().Be(_toolStrip);
+
+    [Fact]
+    public void GetProperties_RemovesItemsProperty() =>
+        _descriptor.GetProperties().Cast<PropertyDescriptor>().Should().NotContain(p => p.Name == "Items");
+
+    [Fact]
+    public void GetProperties_WithAttributes_RemovesItemsProperty()
+    {
+        Attribute[] attributes = [new BrowsableAttribute(true)];
+
+        _descriptor.GetProperties(attributes).Cast<PropertyDescriptor>().Should().NotContain(p => p.Name == "Items");
+    }
+}

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripCustomTypeDescriptorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripCustomTypeDescriptorTests.cs
@@ -19,8 +19,11 @@ public class ToolStripCustomTypeDescriptorTests
     }
 
     [Fact]
-    public void Constructor_InitializesInstance() =>
-        _descriptor.GetPropertyOwner(null).Should().Be(_toolStrip);
+    public void Constructor_InitializesInstance()
+    {
+        ToolStrip instance = _descriptor.TestAccessor().Dynamic._instance;
+        instance.Should().Be(_toolStrip);
+    }
 
     [Fact]
     public void GetPropertyOwner_ReturnsInstance() =>

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripCustomTypeDescriptorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripCustomTypeDescriptorTests.cs
@@ -18,8 +18,7 @@ public class ToolStripCustomTypeDescriptorTests : IDisposable
         _descriptor = new(_toolStrip);
     }
 
-    public void Dispose()
-        => _toolStrip.Dispose();
+    public void Dispose() => _toolStrip.Dispose();
 
     [Fact]
     public void Constructor_InitializesInstance()
@@ -29,8 +28,8 @@ public class ToolStripCustomTypeDescriptorTests : IDisposable
     }
 
     [Fact]
-    public void GetPropertyOwner_ReturnsInstance()
-        => _descriptor.GetPropertyOwner(null).Should().Be(_toolStrip);
+    public void GetPropertyOwner_ReturnsInstance() =>
+        _descriptor.GetPropertyOwner(null).Should().Be(_toolStrip);
 
     [Fact]
     public void GetProperties_ReturnsCachedCollection()
@@ -53,8 +52,8 @@ public class ToolStripCustomTypeDescriptorTests : IDisposable
     }
 
     [Fact]
-    public void GetProperties_RemovesItemsProperty()
-        => _descriptor.GetProperties().Cast<PropertyDescriptor>().Should().NotContain(p => p.Name == "Items");
+    public void GetProperties_RemovesItemsProperty() =>
+        _descriptor.GetProperties().Cast<PropertyDescriptor>().Should().NotContain(p => p.Name == "Items");
 
     [Fact]
     public void GetProperties_WithAttributes_RemovesItemsProperty()

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripCustomTypeDescriptorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripCustomTypeDescriptorTests.cs
@@ -7,7 +7,7 @@ using System.ComponentModel;
 
 namespace System.Windows.Forms.Design.Tests;
 
-public class ToolStripCustomTypeDescriptorTests
+public class ToolStripCustomTypeDescriptorTests : IDisposable
 {
     private readonly ToolStrip _toolStrip;
     private readonly ToolStripCustomTypeDescriptor _descriptor;
@@ -17,6 +17,8 @@ public class ToolStripCustomTypeDescriptorTests
         _toolStrip = new();
         _descriptor = new(_toolStrip);
     }
+
+    public void Dispose() => _toolStrip.Dispose();
 
     [Fact]
     public void Constructor_InitializesInstance()


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773

## Proposed changes
Add unit test file: ToolStripCustomTypeDescriptorTests.cs for public methods of the ToolStripCustomTypeDescriptor.cs.
Enable nullability in ToolStripCustomTypeDescriptorTests.cs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12963)