### PR TITLE
Set stream copy position to beginning

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Internal/GPStream.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Internal/GPStream.cs
@@ -20,6 +20,7 @@ internal sealed partial class GPStream : Ole32.IStream
             // Copy to a memory stream so we can seek
             MemoryStream memoryStream = new MemoryStream();
             stream.CopyTo(memoryStream);
+            memoryStream.Position = 0;
             _dataStream = memoryStream;
         }
         else


### PR DESCRIPTION
This is a manual port of #12953. The code was refactored in .NET 9 so the fix needs manually applied.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12971)