### PR TITLE
Retrieve color data correctly in ListView

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListView.cs
@@ -5992,8 +5992,8 @@ public partial class ListView : Control
                     case NMCUSTOMDRAW_DRAW_STAGE.CDDS_ITEMPREPAINT:
                         {
                             using Graphics g = nmcd->hdc.CreateGraphics();
-                            Color foreColor = Color.FromArgb((int)PInvoke.GetTextColor(nmcd->hdc).Value);
-                            Color backColor = Color.FromArgb((int)PInvoke.GetBkColor(nmcd->hdc).Value);
+                            Color foreColor = PInvoke.GetTextColor(nmcd->hdc);
+                            Color backColor = PInvoke.GetBkColor(nmcd->hdc);
                             Font font = GetListHeaderFont();
                             DrawListViewColumnHeaderEventArgs e = new(
                                 g,


### PR DESCRIPTION
We accidentally dropped the call to ColorTranslator, which properly handles alpha when converting COLORREF. COLORREF's implicit conversion does this correctly.

Fixes #13048

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13062)