### PR TITLE
Add flush helper to ClipboardCore

### DIFF
--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/ClipboardCore.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/ClipboardCore.cs
@@ -49,6 +49,32 @@ internal static unsafe class ClipboardCore<TOleServices>
     }
 
     /// <summary>
+    ///  Flushes data to the Clipboard.
+    /// </summary>
+    /// <returns>An <see cref="HRESULT"/> indicating the success or failure of the operation.</returns>
+    internal static HRESULT Flush(
+        int retryTimes = OleRetryCount,
+        int retryDelay = OleRetryDelay)
+    {
+        TOleServices.EnsureThreadState();
+
+        HRESULT result;
+        int retryCount = retryTimes;
+
+        while ((result = TOleServices.OleFlushClipboard()).Failed)
+        {
+            if (--retryCount < 0)
+            {
+                break;
+            }
+
+            Thread.Sleep(millisecondsTimeout: retryDelay);
+        }
+
+        return result;
+    }
+
+    /// <summary>
     ///  Attempts to set the specified data on the Clipboard.
     /// </summary>
     /// <param name="dataObject">The data object to set on the Clipboard.</param>
@@ -104,7 +130,8 @@ internal static unsafe class ClipboardCore<TOleServices>
     /// <param name="proxyDataObject">The proxy data object retrieved from the Clipboard.</param>
     /// <param name="originalObject">The original object retrieved from the Clipboard, if available.</param>
     /// <returns>An <see cref="HRESULT"/> indicating the success or failure of the operation.</returns>
-    public static HRESULT TryGetData(
+    /// <inheritdoc cref="SetData(IComVisibleDataObject, bool, int, int)"/>
+    internal static HRESULT TryGetData(
         out ComScope<IDataObject> proxyDataObject,
         out object? originalObject,
         int retryTimes = OleRetryCount,
@@ -144,6 +171,38 @@ internal static unsafe class ClipboardCore<TOleServices>
         }
 
         return result;
+    }
+
+    /// <summary>
+    ///  Returns true if the given <paramref name="object"/> is currently on the Clipboard.
+    /// </summary>
+    /// <remarks>
+    ///  <para>This is meant to emulate the OleIsCurrentClipboard API.</para>
+    /// </remarks>
+    /// <param name="object">The object to check.</param>
+    /// <returns>'true' if <paramref name="object"/> is currently on the Clipboard.</returns>
+    /// <inheritdoc cref="SetData(IComVisibleDataObject, bool, int, int)"/>
+    internal static bool IsObjectOnClipboard(
+        object @object,
+        int retryTimes = OleRetryCount,
+        int retryDelay = OleRetryDelay)
+    {
+        if (@object is null)
+        {
+            return false;
+        }
+
+        HRESULT result = TryGetData(
+            out ComScope<IDataObject> proxyDataObject,
+            out object? originalObject,
+            retryTimes,
+            retryDelay);
+
+        // Need to ensure we release the ref count on the proxy object.
+        using (proxyDataObject)
+        {
+            return result.Succeeded && @object == originalObject;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Adds a flush helper (this is a public API in WPF). Tweaks some code in WinFormsOleServices for better clarity and error state handling.

Also adds a helper to check if a given object is on the clipboard.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13049)