### PR TITLE
Issue 12830 multi target demo console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -308,6 +308,9 @@ paket-files/
 .idea/
 *.sln.iml
 
+# ClaudiaIDE extension
+.claudiaideconfig
+
 # CodeRush
 .cr/
 

--- a/Winforms.sln
+++ b/Winforms.sln
@@ -104,7 +104,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "interop", "interop", "{A31B
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DesignSurface", "DesignSurface", "{43E46506-7DF8-4E7A-A579-996CA43041EB}"
 	ProjectSection(SolutionItems) = preProject
-		src\test\integration\DesignSurface\.editorconfig = src\test\integration\DesignSurface\.editorconfig
+		src\test\integration\DesignSurface\README.md = src\test\integration\DesignSurface\README.md
+		src\test\integration\DesignSurface\Directory.Build.props = src\test\integration\DesignSurface\Directory.Build.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DemoConsole", "src\test\integration\DesignSurface\DemoConsole\DemoConsole.csproj", "{93310A19-DDCA-4BCD-AEDE-5C5D788DAFB4}"

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -61,7 +61,8 @@
     <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25209.3</MicrosoftDotNetXUnitExtensionsPackageVersion>
     <MicrosoftNETTestSdkVersion>17.4.0-preview-20220707-01</MicrosoftNETTestSdkVersion>
   </PropertyGroup>
-  <!-- Below have no corresponding entries in Versions.Details.XML because they are not updated via Maestro -->
+  <!-- Below have no corresponding entries in Versions.Details.XML because they are not updated via
+  Maestro -->
   <!-- XUnit-related (not extensions) -->
   <PropertyGroup>
     <XUnitVersion>2.9.2</XUnitVersion>
@@ -114,10 +115,10 @@
     <!-- Pin transitive dependency to avoid vulnerable 8.0.0 version. -->
     <SystemFormatsAsn1PackageVersion>8.0.1</SystemFormatsAsn1PackageVersion>
   </PropertyGroup>
-    
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net481'">
     <PackageReference Include="System.Collections.Immutable" VersionOverride="9.0.2" />
-    <PackageReference Include="System.Resources.Extensions" VersionOverride="5.0.0"/>
+    <PackageReference Include="System.Resources.Extensions" VersionOverride="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -61,8 +61,7 @@
     <MicrosoftDotNetXUnitExtensionsPackageVersion>10.0.0-beta.25209.3</MicrosoftDotNetXUnitExtensionsPackageVersion>
     <MicrosoftNETTestSdkVersion>17.4.0-preview-20220707-01</MicrosoftNETTestSdkVersion>
   </PropertyGroup>
-  <!-- Below have no corresponding entries in Versions.Details.XML because they are not updated via
-  Maestro -->
+  <!-- Below have no corresponding entries in Versions.Details.XML because they are not updated via Maestro -->
   <!-- XUnit-related (not extensions) -->
   <PropertyGroup>
     <XUnitVersion>2.9.2</XUnitVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -114,4 +114,10 @@
     <!-- Pin transitive dependency to avoid vulnerable 8.0.0 version. -->
     <SystemFormatsAsn1PackageVersion>8.0.1</SystemFormatsAsn1PackageVersion>
   </PropertyGroup>
+    
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="System.Collections.Immutable" VersionOverride="9.0.2" />
+    <PackageReference Include="System.Resources.Extensions" VersionOverride="5.0.0"/>
+  </ItemGroup>
+
 </Project>

--- a/src/test/integration/DesignSurface/DemoConsole/DemoConsole.csproj
+++ b/src/test/integration/DesignSurface/DemoConsole/DemoConsole.csproj
@@ -24,8 +24,7 @@
   <ItemGroup>
     <EmbeddedResource Update="Properties\Resources.resx" Generator="ResXFileCodeGenerator"
       LastGenOutput="Resources.Designer.cs" />
-    <Compile Update="Properties\Resources.Designer.cs" AutoGen="True" DependentUpon="Resources.resx"
-      DesignTime="True" />
+    <Compile Update="Properties\Resources.Designer.cs" AutoGen="True" DependentUpon="Resources.resx" DesignTime="True" />
   </ItemGroup>
 
   <ItemGroup>
@@ -36,13 +35,6 @@
     <None Update="painter.ico">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="..\README.md">
-      <Link>..\README.md</Link>
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-    </Content>
   </ItemGroup>
 
 </Project>

