### PR TITLE
make it easier to run the test app in the dark mode if needed

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Program.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Program.cs
@@ -9,6 +9,10 @@ Thread.CurrentThread.SetApartmentState(ApartmentState.Unknown);
 Thread.CurrentThread.SetApartmentState(ApartmentState.STA);
 ApplicationConfiguration.Initialize();
 
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+Application.SetColorMode(SystemColorMode.Classic);
+#pragma warning restore WFO5001
+
 Application.SetUnhandledExceptionMode(UnhandledExceptionMode.ThrowException);
 Thread.CurrentThread.CurrentUICulture = Thread.CurrentThread.CurrentCulture;
 


### PR DESCRIPTION
Start the interactive test in the classic mode, but this is a reminder to test this app in the dark mode as well.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12980)