### PR TITLE
Resizes `DemoConsole` project's `MainForm` for convenience and to make everything visible in the surface designer

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.Designer.cs
@@ -291,7 +291,7 @@ partial class MainForm
         // 
         this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
         this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-        this.ClientSize = new System.Drawing.Size(824, 530);
+        this.ClientSize = new System.Drawing.Size(1500, 915);
         this.Controls.Add(this.splitContainer);
         this.Controls.Add(this.menuStrip1);
         this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));


### PR DESCRIPTION
## Proposed changes

- Resizes `DemoConsole` project's `MainForm` for convenience and to make everything visible in the surface designer.

## Customer Impact

- None

## Regression?

- No

## Risk

- Minimal

## Screenshots

### Before
![before](https://github.com/user-attachments/assets/3128be74-76e1-4e3a-a8f5-a9a21a40afa2)

### After
![after](https://github.com/user-attachments/assets/9f81b14d-23f7-434a-85bb-1f2452e41e74)

## Test methodology

- Manual

## Test environment(s)

- 10.0.100-preview.3.25125.5

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13050)