--- a/src/test/integration/DesignSurface/DemoConsole/DemoConsole.csproj
+++ b/src/test/integration/DesignSurface/DemoConsole/DemoConsole.csproj
@@ -38,4 +38,11 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="..\README.md">
+      <Link>..\README.md</Link>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/src/test/integration/DesignSurface/DemoConsole/DemoConsole.csproj
+++ b/src/test/integration/DesignSurface/DemoConsole/DemoConsole.csproj
@@ -6,38 +6,27 @@
     <ApplicationIcon>painter.ico</ApplicationIcon>
     <OutputType>WinExe</OutputType>
     <StartupObject />
-    <EnableXlfLocalization>false</EnableXlfLocalization>
-    <UpdateXlfOnBuild>false</UpdateXlfOnBuild>
-    <NoWarn>$(NoWarn);SA1633;CS8002</NoWarn>
     <Copyright>Copyright © Paolo Foti 2008</Copyright>
     <Company />
     <Authors>Paolo Foti</Authors>
     <PackageLicenseExpression>CPOL</PackageLicenseExpression>
     <PackageProjectUrl>https://www.codeproject.com/Articles/24385/Have-a-Great-DesignTime-Experience-with-a-Powerful</PackageProjectUrl>
-    <SuppressLicenseValidation>true</SuppressLicenseValidation>
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
-
-    <!-- Do not build this project when doing a .NET product build. -->
-    <!-- The files for this project have been removed from the .NET product due to licensing issues. -->
-    <ExcludeFromDotNetBuild>true</ExcludeFromDotNetBuild>
-    <IsTestUtilityProject>true</IsTestUtilityProject>
-    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Runtime.Serialization.Formatters" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\System.Drawing.Common\src\System.Drawing.Common.csproj" />
-    <ProjectReference Include="..\..\..\..\System.Windows.Forms.Design\src\System.Windows.Forms.Design.csproj" />
-    <ProjectReference Include="..\..\..\..\System.Windows.Forms\System.Windows.Forms.csproj" />
-    <ProjectReference Include="..\DesignSurfaceExt\DesignSurfaceExt.csproj" />
-  </ItemGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
+    <NoWarn>$(NoWarn)CS8002;CA1824</NoWarn>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
 
   <ItemGroup>
     <EmbeddedResource Update="Properties\Resources.resx" Generator="ResXFileCodeGenerator" LastGenOutput="Resources.Designer.cs" />
     <Compile Update="Properties\Resources.Designer.cs" AutoGen="True" DependentUpon="Resources.resx" DesignTime="True" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DesignSurfaceExt\DesignSurfaceExt.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/test/integration/DesignSurface/DemoConsole/DemoConsole.csproj
+++ b/src/test/integration/DesignSurface/DemoConsole/DemoConsole.csproj
@@ -10,19 +10,22 @@
     <Company />
     <Authors>Paolo Foti</Authors>
     <PackageLicenseExpression>CPOL</PackageLicenseExpression>
-    <PackageProjectUrl>https://www.codeproject.com/Articles/24385/Have-a-Great-DesignTime-Experience-with-a-Powerful</PackageProjectUrl>
+    <PackageProjectUrl>
+      https://www.codeproject.com/Articles/24385/Have-a-Great-DesignTime-Experience-with-a-Powerful</PackageProjectUrl>
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net481'">
     <NoWarn>$(NoWarn)CS8002;CA1824</NoWarn>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>
-    <EmbeddedResource Update="Properties\Resources.resx" Generator="ResXFileCodeGenerator" LastGenOutput="Resources.Designer.cs" />
-    <Compile Update="Properties\Resources.Designer.cs" AutoGen="True" DependentUpon="Resources.resx" DesignTime="True" />
+    <EmbeddedResource Update="Properties\Resources.resx" Generator="ResXFileCodeGenerator"
+      LastGenOutput="Resources.Designer.cs" />
+    <Compile Update="Properties\Resources.Designer.cs" AutoGen="True" DependentUpon="Resources.resx"
+      DesignTime="True" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/test/integration/DesignSurface/DemoConsole/MainForm.Designer.cs
+++ b/src/test/integration/DesignSurface/DemoConsole/MainForm.Designer.cs
@@ -298,7 +298,7 @@ partial class MainForm
         this.MainMenuStrip = this.menuStrip1;
         this.Margin = new System.Windows.Forms.Padding(4);
         this.Name = "MainForm";
