### PR TITLE
Handle XAML data format

### DIFF
--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/Composition.NativeToManagedAdapter.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/Composition.NativeToManagedAdapter.cs
@@ -105,7 +105,7 @@ internal unsafe partial class Composition<TOleServices, TNrbfSerializer, TDataFo
             {
                 DataFormatNames.Text or DataFormatNames.Rtf or DataFormatNames.OemText =>
                     ReadStringFromHGLOBAL(hglobal, unicode: false),
-                DataFormatNames.Html => ReadUtf8StringFromHGLOBAL(hglobal),
+                DataFormatNames.Html or DataFormatNames.Xaml => ReadUtf8StringFromHGLOBAL(hglobal),
                 DataFormatNames.UnicodeText => ReadStringFromHGLOBAL(hglobal, unicode: true),
                 DataFormatNames.FileDrop => ReadFileListFromHDROP((HDROP)(nint)hglobal),
                 DataFormatNames.FileNameAnsi => new string[] { ReadStringFromHGLOBAL(hglobal, unicode: false) },

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/GlobalBuffer.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/GlobalBuffer.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using Windows.Win32.System.Memory;
+
+namespace System.Private.Windows.Ole;
+
+/// <summary>
+///  Simple scope for writing to HGLOBAL memory.
+/// </summary>
+internal unsafe ref struct GlobalBuffer
+{
+    private void* _pointer;
+    private Span<byte> _buffer;
+    private HGLOBAL _hglobal;
+
+    public GlobalBuffer(HGLOBAL hglobal, uint length)
+    {
+        if (hglobal.IsNull)
+        {
+            Status = HRESULT.E_INVALIDARG;
+            return;
+        }
+
+        _hglobal = PInvokeCore.GlobalReAlloc(
+            hglobal,
+            length,
+            (uint)GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE);
+
+        if (_hglobal.IsNull)
+        {
+            Status = HRESULT.E_OUTOFMEMORY;
+            return;
+        }
+
+        _pointer = PInvokeCore.GlobalLock(_hglobal);
+        if (_pointer is null)
+        {
+            Status = HRESULT.E_OUTOFMEMORY;
+        }
+
+        _buffer = new((byte*)_pointer, (int)length);
+    }
+
+    public HRESULT Status { get; private set; } = HRESULT.S_OK;
+    public readonly void* Pointer => _pointer;
+
+    public readonly Span<byte> AsSpan() => _buffer;
+
+    public readonly Span<char> AsCharSpan() => MemoryMarshal.Cast<byte, char>(_buffer);
+
+    public void Dispose()
+    {
+        if (!_hglobal.IsNull)
+        {
+            PInvokeCore.GlobalUnlock(_hglobal);
+            _buffer = default;
+            _pointer = null;
+            _hglobal = HGLOBAL.Null;
+        }
+    }
+}


### PR DESCRIPTION
Handle XAML data format.

For clarity, break helpers into three different text formats and add an HGLOBAL scope.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12975)