### PR TITLE
fix #12916 Cannot use down to expand ToolStripDropDownButton in toolStrip2 after using right/Left to collapse ToolStripDropDownButton in toolStrip1

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
@@ -4578,6 +4578,9 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
         if (m.MsgInternal == PInvokeCore.WM_SETFOCUS)
         {
             SnapFocus((HWND)(nint)m.WParamInternal);
+
+            // For fix https://github.com/dotnet/winforms/issues/12916
+            ToolStripManager.ModalMenuFilter.SetActiveToolStrip(this);
         }
 
         if (!AllowClickThrough && m.MsgInternal == PInvokeCore.WM_MOUSEACTIVATE)


### PR DESCRIPTION
Fixes #12916 

## Root cause
When we use Tab key to focus on second ToolStrip and then press down key, ProcessCmdKey method get triggered, but the event owner isn't right, it should have been toolStrip2 not toolStrip1.
![image](https://github.com/user-attachments/assets/4cc2773f-2c46-43e0-80b0-d0af138a148d)

## Proposed changes

- 
- Set Active ToolStrip when ToolStrip get  focused.
- 

<!--
## Customer Impact

- 

## Regression? 

- Yes / No

## Risk

-
-->

## Screenshots 

### Before

![Image](https://github.com/user-attachments/assets/0c9769fe-2835-4ba9-8c95-ed8b35845e2c)

![Image](https://github.com/user-attachments/assets/5bbb8368-3e48-45e4-a3e1-153c35d474de)

### After


![12916_02](https://github.com/user-attachments/assets/aa260595-e049-466c-9077-6013f717cb53)


## Test methodology 

- 
- manually 
- 
<!--
## Accessibility testing  

## Test environment(s) 

-->
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13034)