-        this.Text = "Tiny Form Designer";
+        this.Text = "Tiny Form Designer - .NET";
         this.Load += this.MainForm_Load;
         this.splitContainer.Panel1.ResumeLayout(false);
         this.splitContainer.Panel2.ResumeLayout(false);

--- a/src/test/integration/DesignSurface/DemoConsole/MainForm.MyUserControl.cs
+++ b/src/test/integration/DesignSurface/DemoConsole/MainForm.MyUserControl.cs
@@ -5,6 +5,7 @@ namespace TestConsole;
 
 public partial class MainForm
 {
+    [DesignerCategory("Default")]
     internal class MyUserControl : UserControl
     {
         public MyUserControl()
@@ -40,7 +41,7 @@ public partial class MainForm
                 Size = new(30, 30)
             };
 
-            Controls.AddRange(textBox2, textBox1, textBox);
+            Controls.AddRange([textBox2, textBox1, textBox]);
         }
     }
 }

--- a/src/test/integration/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/test/integration/DesignSurface/DemoConsole/MainForm.cs
@@ -365,7 +365,7 @@ public partial class MainForm : Form
                         NumericUpDown numericUpDown = surface.CreateControl<NumericUpDown>(new(50, 10), new(10, 10));
                         panel.Controls.Add(numericUpDown);
 
-#if NETCOREAPP
+#if NETCOREAPP // A nested host is required for .NET Framework. See #11866 and https://github.com/dotnet/winforms/issues/13248#issuecomment-2803589449
                         BindingNavigator bindingNavigator = surface.CreateControl<BindingNavigator>(new(0, 0), new(0, 0));
 
                         BindingSource bindingSource = new()

--- a/src/test/integration/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/test/integration/DesignSurface/DemoConsole/MainForm.cs
@@ -383,25 +383,6 @@ public partial class MainForm : Form
 
                         panel.Controls.Add(bindingNavigator);
 #endif
-
-#if NETFRAMEWORK
-                        IDesignerHost designerHost = surface.GetIDesignerHost();
-                        DesignerActionService designerActionService = (DesignerActionService)designerHost.GetService(typeof(DesignerActionService));
-
-                        DesignerActionListCollection dataGridViewActionLists = designerActionService.GetComponentActions(toolStripContainer);
-
-                        foreach (DesignerActionList actionList in dataGridViewActionLists)
-                        {
-                            actionList.AutoShow = false;
-                        }
-
-                        DesignerActionListCollection toolStripContainerActionLists = designerActionService.GetComponentActions(toolStripContainer);
-
-                        foreach (DesignerActionList actionList in toolStripContainerActionLists)
-                        {
-                            actionList.AutoShow = false;
-                        }
-#endif
                     }
 
                     break;

--- a/src/test/integration/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/test/integration/DesignSurface/DemoConsole/MainForm.cs
@@ -13,6 +13,10 @@ public partial class MainForm : Form
     public MainForm()
     {
         InitializeComponent();
+
+#if !NETCOREAPP
+        Text = "Tiny Form Designer - .NET Framework";
+#endif
     }
 
     private void InitFormDesigner()

--- a/src/test/integration/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/test/integration/DesignSurface/DemoConsole/MainForm.cs
@@ -365,7 +365,10 @@ public partial class MainForm : Form
                         NumericUpDown numericUpDown = surface.CreateControl<NumericUpDown>(new(50, 10), new(10, 10));
                         panel.Controls.Add(numericUpDown);
 
-#if NETCOREAPP // A nested host is required for .NET Framework. See #11866 and https://github.com/dotnet/winforms/issues/13248#issuecomment-2803589449
+                        // A nested host is required for .NET Framework.
+                        // See https://github.com/dotnet/winforms/issues/11866#issuecomment-2673266564
+                        // and https://github.com/dotnet/winforms/issues/13248#issuecomment-2803589449
+#if NETCOREAPP
                         BindingNavigator bindingNavigator = surface.CreateControl<BindingNavigator>(new(0, 0), new(0, 0));
 
                         BindingSource bindingSource = new()

--- a/src/test/integration/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/test/integration/DesignSurface/DemoConsole/MainForm.cs
@@ -3,6 +3,7 @@
 
 namespace TestConsole;
 
