### PR TITLE
Fixes a potential null reference exception in the `DataGridViewDesigner`, preventing unexpected crashes.

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewDesigner.cs
@@ -822,7 +822,7 @@ internal class DataGridViewDesigner : ControlDesigner
                 nameof(DataSource),
                 SR.DataGridViewChooseDataSource)
             {
-                RelatedComponent = _owner.Component
+                RelatedComponent = _owner.HasComponent ? _owner.Component : null
             };
 
             items.Add(chooseDataSource);


### PR DESCRIPTION
Fixes #12889

## Root Cause

- The `RelatedComponent` property was being assigned directly from `_owner.Component` without checking if `_owner` was initialized. This could lead to a null reference issue.

## Proposed changes

- Added a null check on `_owner` using `HasComponent` before accessing `_owner.Component`.

## Customer Impact

- Fixes a potential null reference exception in the `DataGridViewDesigner`, preventing unexpected crashes.

## Regression?

- No

## Risk

- Minimal

## Screenshots

### Before
![before](https://github.com/user-attachments/assets/32c79c30-738e-4bd4-b978-dcad03d9663e)

### After

![after](https://github.com/user-attachments/assets/dac1d3d2-c45e-4736-bca4-e747608e0a1e)

## Test methodology

- Manual testing

## Test environment(s)

- 10.0.100-preview.3.25122.1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13027)