### PR TITLE
Move SetFileDropList to ClipboardCore

### DIFF
--- a/src/System.Private.Windows.Core/src/Resources/SR.resx
+++ b/src/System.Private.Windows.Core/src/Resources/SR.resx
@@ -170,4 +170,10 @@
   <data name="UnexpectedTypeForClipboardFormat" xml:space="preserve">
     <value>The specified Clipboard format is not compatible with '{0}' type.</value>
   </data>
+  <data name="CollectionEmptyException" xml:space="preserve">
+    <value>Cannot operate with an empty collection.</value>
+  </data>
+  <data name="Clipboard_InvalidPath" xml:space="preserve">
+    <value>Path "{0}" in the argument "{1}" is not valid.</value>
+  </data>
 </root>

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/ClipboardCore.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/ClipboardCore.cs
@@ -233,26 +233,8 @@ internal static unsafe class ClipboardCore<TOleServices>
 
     internal static void SetFileDropList(StringCollection filePaths)
     {
-        if (filePaths.OrThrowIfNull().Count == 0)
-        {
-            throw new ArgumentException(SR.CollectionEmptyException);
-        }
-
-        // Validate the paths to make sure they don't contain invalid characters
-        string[] filePathsArray = new string[filePaths.Count];
-        filePaths.CopyTo(filePathsArray, 0);
-
-        foreach (string path in filePathsArray)
-        {
-            // These are the only error states for Path.GetFullPath
-            if (string.IsNullOrEmpty(path) || path.Contains('\0'))
-            {
-                throw new ArgumentException(string.Format(SR.Clipboard_InvalidPath, path ?? "<null>", nameof(filePaths)));
-            }
-        }
-
         IComVisibleDataObject dataObject = TOleServices.CreateDataObject();
-        dataObject.SetData(DataFormatNames.FileDrop, autoConvert: true, filePathsArray);
+        dataObject.SetFileDropList(filePaths);
         SetData(dataObject, copy: true);
     }
 }

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/DataObjectExtensions.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/DataObjectExtensions.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Specialized;
+
+namespace System.Private.Windows.Ole;
+
+internal static class DataObjectExtensions
+{
+    internal static void SetFileDropList(this IComVisibleDataObject dataObject, StringCollection filePaths)
+    {
+        if (filePaths.OrThrowIfNull().Count == 0)
+        {
+            throw new ArgumentException(SR.CollectionEmptyException);
+        }
+
+        // Validate the paths to make sure they don't contain invalid characters
+        string[] filePathsArray = new string[filePaths.Count];
+        filePaths.CopyTo(filePathsArray, 0);
+
+        foreach (string path in filePathsArray)
+        {
+            // These are the only error states for Path.GetFullPath
+            if (string.IsNullOrEmpty(path) || path.Contains('\0'))
+            {
+                throw new ArgumentException(string.Format(SR.Clipboard_InvalidPath, path ?? "<null>", nameof(filePaths)));
+            }
+        }
+
+        dataObject.SetData(DataFormatNames.FileDrop, autoConvert: true, filePathsArray);
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
@@ -451,28 +451,8 @@ public static class Clipboard
     /// <summary>
     ///  Clears the Clipboard and then adds a collection of file names in the <see cref="DataFormats.FileDrop"/> format.
     /// </summary>
-    public static void SetFileDropList(StringCollection filePaths)
-    {
-        if (filePaths.OrThrowIfNull().Count == 0)
-        {
-            throw new ArgumentException(SR.CollectionEmptyException);
-        }
-
-        // Validate the paths to make sure they don't contain invalid characters
-        string[] filePathsArray = new string[filePaths.Count];
-        filePaths.CopyTo(filePathsArray, 0);
-
-        foreach (string path in filePathsArray)
-        {
-            // These are the only error states for Path.GetFullPath
-            if (string.IsNullOrEmpty(path) || path.Contains('\0'))
-            {
-                throw new ArgumentException(string.Format(SR.Clipboard_InvalidPath, path, nameof(filePaths)));
-            }
-        }
-
-        SetDataObject(new DataObject(DataFormatNames.FileDrop, autoConvert: true, filePathsArray), copy: true);
-    }
+    public static void SetFileDropList(StringCollection filePaths) =>
+        ClipboardCore.SetFileDropList(filePaths);
 
     /// <summary>
     ///  Clears the Clipboard and then adds an <see cref="Image"/> in the <see cref="DataFormats.Bitmap"/> format.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
@@ -246,7 +246,7 @@ public unsafe partial class DataObject :
     {
         string[] strings = new string[filePaths.OrThrowIfNull().Count];
         filePaths.CopyTo(strings, 0);
-        SetData(DataFormatNames.FileDrop, true, strings);
+        SetData(DataFormatNames.FileDrop, autoConvert: true, strings);
     }
 
     public virtual void SetImage(Image image) => SetData(DataFormatNames.Bitmap, true, image.OrThrowIfNull());


### PR DESCRIPTION
Implementation is the same with WPF.

Add a null check for formatting the ArgumentException. Removal of resources from SWF will happen in a later audit.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13016)