### PR TITLE
Related #12830.  Sets `DesignerSerializationVisibility` to `Hidden` in `PropertyGridExt.DesignerHost`

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/PropertyGridExt.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/PropertyGridExt.cs
@@ -33,6 +33,7 @@ public class PropertyGridExt : PropertyGrid
         base.Dispose(disposing);
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public IDesignerHost DesignerHost
     {
         get


### PR DESCRIPTION
- Sets `DesignerSerializationVisibility` to `Hidden` in `PropertyGridExt.DesignerHost`

- None

- No

- Minimal

- Manual

- 10.0.100-preview.3.25125.5

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13043)