### PR TITLE
Experimenting with a different image to run CI on

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,8 @@ extends:
         name: NetCore1ESPool-Svc-Internal
       ${{ else }}:
         name: NetCore1ESPool-Internal
-      image: 1es-windows-2022
+# image is described here - https://helix.dot.net/#1ESHostedPoolImagesWestUS-rg-Internal
+      image: windows.vs2022preview.amd64
       os: windows
     customBuildTags:
     - ES365AIMigrationTooling

--- a/eng/common/core-templates/job/onelocbuild.yml
+++ b/eng/common/core-templates/job/onelocbuild.yml
@@ -58,7 +58,7 @@ jobs:
       # If it's not devdiv, it's dnceng
       ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
         name: $(DncEngInternalBuildPool)
-        image: 1es-windows-2022
+        image: windows.vs2022preview.amd64
         os: windows
 
   steps:

--- a/eng/common/core-templates/post-build/post-build.yml
+++ b/eng/common/core-templates/post-build/post-build.yml
@@ -166,7 +166,7 @@ stages:
         ${{ else }}:
           ${{ if eq(parameters.is1ESPipeline, true) }}:        
             name: $(DncEngInternalBuildPool)
-            image: 1es-windows-2022
+            image: windows.vs2022preview.amd64
             os: windows
           ${{ else }}:
             name: $(DncEngInternalBuildPool)
@@ -230,7 +230,7 @@ stages:
         ${{ else }}:
           ${{ if eq(parameters.is1ESPipeline, true) }}:          
             name: $(DncEngInternalBuildPool)
-            image: 1es-windows-2022
+            image: windows.vs2022preview.amd64
             os: windows
           ${{ else }}:
             name: $(DncEngInternalBuildPool)

--- a/eng/common/templates-official/variables/pool-providers.yml
+++ b/eng/common/templates-official/variables/pool-providers.yml
@@ -23,7 +23,7 @@
 #
 #        pool:
 #           name: $(DncEngInternalBuildPool)
-#           image: 1es-windows-2022
+#           image: windows.vs2022preview.amd64
 
 variables:
   # Coalesce the target and source branches so we know when a PR targets a release branch

--- a/eng/pipelines/azure-pipelines-codeql.yml
+++ b/eng/pipelines/azure-pipelines-codeql.yml
@@ -43,7 +43,7 @@ jobs:
   displayName: CodeQL
   pool:
     name: $(DncEngInternalBuildPool)
-    demands: ImageOverride -equals 1es-windows-2022
+    demands: ImageOverride -equals windows.vs2022preview.amd64
   timeoutInMinutes: 90
 
   steps:


### PR DESCRIPTION
Change: update 1es-windows-2022 to windows.vs2022preview.amd64 in order to get a newer version of the VS on the CI machines

The same test on AzDO - https://dnceng.visualstudio.com/internal/_build/results?buildId=2650564&view=results

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13025)