### PR TITLE
React to NuGet package pruning warnings (2)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,6 @@
     <PackageVersion Include="Microsoft.Win32.SystemEvents" Version="$(MicrosoftWin32SystemEventsPackageVersion)" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="$(MicrosoftWindowsCsWin32PackageVersion)" PrivateAssets="all" />
     <PackageVersion Include="System.CodeDom" Version="$(SystemCodeDomPackageVersion)" />
-    <PackageVersion Include="System.Collections.Concurrent" Version="4.3.0" />
     <PackageVersion Include="System.ComponentModel.TypeConverter.TestData" Version="$(SystemComponentModelTypeConverterTestDataVersion)" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerPackageVersion)" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.9.0" />

--- a/src/Common/tests/TestUtilities/System.Private.Windows.Core.TestUtilities.csproj
+++ b/src/Common/tests/TestUtilities/System.Private.Windows.Core.TestUtilities.csproj
@@ -13,7 +13,6 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Moq" />
-    <PackageReference Include="System.Collections.Concurrent" />
     <PackageReference Include="xunit.assert" />
     <PackageReference Include="xunit.stafact" />
     <PackageReference Include="Microsoft.DotNet.RemoteExecutor" />

--- a/src/Microsoft.VisualBasic/src/Microsoft.VisualBasic.Facade.csproj
+++ b/src/Microsoft.VisualBasic/src/Microsoft.VisualBasic.Facade.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <AssemblyName>Microsoft.VisualBasic</AssemblyName>
-    <!-- Set PackageId not to the assembly name as NuGet prunes package and project references
-         for dependencies that are inbox in the framework. This is only necessary for this facade
-         project as only System.VisualBasic is inbox on .NETCoreApp. -->
+    <!-- Set PackageId to something different than the assembly name as NuGet prunes package and project
+         references for dependencies that are inbox in the framework. NuGet uses the PackageId information
+         for that. This is necessary for this facadeproject as System.VisualBasic is inbox on .NETCoreApp. -->
     <PackageId>$(MSBuildProjectName)</PackageId>
   </PropertyGroup>
 

--- a/src/Microsoft.VisualBasic/src/Microsoft.VisualBasic.Facade.csproj
+++ b/src/Microsoft.VisualBasic/src/Microsoft.VisualBasic.Facade.csproj
@@ -2,6 +2,10 @@
 
   <PropertyGroup>
     <AssemblyName>Microsoft.VisualBasic</AssemblyName>
+    <!-- Set PackageId not to the assembly name as NuGet prunes package and project references
+         for dependencies that are inbox in the framework. This is only necessary for this facade
+         project as only System.VisualBasic is inbox on .NETCoreApp. -->
+    <PackageId>$(MSBuildProjectName)</PackageId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualBasic/src/Microsoft.VisualBasic.Facade.csproj
+++ b/src/Microsoft.VisualBasic/src/Microsoft.VisualBasic.Facade.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>Microsoft.VisualBasic</AssemblyName>
     <!-- Set PackageId to something different than the assembly name as NuGet prunes package and project
          references for dependencies that are inbox in the framework. NuGet uses the PackageId information
-         for that. This is necessary for this facadeproject as System.VisualBasic is inbox on .NETCoreApp. -->
+         for that. This is necessary for this facadeproject as Microsoft.VisualBasic is inbox on .NETCoreApp. -->
     <PackageId>$(MSBuildProjectName)</PackageId>
   </PropertyGroup>
 

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/System.Windows.Forms.Primitives.TestUtilities.csproj
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/System.Windows.Forms.Primitives.TestUtilities.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="System.Collections.Concurrent" />
     <PackageReference Include="Microsoft.DotNet.XUnitExtensions" />
   </ItemGroup>
 

--- a/src/System.Windows.Forms/tests/TestUtilities/System.Windows.Forms.TestUtilities.csproj
+++ b/src/System.Windows.Forms/tests/TestUtilities/System.Windows.Forms.TestUtilities.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Concurrent" />
     <PackageReference Include="Microsoft.DotNet.RemoteExecutor" />
     <PackageReference Include="Microsoft.DotNet.XUnitExtensions" />
   </ItemGroup>


### PR DESCRIPTION
Replaces https://github.com/dotnet/winforms/pull/12960
Unsure why those weren't flagged in 9249b89d72852616b25660141f9d1a155c1aebd9 but this is the right thing to do.

Set PackageId for the facade project to avoid project prune warnings.