### PR TITLE
fix #12990 DisplayMember and ValueMember drop-down boxes cannot be expanded when None is selected for DataSource in DemoConsole application

### DIFF
--- a/src/System.Design/src/System.Design.Forwards.cs
+++ b/src/System.Design/src/System.Design.Forwards.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.BindingSourceDesigner))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ColumnHeaderCollectionEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.DataMemberFieldConverter))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.DataSourceConverter))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.DataMemberFieldEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.DataGridViewCellStyleEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.DataGridViewColumnTypeEditor))]

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataMemberFieldEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataMemberFieldEditor.cs
@@ -28,11 +28,6 @@ internal class DataMemberFieldEditor : UITypeEditor
 
         object? dataSource = property.GetValue(instance);
 
-        if (dataSource is null )
-        {
-            return value;
-        }
-
         _designBindingPicker ??= new();
 
         DesignBinding oldSelection = new DesignBinding(dataSource, (string?)value);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataSourceConverter.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataSourceConverter.cs
@@ -1,0 +1,116 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.ComponentModel;
+using System.Data;
+using System.Globalization;
+
+namespace System.Windows.Forms.Design;
+
+internal class DataSourceConverter : ReferenceConverter
+{
+    private readonly ReferenceConverter _listConverter = new ReferenceConverter(typeof(IList));
+
+    public DataSourceConverter() : base(typeof(IListSource))
+    {
+    }
+
+    public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext? context)
+    {
+        ArrayList listSources = new ArrayList(base.GetStandardValues(context));
+        StandardValuesCollection lists = _listConverter.GetStandardValues(context);
+
+        ArrayList listsList = [];
+
+        BindingSource? bs = context?.Instance as BindingSource;
+
+        foreach (object listSource in listSources)
+        {
+            if (listSource is not null)
+            {
+                // bug 46563: work around the TableMappings property on the OleDbDataAdapter
+                ListBindableAttribute? listBindable = TypeDescriptor.GetAttributes(listSource)[typeof(ListBindableAttribute)] as ListBindableAttribute;
+                if (listBindable is not null && !listBindable.ListBindable)
+                {
+                    continue;
+                }
+
+                // Prevent user from being able to connect a BindingSource to itself
+                if (bs is not null && bs == listSource)
+                {
+                    continue;
+                }
+
+                // Per Whidbey spec : DataSourcePicker.doc, 3.4.1
+                //
+                // if this is a DataTable and the DataSet that owns the table is in the list,
+                // don't add it.  this way we only show the top-level data sources and don't clutter the
+                // list with duplicates like:
+                //
+                //   NorthWind1.Customers
+                //   NorthWind1.Employees
+                //   NorthWind1
+                //
+                // but instead just show "NorthWind1".  This does force the user to pick a data member but helps
+                // with simplicity.
+                //
+                // we are doing an n^2 lookup here but this list will never be more than 10 or 15 entries long so it should
+                // not be a problem.
+                //
+                if (listSource is not DataTable listSourceDataTable || !listSources.Contains(listSourceDataTable.DataSet))
+                {
+                    listsList.Add(listSource);
+                }
+            }
+        }
+
+        foreach (object list in lists)
+        {
+            if (list is not null)
+            {
+                // bug 46563: work around the TableMappings property on the OleDbDataAdapter
+                ListBindableAttribute? listBindable = TypeDescriptor.GetAttributes(list)[typeof(ListBindableAttribute)] as ListBindableAttribute;
+                if (listBindable is not null && !listBindable.ListBindable)
+                {
+                    continue;
+                }
+
+                // Prevent user from being able to connect a BindingSource to itself
+                if (bs is not null && bs == list)
+                {
+                    continue;
+                }
+
+                listsList.Add(list);
+            }
+        }
+
+        // bug 71417: add a null list to reset the dataSource
+        listsList.Add(null);
+
+        return new StandardValuesCollection(listsList);
+    }
+
+    public override bool GetStandardValuesExclusive(ITypeDescriptorContext? context)
+    {
+        return true;
+    }
+
+    public override bool GetStandardValuesSupported(ITypeDescriptorContext? context)
+    {
+        return true;
+    }
+
+    public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
+    {
+        // Types are now valid data sources, so we need to be able to
+        // represent them as strings (since ReferenceConverter can't)
+        if (destinationType == typeof(string) && value is Type)
+        {
+            return value.ToString();
+        }
+
+        return base.ConvertTo(context, culture, value, destinationType);
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataSourceConverter.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataSourceConverter.cs
@@ -10,7 +10,7 @@ namespace System.Windows.Forms.Design;
 
 internal class DataSourceConverter : ReferenceConverter
 {
-    private readonly ReferenceConverter _listConverter = new ReferenceConverter(typeof(IList));
+    private readonly ReferenceConverter _listConverter = new(typeof(IList));
 
     public DataSourceConverter() : base(typeof(IListSource))
     {
@@ -18,12 +18,12 @@ internal class DataSourceConverter : ReferenceConverter
 
     public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext? context)
     {
-        ArrayList listSources = new ArrayList(base.GetStandardValues(context));
+        ArrayList listSources = new(base.GetStandardValues(context));
         StandardValuesCollection lists = _listConverter.GetStandardValues(context);
 
         ArrayList listsList = [];
 
-        BindingSource? bs = context?.Instance as BindingSource;
+        BindingSource? bindingSource = context?.Instance as BindingSource;
 
         foreach (object listSource in listSources)
         {
@@ -37,7 +37,7 @@ internal class DataSourceConverter : ReferenceConverter
                 }
 
                 // Prevent user from being able to connect a BindingSource to itself
-                if (bs is not null && bs == listSource)
+                if (bindingSource is not null && bindingSource == listSource)
                 {
                     continue;
                 }
@@ -77,7 +77,7 @@ internal class DataSourceConverter : ReferenceConverter
                 }
 
                 // Prevent user from being able to connect a BindingSource to itself
-                if (bs is not null && bs == list)
+                if (bindingSource is not null && bindingSource == list)
                 {
                     continue;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListControl/ListControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListControl/ListControl.cs
@@ -42,6 +42,7 @@ public abstract class ListControl : Control
     [SRCategory(nameof(SR.CatData))]
     [DefaultValue(null)]
     [RefreshProperties(RefreshProperties.Repaint)]
+    [TypeConverter($"System.Windows.Forms.Design.DataSourceConverter, {Assemblies.SystemDesign}")]
     [AttributeProvider(typeof(IListSource))]
     [SRDescription(nameof(SR.ListControlDataSourceDescr))]
     public object? DataSource


### PR DESCRIPTION


Fixes #12990 


## Proposed changes

- Add DataSourceConverter
- fix DataMemberFieldEditor.EditValue method, don't return when DataSource is null
- 



## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

https://github.com/user-attachments/assets/5795cee9-d105-461a-8a8a-7b43ab91b510

1. There also should be a **(none)** displayed in Datasource property when None is selected. 
![Image](https://github.com/user-attachments/assets/3fb69000-65e8-4fa4-aa6c-a42552fb14f6)
2. The issue also repro in DataGridViewColumn.
![Image](https://github.com/user-attachments/assets/0a1abc17-5bb9-4200-bc59-815e92980ce0)

### After


https://github.com/user-attachments/assets/b239e552-5ea8-4893-afe3-6add02b1773b




## Test methodology 

- 
- manual 
- 
<!--
## Accessibility testing  


## Test environment(s) 


  -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13019)