### PR TITLE
Fixed operation and display issues related to ToolStrip and ToolStripItemEditorForm in demoConsole

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripCollectionEditor.ToolStripItemEditorForm.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripCollectionEditor.ToolStripItemEditorForm.cs
@@ -802,7 +802,7 @@ internal partial class ToolStripCollectionEditor
         private void OnListBoxItems_SelectedIndexChanged(object sender, EventArgs e)
         {
             // Push the items into the grid.
-            object[] selectedItems = [_listBoxItems.SelectedItems.Count];
+            object[] selectedItems = new object[_listBoxItems.SelectedItems.Count];
             if (selectedItems.Length > 0)
             {
                 _listBoxItems.SelectedItems.CopyTo(selectedItems, 0);
@@ -816,7 +816,7 @@ internal partial class ToolStripCollectionEditor
                 {
                     _toolStripCustomTypeDescriptor ??= new(toolStrip);
 
-                    _selectedItemProps.SelectedObjects = [_toolStripCustomTypeDescriptor];
+                    _selectedItemProps.SelectedObjects = new[] { _toolStripCustomTypeDescriptor };
                 }
                 else
                 {

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
@@ -289,9 +289,9 @@ public partial class MainForm : Form
                         toolStripContainer.Dock = DockStyle.Fill;
 
                         ToolStrip toolStrip1 = surface.CreateControl<ToolStrip>(new Size(400, 50), new Point(0, 0));
-                        ToolStripButton toolStripButton1 = new("toolStripButton1");
-                        ToolStripDropDownButton toolStripDropDownButton1 = new("toolStripDropDownButton1");
-                        ToolStripTextBox toolStripTextBox= new("toolStripTextBox");
+                        ToolStripButton toolStripButton1 = surface.CreateComponent<ToolStripButton>();
+                        ToolStripDropDownButton toolStripDropDownButton1 = surface.CreateComponent<ToolStripDropDownButton>();
+                        ToolStripTextBox toolStripTextBox = surface.CreateComponent<ToolStripTextBox>();
                         toolStrip1.Items.Add(toolStripButton1);
                         toolStrip1.Items.Add(toolStripDropDownButton1);
                         toolStrip1.Items.Add(toolStripTextBox);
@@ -299,18 +299,22 @@ public partial class MainForm : Form
                         MenuStrip menuStrip1 = surface.CreateControl<MenuStrip>(new Size(400, 50), new Point(0, 60));
                         MenuStrip menuStrip2 = surface.CreateControl<MenuStrip>(new Size(400, 50), new Point(0, 150));
 
-                        ToolStripMenuItem toolStripMenuItem1 = new("TopMenuItem1");
-                        ToolStripMenuItem toolStripMenuItem2 = new("TopMenuItem2");
-                        ToolStripMenuItem menu1 = new("BottomMenuItem1");
-                        ToolStripMenuItem menuNew1 = new("BottomMenuItem2");
+                        ToolStripMenuItem topMenuItem1 = surface.CreateComponent<ToolStripMenuItem>();
+                        topMenuItem1.Text = "TopMenuItem1";
+                        ToolStripMenuItem topMenuItem2 = surface.CreateComponent<ToolStripMenuItem>();
+                        topMenuItem2.Text = "TopMenuItem2";
+                        ToolStripMenuItem bottomMenuItem1 = surface.CreateComponent<ToolStripMenuItem>();
+                        bottomMenuItem1.Text = "BottomMenuItem1";
+                        ToolStripMenuItem bottomMenuItem2 = surface.CreateComponent<ToolStripMenuItem>();
+                        bottomMenuItem2.Text = "BottomMenuItem1";
 
-                        menuStrip1.Items.Add(toolStripMenuItem1);
-                        menuStrip1.Items.Add(toolStripMenuItem2);
-                        menuStrip2.Items.Add(menu1);
-                        menuStrip2.Items.Add(menuNew1);
+                        menuStrip1.Items.Add(topMenuItem1);
+                        menuStrip1.Items.Add(topMenuItem2);
+                        menuStrip2.Items.Add(bottomMenuItem1);
+                        menuStrip2.Items.Add(bottomMenuItem2);
 
-                        toolStripMenuItem1.DropDownItems.Add("DropDownItem1");
-                        toolStripMenuItem2.DropDownItems.Add("DropDownItem12");
+                        topMenuItem1.DropDownItems.Add("DropDownItem1");
+                        topMenuItem2.DropDownItems.Add("DropDownItem12");
 
                         ToolStripPanel topToolStripPanel = surface.CreateControl<ToolStripPanel>(new(50, 50), new(0, 0));
                         topToolStripPanel = toolStripContainer.TopToolStripPanel;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12988,  #12989, #13000


## Proposed changes

- Use `surface.CreateComponent<ToolStripButton>` to initialize `ToolStripItem` and `ToolStripMenuItem` components in DemoConsole project
- In the method `OnListBoxItems_SelectedIndexChanged` , use `new object[]` to correctly initialize an array of type object 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Operations in the Items Collection Editor can be successfully executed

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

- The text is not correct in the default added Items Collection Editor dialog for MenuStrip control
- After adding two items to the MenuStrip/ToolStrip project and clicking cancel, all items will disappear
- Selecting two items at the same time in the MenuStrip/ToolStrip will result in an error

![BeforeChanges](https://github.com/user-attachments/assets/d314ccae-b472-4252-8c41-1dd380c6ce3f)

### After
![AfterChange](https://github.com/user-attachments/assets/e390df4f-e98c-4d83-bc06-def3e6a3ed31)


## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- 10.0.0-preview.2.25119.7


<!-- Mention language, UI scaling, or anything else that might be relevant -->
