### PR TITLE
Ensure `ComManagedStream` seekable wrapper stream has position of 0 (…

### DIFF
--- a/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/ComManagedStream.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/ComManagedStream.cs
@@ -19,6 +19,7 @@ internal sealed unsafe class ComManagedStream : IStream.Interface, IManagedWrapp
             // Copy to a memory stream so we can seek
             MemoryStream memoryStream = new();
             stream.CopyTo(memoryStream);
+            memoryStream.Seek(0, SeekOrigin.Begin);
             _dataStream = memoryStream;
         }
         else

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/Windows/Win32/System/Com/ComManagedStreamTests.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/Windows/Win32/System/Com/ComManagedStreamTests.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Windows.Win32.System.Com.Tests;
+
+public class ComManagedStreamTests
+{
+    [Fact]
+    public void Ctor_NonSeekableStream_WrapsWithSeekableStreamAtPositionZero()
+    {
+        using TestStream nonSeekableStream = new(canSeek: false, numBytes: 4);
+        ComManagedStream comManagedStream = new(nonSeekableStream, makeSeekable: true);
+        comManagedStream.GetDataStream().CanSeek.Should().Be(true);
+        comManagedStream.GetDataStream().Position.Should().Be(0);
+    }
+
+    [Fact]
+    public void Ctor_SeekableStream_UsesOriginalStream()
+    {
+        using TestStream seekableStream = new(canSeek: true, numBytes: 4);
+        ComManagedStream comManagedStream = new(seekableStream, makeSeekable: true);
+        comManagedStream.GetDataStream().Should().BeSameAs(seekableStream);
+    }
+
+    private class TestStream : MemoryStream
+    {
+        private readonly bool _canSeek;
+
+        public override bool CanSeek => _canSeek;
+
+        public TestStream(bool canSeek, int numBytes) : base(new byte[numBytes])
+        {
+            _canSeek = canSeek;
+        }
+    }
+}


### PR DESCRIPTION
…#12953)

PORTS #12953 - DO NOT SQUASH

Until .NET 5, `ComManagedStream` (then `GPStream`) would wrap a non-seekable stream in a `MemoryStream` using the `MemoryStream(Byte[])` constructor. This results in a stream with a position of 0.

dotnet/runtime commit 136527537e6 (Improve perfromance for loading from Stream on Windows (dotnet/corefx#31142), 2018-07-20) updated this logic to instead use `CopyTo` to populate the wrapping `MemoryStream`. This results in a stream with a non-zero position.

It seems that this non-zero position causes some issues in downstream code when using `Image.FromStream` to load `.emf` and `.wmf` files, resulting in `LoadGdipImageFromStream` returning a status of 2 and thus an exception.

Seek the wrapping `MemoryStream` back to the beginning after copying the source stream into it to prevent this exception.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12970)