### PR TITLE
Run CI build on a more up-to-date image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,8 @@ extends:
         name: NetCore1ESPool-Svc-Internal
       ${{ else }}:
         name: NetCore1ESPool-Internal
-      image: 1es-windows-2022
+# image is described here - https://helix.dot.net/#1ESHostedPoolImagesWestUS-rg-Internal
+      image: windows.vs2022preview.amd64
       os: windows
     customBuildTags:
     - ES365AIMigrationTooling
@@ -125,7 +126,7 @@ extends:
             binlogPath: msbuild.binlog
             pool:
               name: $(DncEngInternalBuildPool)
-              demands: ImageOverride -equals 1es-windows-2022
+              demands: ImageOverride -equals windows.vs2022preview.amd64
 
     - ${{ if eq(variables['EnableLoc'], 'true') }}:
       - stage: OneLocBuild

--- a/eng/pipelines/azure-pipelines-codeql.yml
+++ b/eng/pipelines/azure-pipelines-codeql.yml
@@ -43,7 +43,7 @@ jobs:
   displayName: CodeQL
   pool:
     name: $(DncEngInternalBuildPool)
-    demands: ImageOverride -equals 1es-windows-2022
+    demands: ImageOverride -equals windows.vs2022preview.amd64
   timeoutInMinutes: 90
 
   steps:


### PR DESCRIPTION
update 1es-windows-2022 to windows.vs2022preview.amd64 in order to get a newer version of the VS on the CI machines

Tests
CI - https://dev.azure.com/dnceng/internal/_build/results?buildId=2650725&view=results
CodeQL - https://dev.azure.com/dnceng/internal/_build/results?buildId=2650655&view=results



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13026)