+[DesignerCategory("Default")]
 public partial class MainForm : Form
 {
     private ISelectionService _selectionService;
@@ -264,6 +265,7 @@ public partial class MainForm : Form
                         rootComponent.Text = "Root Component hosted by the DesignSurface N.5";
 
                         surface.CreateControl<TabControl>(new Size(400, 100), new Point(12, 21));
+                        // See https://github.com/microsoft/winforms-designer/issues/2508
                         surface.CreateControl<TableLayoutPanel>(new Size(290, 160), new Point(20, 150));
                         surface.CreateControl<PropertyGrid>(new Size(200, 150), new Point(430, 23));
                         surface.CreateComponent<NotifyIcon>();
@@ -290,6 +292,7 @@ public partial class MainForm : Form
 
                         ToolStrip toolStrip1 = surface.CreateControl<ToolStrip>(new Size(400, 50), new Point(0, 0));
                         ToolStripButton toolStripButton1 = surface.CreateComponent<ToolStripButton>();
+                        // See https://github.com/dotnet/winforms/issues/13040
                         ToolStripDropDownButton toolStripDropDownButton1 = surface.CreateComponent<ToolStripDropDownButton>();
                         ToolStripTextBox toolStripTextBox = surface.CreateComponent<ToolStripTextBox>();
                         toolStrip1.Items.Add(toolStripButton1);
@@ -349,7 +352,7 @@ public partial class MainForm : Form
                         splitterPanel1.Controls.Add(richTextBox);
                         splitterPanel2.Controls.Add(scrollableControl);
 
-                        toolStripContainer.ContentPanel.Controls.AddRange(splitContainer);
+                        toolStripContainer.ContentPanel.Controls.Add(splitContainer);
 
                         Component component = surface.CreateComponent<Component>();
 
@@ -362,6 +365,7 @@ public partial class MainForm : Form
                         NumericUpDown numericUpDown = surface.CreateControl<NumericUpDown>(new(50, 10), new(10, 10));
                         panel.Controls.Add(numericUpDown);
 
+#if NETCOREAPP
                         BindingNavigator bindingNavigator = surface.CreateControl<BindingNavigator>(new(0, 0), new(0, 0));
 
                         BindingSource bindingSource = new()
@@ -375,6 +379,26 @@ public partial class MainForm : Form
                         richTextBox.DataBindings.Add(new Binding("Text", bindingSource, "Text", true, DataSourceUpdateMode.OnPropertyChanged));
 
                         panel.Controls.Add(bindingNavigator);
+#endif
+
+#if NETFRAMEWORK
+                        IDesignerHost designerHost = surface.GetIDesignerHost();
+                        DesignerActionService designerActionService = (DesignerActionService)designerHost.GetService(typeof(DesignerActionService));
+
+                        DesignerActionListCollection dataGridViewActionLists = designerActionService.GetComponentActions(toolStripContainer);
+
+                        foreach (DesignerActionList actionList in dataGridViewActionLists)
+                        {
+                            actionList.AutoShow = false;
+                        }
+
+                        DesignerActionListCollection toolStripContainerActionLists = designerActionService.GetComponentActions(toolStripContainer);
+
+                        foreach (DesignerActionList actionList in toolStripContainerActionLists)
+                        {
+                            actionList.AutoShow = false;
+                        }
+#endif
                     }
 
                     break;

--- a/src/test/integration/DesignSurface/DemoConsole/Properties/launchSettings.json
+++ b/src/test/integration/DesignSurface/DemoConsole/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "DemoConsole": {
+      "commandName": "Project",
+      "nativeDebugging": false
+    }
+  }
+}

