### PR TITLE
Add a new TypeConverter for `ToolStripMenuItem.ShortcutKeys` that does not provide standard items

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
@@ -3131,7 +3131,10 @@ internal sealed partial class PropertyGridView :
 
         // Should this only work if the Edit has focus?
         // We use the mouse wheel to change the values in the dropdown if it's an enumerable value.
-        if (_selectedGridEntry is not null && _selectedGridEntry.Enumerable && EditTextBox.Focused && _selectedGridEntry.IsValueEditable)
+        if (_selectedGridEntry is not null
+            && _selectedGridEntry.Enumerable
+            && EditTextBox.Focused
+            && _selectedGridEntry.IsValueEditable)
         {
             int index = GetCurrentValueIndex(_selectedGridEntry);
             if (index != -1)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ShortcutKeysConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ShortcutKeysConverter.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+
+namespace System.Windows.Forms;
+
+/// <summary>
+///  Provides a type converter to convert <see cref="Keys"/> objects to and from strings.
+/// </summary>
+internal class ShortcutKeysConverter : KeysConverter
+{
+    public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext? context) =>
+        new StandardValuesCollection(Array.Empty<object>());
+
+    /// <summary>
+    ///  Shortcuts do not have standard values, they are combinations of alphanumeric keys with modifiers.
+    /// </summary>
+    public override bool GetStandardValuesSupported(ITypeDescriptorContext? context) => false;
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
@@ -354,6 +354,7 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
     [Localizable(true)]
     [DefaultValue(Keys.None)]
     [SRDescription(nameof(SR.MenuItemShortCutDescr))]
+    [TypeConverter(typeof(ShortcutKeysConverter))]
     public Keys ShortcutKeys
     {
         get => Properties.GetValueOrDefault(s_propShortcutKeys, Keys.None);
@@ -398,7 +399,7 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
             {
                 if (GetCurrentParentDropDown() is ToolStripDropDownMenu parent)
                 {
-                    LayoutTransaction.DoLayout(ParentInternal, this, "ShortcutKeys");
+                    LayoutTransaction.DoLayout(ParentInternal, this, nameof(ShortcutKeys));
                     parent.AdjustSize();
                 }
             }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyGridView.DropDownHolderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyGridView.DropDownHolderTests.cs
@@ -9,7 +9,7 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests;
 public class PropertyGridView_DropDownHolderTests
 {
     [WinFormsFact]
-    public void DropDownHolder_AccessibilityObject_Constructor_initializes_correctly()
+    public void DropDownHolder_Constructor_initializes_correctly()
     {
         using PropertyGridView propertyGridView = new(null, null);
         propertyGridView.BackColor = Color.Green;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ShortcutKeysConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ShortcutKeysConverterTests.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+
+namespace System.Windows.Forms.Tests;
+
+public class ShortcutKeysConverterTests
+{
+    [Fact]
+    public void GetStandardValues_ShouldReturnEmptyCollection()
+    {
+        ShortcutKeysConverter converter = new();
+        var values = converter.GetStandardValues(null).Should().BeOfType<TypeConverter.StandardValuesCollection>().Subject;
+        values.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void GetStandardValuesSupported_ShouldReturnFalse()
+    {
+        ShortcutKeysConverter converter = new();
+        converter.GetStandardValuesSupported(null).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/winforms/issues/12982

## Proposed changes

`ToolStripMenuItem.ShortcutKeys` property type (Keys enum) has a TypeConverter that reports that it has a set of standard values. This is not entirely accurate. `Keys` type has a set of standard values, but the `ShortcutKeys` property does not, even the ShortcutKeys type contains different key combinations from what can be generated by the shortcut key editor. Shortcuts are combinations of keys and modifiers, it's not practical to present all combinations for user to step through with up/down keys or with mouse wheel. To disable this behavior, we need to add a new TypeConverter that does not provide standard values.
I would like to add a new TypeConverter to this property. `KeysConverter` is defined on the Keys enum, the property does not have one right now. TypeDescriptor prioretizes attributese defined on properties over those defined on property types. This change is "borderline" allowed depending on whether this is considered a changed attribute or a new one https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/breaking-change-rules.md#attributes.

We don't have any other public instance properties of type Keys.

This behavior regressed when we added Keys.None value to the list of standard values - https://github.com/dotnet/winforms/pull/8401. This was done to localize "None" (as "(none)") in the property grid. When the current value of the shortcut is not one of the standard values, property grid entry does not enter the "scroll through the standard items" functionality. This is a beneficial change, I'd prefer to keep it.


https://github.com/user-attachments/assets/3aad563a-b452-4666-99ca-3ed6b51426f0



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13039)