### PR TITLE
fix issues#12941 Combox autocomplete list weird selection behaviour

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
@@ -2435,6 +2435,16 @@ public partial class ComboBox : ListControl
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     protected override void OnKeyDown(KeyEventArgs e)
     {
+        // for fix https://github.com/dotnet/winforms/issues/12941
+        char input = (char)e.KeyValue;
+        if ((AutoCompleteMode == AutoCompleteMode.Suggest || AutoCompleteMode == AutoCompleteMode.SuggestAppend) &&
+            !char.IsControl(input))
+        {
+            DroppedDown = false;
+        }
+
+        // End fix
+
         // Do Return/ESC handling
         if (SystemAutoCompleteEnabled)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
@@ -2435,7 +2435,7 @@ public partial class ComboBox : ListControl
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     protected override void OnKeyDown(KeyEventArgs e)
     {
-        // for fix https://github.com/dotnet/winforms/issues/12941
+        // For fix https://github.com/dotnet/winforms/issues/12941
         char input = (char)e.KeyValue;
         if ((AutoCompleteMode == AutoCompleteMode.Suggest || AutoCompleteMode == AutoCompleteMode.SuggestAppend) &&
             !char.IsControl(input))


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12941

## Proposed changes

- 
- when OnKeyDown is triggered, Hide dropdown properly.
- 

<!--  

## Customer Impact

- 

## Risk

-

-->
## Regression? 

-  No



<!--  -->


## Screenshots

### Before


https://github.com/user-attachments/assets/0508c7ce-6617-4265-a74b-87ed317149cc

### After


https://github.com/user-attachments/assets/8737b626-60e3-4dc0-b3eb-e6e9209de482


## Test methodology 

- 
- Manual
- 
<!-- 
## Accessibility testing  


 

## Test environment(s) 
-->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12999)