--- a/src/test/integration/DesignSurface/DemoConsole/README.md
+++ b/src/test/integration/DesignSurface/DemoConsole/README.md
@@ -1,0 +1,56 @@
+# README 
+
+## Debugging Native Code in This Project
+
+To fully enable debugging in this project (including native code and symbol resolution), perform the following two steps:
+
+### 1. Enable Native Code Debugging
+
+This allows Visual Studio to step into native code
+
+**Option A – Using Visual Studio GUI:**
+
+1. Right-click the project in Solution Explorer and select **Properties**.
+2. Go to the **Debug** then **Open debug launch profiles UI**.
+3. Check the box **Enable native code debugging**.
+4. Save and rebuild the project.
+
+> This setting is saved in a user-specific `.csproj.user` file.
+
+**Option B – Editing `launchSettings.json`:**
+
+1. Open the file `Properties\launchSettings.json`.
+2. Under the `"profiles"` section, locate the profile matching your project name.
+3. Add or update the property `"nativeDebugging": true`.
+
+Example:
+
+```json 
+{
+  "profiles": {
+    "YourProjectName": {
+      "commandName": "Project",
+      "nativeDebugging": true
+    }
+  }
+}
+```
+
+---
+
+### 2. Configure Symbol Server for Native Debugging (Symweb)
+
+To resolve native symbols when stepping through native code, configure the Symweb server:
+
+1. Go to **Debug > Options** from the Visual Studio toolbar.
+2. In the left pane, select **Debugging > Symbols**.
+3. Under **Symbol file (.pdb) locations**, click the **➕** (plus) button.
+4. Enter the following URL:
+  ```
+  https://symweb
+  ```
+5. Press **Enter** or click **OK** to save.
+
+---
+
+After completing both steps above, Visual Studio will be able to debug both managed and native parts of the application, using symbols downloaded from Symweb as needed.

--- a/src/test/integration/DesignSurface/DesignSurfaceExt/DesignSurfaceExt.cs
+++ b/src/test/integration/DesignSurface/DesignSurfaceExt/DesignSurfaceExt.cs
@@ -211,7 +211,9 @@ public class DesignSurfaceExt : DesignSurface, IDesignSurfaceExt
 
             if (designer is IComponentInitializer initializer)
             {
-                initializer.InitializeNewComponent(null);
+                // This is to address a difference in nullability annotations between the .NET and NETFX
+                // See https://github.com/dotnet/winforms/pull/12996/#issuecomment-2765302289
+                initializer.InitializeNewComponent(new Dictionary<object, object>());
             }
 
             return (TComponent)newComp;

--- a/src/test/integration/DesignSurface/DesignSurfaceExt/DesignSurfaceExt.csproj
+++ b/src/test/integration/DesignSurface/DesignSurfaceExt/DesignSurfaceExt.csproj
@@ -3,32 +3,18 @@
   <PropertyGroup>
     <AssemblyName>DesignSurfaceExt</AssemblyName>
     <RootNamespace>DesignSurfaceExt</RootNamespace>
-    <EnableXlfLocalization>false</EnableXlfLocalization>
-    <UpdateXlfOnBuild>false</UpdateXlfOnBuild>
     <ApplicationIcon>dll.ico</ApplicationIcon>
-    <SignAssembly>false</SignAssembly>
 
-    <NoWarn>$(NoWarn),SA1633</NoWarn>
     <Copyright>Copyright © Paolo Foti 2008</Copyright>
     <Company />
     <Authors>Paolo Foti</Authors>
     <PackageLicenseExpression>CPOL</PackageLicenseExpression>
     <PackageProjectUrl>https://www.codeproject.com/Articles/24385/Have-a-Great-DesignTime-Experience-with-a-Powerful</PackageProjectUrl>
-
-    <SuppressLicenseValidation>true</SuppressLicenseValidation>
-
-    <!-- Do not build this project when doing a .NET product build. -->
-    <!-- The files for this project have been removed from the .NET product due to licensing issues. -->
-    <ExcludeFromDotNetBuild>true</ExcludeFromDotNetBuild>
-    <IsTestUtilityProject>true</IsTestUtilityProject>
-    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\System.Design\src\System.Design.Facade.csproj" />
-    <ProjectReference Include="..\..\..\..\System.Drawing.Design\src\System.Drawing.Design.Facade.csproj" />
-    <ProjectReference Include="..\..\..\..\System.Windows.Forms.Design\src\System.Windows.Forms.Design.csproj" />
-    <ProjectReference Include="..\..\..\..\System.Windows.Forms\System.Windows.Forms.csproj" />
-  </ItemGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
+    <SignAssembly>true</SignAssembly>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
 
 </Project>

--- a/src/test/integration/DesignSurface/DesignSurfaceExt/DesignSurfaceExt.csproj
+++ b/src/test/integration/DesignSurface/DesignSurfaceExt/DesignSurfaceExt.csproj
@@ -9,10 +9,11 @@
     <Company />
     <Authors>Paolo Foti</Authors>
     <PackageLicenseExpression>CPOL</PackageLicenseExpression>
