### PR TITLE
Add switch "NotifyUIAProviderTheText" to control screen Reader to announce the content of RichTextBox

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -26,6 +26,7 @@ internal static partial class LocalAppContextSwitches
     internal const string EnableMsoComponentManagerSwitchName = "Switch.System.Windows.Forms.EnableMsoComponentManager";
     internal const string TreeNodeCollectionAddRangeRespectsSortOrderSwitchName = "System.Windows.Forms.TreeNodeCollectionAddRangeRespectsSortOrder";
     internal const string MoveTreeViewTextLocationOnePixelSwitchName = "System.Windows.Forms.TreeView.MoveTreeViewTextLocationOnePixel";
+    internal const string NotifyUIAProviderTheTextSwitchName = "System.Windows.Forms.RichTextBox.NotifyUIAProviderTheText";
 
     private static int s_scaleTopLevelFormMinMaxSizeForDpi;
     private static int s_anchorLayoutV2;
@@ -37,8 +38,8 @@ internal static partial class LocalAppContextSwitches
     private static int s_noClientNotifications;
     private static int s_enableMsoComponentManager;
     private static int s_treeNodeCollectionAddRangeRespectsSortOrder;
-
     private static int s_moveTreeViewTextLocationOnePixel;
+    private static int s_notifyUIAProviderTheText;
 
     private static FrameworkName? s_targetFrameworkName;
 
@@ -230,5 +231,14 @@ internal static partial class LocalAppContextSwitches
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => GetCachedSwitchValue(MoveTreeViewTextLocationOnePixelSwitchName, ref s_moveTreeViewTextLocationOnePixel);
+    }
+
+    /// <summary>
+    ///  Indicates whether the text of the RichTextBox is sent to the UIA provider.
+    /// </summary>
+    public static bool NotifyUIAProviderTheText
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetCachedSwitchValue(NotifyUIAProviderTheTextSwitchName, ref s_notifyUIAProviderTheText);
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
@@ -2403,7 +2403,7 @@ public partial class RichTextBox : TextBoxBase
 
         // Use parent's accessible object because RichTextBox doesn't support UIA Providers, and its
         // AccessibilityObject doesn't get created even when assistive tech (e.g. Narrator) is used
-        if (Parent?.IsAccessibilityObjectCreated == true)
+        if (AppContextSwitches.NotifyUIAProviderTheText && Parent?.IsAccessibilityObjectCreated == true)
         {
             Parent.AccessibilityObject.InternalRaiseAutomationNotification(
                 Automation.AutomationNotificationKind.Other,

--- a/src/System.Windows.Forms/tests/TestUtilities/NotifyUIAProviderTheRichTextContent.cs
+++ b/src/System.Windows.Forms/tests/TestUtilities/NotifyUIAProviderTheRichTextContent.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Windows.Forms.Primitives;
+
+namespace System;
+
+/// <summary>
+///  Scope for enabling / disabling the NotifyUIAProviderTheText Switch.
+/// </summary>
+public readonly ref struct NotifyUIAProviderTheRichTextContent
+{
+    private readonly AppContextSwitchScope _switchScope;
+
+    public NotifyUIAProviderTheRichTextContent(bool enable)
+    {
+        // Prevent multiple NotifyUIAProviderTheRichTextContent from running simultaneously. Using Monitor to allow recursion on
+        // the same thread.
+        Monitor.Enter(typeof(NotifyUIAProviderTheRichTextContent));
+        _switchScope = new(WinFormsAppContextSwitchNames.NotifyUIAProviderTheText, GetDefaultValue, enable);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            _switchScope.Dispose();
+        }
+        finally
+        {
+            Monitor.Exit(typeof(NotifyUIAProviderTheRichTextContent));
+        }
+    }
+
+    public static bool GetDefaultValue() =>
+        typeof(LocalAppContextSwitches).TestAccessor()
+            .CreateDelegate<Func<string, bool>>("GetSwitchDefaultValue")(WinFormsAppContextSwitchNames.NotifyUIAProviderTheText);
+}

--- a/src/System.Windows.Forms/tests/TestUtilities/WinFormsAppContextSwitchNames.cs
+++ b/src/System.Windows.Forms/tests/TestUtilities/WinFormsAppContextSwitchNames.cs
@@ -50,4 +50,10 @@ public static class WinFormsAppContextSwitchNames
     /// </summary>
     public const string TreeNodeCollectionAddRangeRespectsSortOrder
         = "System.Windows.Forms.TreeNodeCollectionAddRangeRespectsSortOrder";
+
+    /// <summary>
+    ///  The switch that controls whether the text of the <see cref="Windows.Forms.RichTextBox" /> is sent to the UIA provider.
+    /// </summary>
+    public const string NotifyUIAProviderTheText
+        = "System.Windows.Forms.RichTextBox.NotifyUIAProviderTheText";
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
@@ -10594,6 +10594,7 @@ public partial class RichTextBoxTests
     [NewAndDefaultData<EventArgs>]
     public void RichTextBox_OnGotFocus_RaisesAutomationNotification_WithText(EventArgs eventArgs)
     {
+        using NotifyUIAProviderTheRichTextContent scope = new(enable: true);
         Mock<Control> mockParent = new() { CallBase = true };
         Mock<Control.ControlAccessibleObject> mockAccessibleObject = new(MockBehavior.Strict, mockParent.Object);
         mockAccessibleObject


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12772

## Proposed changes

- Add switch `System.Windows.Forms.RichTextBox.NotifyUIAProviderTheText` to control screen Reader to announce the content of RichTextBox

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- RichTextBox sends the currently focused line instead of its entire contents as an accessibility event on focus.

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
When NVDA get focus, the entire content gets read, not just the currently focused line
<img width="520" alt="image" src="https://github.com/user-attachments/assets/2a9042d3-c05a-4ceb-bf8e-f825f95db520" />

### After
When the switch is on, Narrator, JAWS and NVDA will read the full contents of the RichTextBox. 
When the switch is off, JAWS and NVDA will only read the contents of the currently focused line, while Narrator will not read the contents of the RichTextBox.
<img width="515" alt="image" src="https://github.com/user-attachments/assets/4f5362fe-df89-4366-88bb-303456150cbc" />

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-preview.2.25112.7

<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12986)