### PR TITLE
Remove autoconvert from SetDataAsJson

### DIFF
--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/Composition.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/Composition.cs
@@ -100,7 +100,6 @@ internal sealed unsafe partial class Composition<TOleServices, TNrbfSerializer, 
     ///  Stores the data in the specified format using the <see cref="JsonSerializer"/>.
     /// </summary>
     /// <param name="format">The format associated with the data. See DataFormats for predefined formats.</param>
-    /// <param name="autoConvert"><see langword="true"/> to allow the data to be converted to another format; otherwise, <see langword="false"/>.</param>
     /// <param name="data">The data to store.</param>
     /// <remarks>
     ///  <para>
@@ -122,13 +121,13 @@ internal sealed unsafe partial class Composition<TOleServices, TNrbfSerializer, 
     /// </remarks>
     /// <inheritdoc cref="DataObjectCore{TDataObject}.TryJsonSerialize{T}(string, T)"/>
     [RequiresUnreferencedCode("Uses default System.Text.Json behavior which is not trim-compatible.")]
-    public void SetDataAsJson<T, TDataObject>(T data, string? format = default, bool autoConvert = true)
+    public void SetDataAsJson<T, TDataObject>(T data, string? format = default)
         where TDataObject : IComVisibleDataObject
     {
         format ??= typeof(T).FullName.OrThrowIfNull();
         SetData(
             format,
-            autoConvert,
+            autoConvert: false,
             DataObjectCore<TDataObject>.TryJsonSerialize(format, data));
     }
 

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/IDataObjectInternal.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/IDataObjectInternal.cs
@@ -166,5 +166,30 @@ internal unsafe interface IDataObjectInternal<TDataObject, TIDataObject> : IData
     static abstract TDataObject Create(object data);
     static abstract IDataObjectInternal Wrap(TIDataObject data);
 
+    /// <summary>
+    ///  Unwraps the user IDataObject instance when applicable.
+    /// </summary>
+    /// <param name="dataObject">
+    ///  <para>
+    ///   This is used to return the "original" IDataObject instance when getting data back from OLE. Providing the
+    ///   original instance back allows casting to the original type, which historically happened through "magic"
+    ///   casting support for built-in COM interop.
+    ///  </para>
+    ///  <para>
+    ///   Now that we use ComWrappers, we can't rely on the "magic" casting support. Instead, we provide the original
+    ///   object back when we're able to unwrap it. The unfortunate caveat is that the behavior of calling through
+    ///   the OLE IDataObject proxy results in different behavior than calling through the original object. This
+    ///   primarily happens through `autoConvert` scenarios, where no such concept exists in the COM interfaces. As
+    ///   such, when calling through the COM interface, "autoConvert" is always considered to be <see langword="true"/>.
+    ///   To mitigate the COM caveat, we do not give back the original DataObject if we created it implicitly via
+    ///   Clipboard.SetData. This allows the calls to go through the proxy, which gets the expected "autoConvert"
+    ///   behavior.
+    ///  </para>
+    ///  <para>
+    ///   One potential alternative would be to wrap the created IDataObject in an adapter that mimics the
+    ///   "autoConvert" behavior. This would avoid BinaryFormat serialization when in process and not copying.
+    ///  </para>
+    /// </param>
+    /// <returns>true when a data object was returned.</returns>
     bool TryUnwrapUserDataObject([NotNullWhen(true)] out TIDataObject? dataObject);
 }

--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -6492,7 +6492,6 @@ System.Windows.Forms.DataObject
 System.Windows.Forms.DataObject.DataObject() -> void
 System.Windows.Forms.DataObject.DataObject(object! data) -> void
 System.Windows.Forms.DataObject.DataObject(string! format, object! data) -> void
-System.Windows.Forms.DataObject.SetDataAsJson<T>(string! format, bool autoConvert, T data) -> void
 System.Windows.Forms.DataObject.SetDataAsJson<T>(string! format, T data) -> void
 System.Windows.Forms.DataObject.SetDataAsJson<T>(T data) -> void
 System.Windows.Forms.DataObject.TryGetData<T>(out T data) -> bool

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
@@ -435,7 +435,7 @@ public static class Clipboard
         SetDataObject(new DataObject(format, data), copy: true);
     }
 
-    /// <inheritdoc cref="DataObject.SetDataAsJson{T}(string, bool, T)"/>
+    /// <inheritdoc cref="DataObject.SetDataAsJson{T}(string, T)"/>
     public static void SetDataAsJson<T>(string format, T data)
     {
         ArgumentNullException.ThrowIfNull(data);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
@@ -94,20 +94,15 @@ public unsafe partial class DataObject :
         return dataObject is not null;
     }
 
-    /// <inheritdoc cref="SetDataAsJson{T}(string, bool, T)"/>
+    /// <inheritdoc cref="Composition.SetDataAsJson{T, TDataObject}(T, string)"/>
     [RequiresUnreferencedCode("Uses default System.Text.Json behavior which is not trim-compatible.")]
     public void SetDataAsJson<T>(string format, T data) =>
         _innerData.SetDataAsJson<T, DataObject>(data, format);
 
-    /// <inheritdoc cref="SetDataAsJson{T}(string, bool, T)"/>
+    /// <inheritdoc cref="SetDataAsJson{T}(T)"/>
     [RequiresUnreferencedCode("Uses default System.Text.Json behavior which is not trim-compatible.")]
     public void SetDataAsJson<T>(T data) =>
         _innerData.SetDataAsJson<T, DataObject>(data);
-
-    /// <inheritdoc cref="Composition.SetDataAsJson{T, TDataObject}(T, string, bool)"/>
-    [RequiresUnreferencedCode("Uses default System.Text.Json behavior which is not trim-compatible.")]
-    public void SetDataAsJson<T>(string format, bool autoConvert, T data) =>
-        _innerData.SetDataAsJson<T, DataObject>(data, format, autoConvert);
 
     #region IDataObject
     [Obsolete(


### PR DESCRIPTION
The autoconvert argument doesn't make sense when setting data as JSON as the only place this has any impact is with a fixed set of predefined formats (text for example). You shouldn't be setting known formats with this method.

Also add a more extensive comment to `TryUnwrapUserDataObject`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13060)