-    <PackageProjectUrl>https://www.codeproject.com/Articles/24385/Have-a-Great-DesignTime-Experience-with-a-Powerful</PackageProjectUrl>
+    <PackageProjectUrl>
+      https://www.codeproject.com/Articles/24385/Have-a-Great-DesignTime-Experience-with-a-Powerful</PackageProjectUrl>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net481'">
     <SignAssembly>true</SignAssembly>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/src/test/integration/DesignSurface/DesignSurfaceExt/NameCreationServiceImp.cs
+++ b/src/test/integration/DesignSurface/DesignSurfaceExt/NameCreationServiceImp.cs
@@ -7,14 +7,14 @@ namespace DesignSurfaceExt;
 /// Implements <see cref="INameCreationService"/> to provide names for newly created controls.
 /// </summary>
 /// <remarks>
-/// <para>The <see cref="INameCreationService"/> interface is used to generate names for newly created controls.
-/// The <c>CreateName</c> method follows the same naming algorithm used by Visual Studio:
-/// it increments an integer counter until it finds a unique name that is not already in use.</para>
+///  <para>
+///   The <see cref="INameCreationService"/> interface is used to generate names for newly created controls.
+///   The <c>CreateName</c> method follows the same naming algorithm used by Visual Studio:
+///   it increments an integer counter until it finds a unique name that is not already in use.
+///  </para>
 /// </remarks>
 internal sealed class NameCreationServiceImp : INameCreationService
 {
-    public NameCreationServiceImp() { }
-
     public string CreateName(IContainer container, Type type)
     {
         if (container is null)
@@ -77,7 +77,7 @@ internal sealed class NameCreationServiceImp : INameCreationService
             return false;
 
         // - then the first character must be a letter
-        if (!(char.IsLetter(name, 0)))
+        if (!char.IsLetter(name, 0))
             return false;
 
         // - then don't allow a leading underscore
@@ -91,7 +91,7 @@ internal sealed class NameCreationServiceImp : INameCreationService
     public void ValidateName(string name)
     {
         // -  Use our existing method to check, if it's invalid throw an exception
-        if (!(IsValidName(name)))
+        if (!IsValidName(name))
             throw new ArgumentException($"Invalid name: {name}");
     }
 }

--- a/src/test/integration/DesignSurface/DesignSurfaceExt/NameCreationServiceImp.cs
+++ b/src/test/integration/DesignSurface/DesignSurfaceExt/NameCreationServiceImp.cs
@@ -1,12 +1,16 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// - NameCreationServiceImp - Implementing INameCreationService
-// - The INameCreationService interface is used to supply a name to the control just created
-// - In the CreateName() we use the same naming algorithm used by Visual Studio: just
-// - increment an integer counter until we find a name that isn't already in use.
 namespace DesignSurfaceExt;
 
+/// <summary>
+/// Implements <see cref="INameCreationService"/> to provide names for newly created controls.
+/// </summary>
+/// <remarks>
+/// <para>The <see cref="INameCreationService"/> interface is used to generate names for newly created controls.
+/// The <c>CreateName</c> method follows the same naming algorithm used by Visual Studio:
+/// it increments an integer counter until it finds a unique name that is not already in use.</para>
+/// </remarks>
 internal sealed class NameCreationServiceImp : INameCreationService
 {
     public NameCreationServiceImp() { }
@@ -32,7 +36,12 @@ internal sealed class NameCreationServiceImp : INameCreationService
                     count++;
                     try
                     {
-                        int value = int.Parse(name[type.Name.Length..]);
+                        int value;
+#if NETFRAMEWORK
+                        value = int.Parse(name.Substring(type.Name.Length));
+#elif NETCOREAPP
+                        value = int.Parse(name[type.Name.Length..]);
+#endif
                         if (value < min)
                             min = value;
                         if (value > max)
@@ -72,7 +81,7 @@ internal sealed class NameCreationServiceImp : INameCreationService
             return false;
 
         // - then don't allow a leading underscore
-        if (name.StartsWith('_'))
+        if (name[0] == '_')
             return false;
 
         // - ok, it's a valid name

--- a/src/test/integration/DesignSurface/Directory.Build.props
+++ b/src/test/integration/DesignSurface/Directory.Build.props
@@ -1,0 +1,51 @@
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <EnableXlfLocalization>false</EnableXlfLocalization>
+    <UpdateXlfOnBuild>false</UpdateXlfOnBuild>
+
+    <SuppressLicenseValidation>true</SuppressLicenseValidation>
+    <NoWarn>$(NoWarn);SA1633</NoWarn>
+
+    <!-- Do not build this project when doing a .NET product build. -->
+    <!-- The files for this project have been removed from the .NET product due to licensing issues. -->
+    <ExcludeFromDotNetBuild>true</ExcludeFromDotNetBuild>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
+    <TargetFrameworks>$(NetCurrent)-windows;net472</TargetFrameworks>
+    <!-- Unset TargetFramework as this property gets set in the repo's root. This is necessary to avoid over-building. -->
+    <TargetFramework />
+
+    <DefaultItemExcludes Condition="'$(TargetFramework)' != 'net472'">$(DefaultItemExcludes);**/Framework/*</DefaultItemExcludes>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
+    <!-- Include the Framework specific items as none so we can see them easily in the Solution Explorer. -->
+    <None Include="**/Framework/*"/>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == '$(NetCurrent)-windows'">
+    <PackageReference Include="System.Runtime.Serialization.Formatters" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == '$(NetCurrent)-windows'">
+    <ProjectReference Include="..\..\..\..\System.Design\src\System.Design.Facade.csproj" />
+    <ProjectReference Include="..\..\..\..\System.Drawing.Design\src\System.Drawing.Design.Facade.csproj" />
+    <ProjectReference Include="..\..\..\..\System.Windows.Forms.Design\src\System.Windows.Forms.Design.csproj" />
+    <ProjectReference Include="..\..\..\..\System.Windows.Forms\System.Windows.Forms.csproj" />
+    <ProjectReference Include="..\..\..\..\System.Drawing.Common\src\System.Drawing.Common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Design" />
+  </ItemGroup>
+
+</Project>

--- a/src/test/integration/DesignSurface/Directory.Build.props
+++ b/src/test/integration/DesignSurface/Directory.Build.props
@@ -19,20 +19,12 @@
     avoid over-building. -->
     <TargetFramework />
 
-    <DefaultItemExcludes Condition="'$(TargetFramework)' != 'net481'">
-      $(DefaultItemExcludes);**/Framework/*</DefaultItemExcludes>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net481'">
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'net481'">
-    <!-- Include the Framework specific items as none so we can see them easily in the Solution
-    Explorer. -->
-    <None Include="**/Framework/*" />
-  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetCurrent)-windows'">
     <PackageReference Include="System.Runtime.Serialization.Formatters" />

--- a/src/test/integration/DesignSurface/Directory.Build.props
+++ b/src/test/integration/DesignSurface/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
 
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  <Import
+    Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
     <EnableXlfLocalization>false</EnableXlfLocalization>
@@ -13,21 +14,24 @@
     <!-- The files for this project have been removed from the .NET product due to licensing issues. -->
     <ExcludeFromDotNetBuild>true</ExcludeFromDotNetBuild>
     <IsTestUtilityProject>true</IsTestUtilityProject>
-    <TargetFrameworks>$(NetCurrent)-windows;net472</TargetFrameworks>
-    <!-- Unset TargetFramework as this property gets set in the repo's root. This is necessary to avoid over-building. -->
+    <TargetFrameworks>$(NetCurrent)-windows;net481</TargetFrameworks>
+    <!-- Unset TargetFramework as this property gets set in the repo's root. This is necessary to
+    avoid over-building. -->
     <TargetFramework />
 
-    <DefaultItemExcludes Condition="'$(TargetFramework)' != 'net472'">$(DefaultItemExcludes);**/Framework/*</DefaultItemExcludes>
+    <DefaultItemExcludes Condition="'$(TargetFramework)' != 'net481'">
+      $(DefaultItemExcludes);**/Framework/*</DefaultItemExcludes>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net481'">
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
-    <!-- Include the Framework specific items as none so we can see them easily in the Solution Explorer. -->
-    <None Include="**/Framework/*"/>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net481'">
+    <!-- Include the Framework specific items as none so we can see them easily in the Solution
+    Explorer. -->
+    <None Include="**/Framework/*" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetCurrent)-windows'">
@@ -36,13 +40,15 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetCurrent)-windows'">
     <ProjectReference Include="..\..\..\..\System.Design\src\System.Design.Facade.csproj" />
-    <ProjectReference Include="..\..\..\..\System.Drawing.Design\src\System.Drawing.Design.Facade.csproj" />
-    <ProjectReference Include="..\..\..\..\System.Windows.Forms.Design\src\System.Windows.Forms.Design.csproj" />
+    <ProjectReference
+      Include="..\..\..\..\System.Drawing.Design\src\System.Drawing.Design.Facade.csproj" />
+    <ProjectReference
+      Include="..\..\..\..\System.Windows.Forms.Design\src\System.Windows.Forms.Design.csproj" />
     <ProjectReference Include="..\..\..\..\System.Windows.Forms\System.Windows.Forms.csproj" />
     <ProjectReference Include="..\..\..\..\System.Drawing.Common\src\System.Drawing.Common.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net481'">
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Design" />

--- a/src/test/integration/DesignSurface/README.md
+++ b/src/test/integration/DesignSurface/README.md
@@ -1,4 +1,9 @@
-# README 
+# DesignSurface (DemoConsole)
+
+- [Debugging Native Code in This Project](#debugging-native-code-in-this-project)
+  - [1. Enable Native Code Debugging](#1.-enable-native-code-debugging)
+  - [2. Configure Symbol Server for Native Debugging (Symweb)](<#2.-configure-symbol-server-for-native-debugging-(symweb)>)
+- [Running the Project Against .NET Framework](#running-the-project-against-.net-framework)
 
 ## Debugging Native Code in This Project
 
@@ -25,7 +30,7 @@ This allows Visual Studio to step into native code
 
 Example:
 
-```json 
+```json
 {
   "profiles": {
     "YourProjectName": {
@@ -46,11 +51,29 @@ To resolve native symbols when stepping through native code, configure the Symwe
 2. In the left pane, select **Debugging > Symbols**.
 3. Under **Symbol file (.pdb) locations**, click the **➕** (plus) button.
 4. Enter the following URL:
-  ```
-  https://symweb
-  ```
+
+```
+https://symweb
+```
+
 5. Press **Enter** or click **OK** to save.
 
 ---
 
 After completing both steps above, Visual Studio will be able to debug both managed and native parts of the application, using symbols downloaded from Symweb as needed.
+
+## Running the Project Against .NET Framework
+
+This project targets multiple frameworks, including .NET Framework 4.8.1. To run or debug it against the .NET Framework instead of .NET (e.g., net10.0-windows), follow the steps below:
+
+1. In Visual Studio, locate the Debug dropdown on the top toolbar (next to the green **Start** button).
+2. Click the small downward arrow next to the active configuration. You will see the currently selected framework (typically something like `Framework (net10.0-windows)`).
+3. Click the displayed framework name to open a submenu showing all target frameworks for this project.
+4. Select **net481** from the list.
+5. Build and run the project using any of the usual commands:
+   - **Build**: `Ctrl + Shift + B`
+   - **Start Without Debugging**: `Ctrl + F5`
+   - **Start With Debugging**: `F5`
+
+This configuration change ensures that Visual Studio builds and runs the project using the .NET Framework target.
+


### PR DESCRIPTION
Fixes #12830

## Proposed changes

- Updated `DemoConsole.csproj` and `DesignSurfaceExt.csproj` to support multiple target frameworks (`$(NetCurrent)-windows;net481`).
- Adjusted `TargetFramework` property to avoid over-building.
- Enabled `SignAssembly` and `GenerateAssemblyInfo` properties in the project files.
- Updated resource and reference handling in `DemoConsole.csproj` and `DesignSurfaceExt.csproj` to improve compatibility.
- Fixed `Controls.AddRange` usage to use the correct syntax in `MainForm.MyUserControl.cs`.
- Corrected `Controls.AddRange` call in `MainForm.cs` to `Controls.Add`.
- Suppressed `IDE0057` warning and reverted to `Substring` method for compatibility in `NameCreationServiceImp.cs`.
- Changed `StartsWith('_')` check by directly accessing the first character in `NameCreationServiceImp.cs` for compatibility.
- Disabled error `CA1824` for projects `DemoConsole` and `DesignSurficeExt`, because it would be triggered even though properly configured in those projects, according to the fix provided by the [documentation](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1824#fix-violations).

## Customer Impact

- None

## Regression?

- No

## Risk

- Minimal

## Screenshots

### Before

- `DemoConsole` would not run on `net481`.

### After

![image](https://github.com/user-attachments/assets/b414f156-42d1-4013-b572-8744c2596157)

## Test methodology

- Manual

## Test environment(s)

- 10.0.100-alpha.1.25077.2