### PR TITLE
Enable nullable by default in System.Windows.Forms.Design.Tests

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/BinaryEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/BinaryEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel.Design;
 using Moq;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/ButtonBaseDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/ButtonBaseDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.Collections;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/CodeDomHelpers.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/CodeDomHelpers.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.CodeDom;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel;
 using System.Windows.Forms.Design.Behavior;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/DataMemberFieldEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/DataMemberFieldEditorTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel;
 using System.Drawing.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/EnsureDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/EnsureDesignerTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel.Design;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/EnsureEditorsTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/EnsureEditorsTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Collections;
 using System.ComponentModel;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/GlobalUsings.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/GlobalUsings.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 global using System.Windows.Forms;
 global using FluentAssertions;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/ListViewDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/ListViewDesignerTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/Mocks/MockSite.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/Mocks/MockSite.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel.Design;
 using System.ComponentModel;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/SerializableAttributeTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/SerializableAttributeTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 namespace System.Windows.Forms.Design.Tests.Serialization;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/Serialization/CodeDomSerializerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/Serialization/CodeDomSerializerTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel.Design.Serialization;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/Serialization/CollectionCodeDomSerializerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/Serialization/CollectionCodeDomSerializerTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel.Design.Serialization;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/Serialization/PrimitiveCodeDomSerializerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/Serialization/PrimitiveCodeDomSerializerTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.CodeDom;
 using System.ComponentModel.Design.Serialization;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/Serialization/TypeCodeDomSerializerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/Serialization/TypeCodeDomSerializerTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using Moq;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/SplitContainerDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/SplitContainerDesignerTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel.Design;
 using Moq;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System.Windows.Forms.Design.Tests.csproj
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System.Windows.Forms.Design.Tests.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>System.Windows.Forms.Design.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <NoWarn>$(NoWarn);SYSLIB0050;SYSLIB0051;SYSLIB0011</NoWarn>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ArrayEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ArrayEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Collections;
 using System.Drawing.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ByteViewerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ByteViewerTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Drawing;
 using System.Windows.Forms.TestUtilities;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/CollectionEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/CollectionEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Collections;
 using System.Drawing.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/CollectionFormTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/CollectionFormTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Windows.Forms.Design;
 using Moq;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ComponentDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ComponentDesignerTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Collections;
 using System.Configuration;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignSurfaceTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignSurfaceTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel.Design.Serialization;
 using System.Reflection;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerActionHeaderItemTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerActionHeaderItemTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Collections.Specialized;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerActionItemCollectionTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerActionItemCollectionTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 namespace System.ComponentModel.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerActionItemTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerActionItemTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Collections.Specialized;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerActionListCollectionTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerActionListCollectionTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 namespace System.ComponentModel.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerActionListTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerActionListTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Runtime.CompilerServices;
 using Moq;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerActionListsChangedEventArgsTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerActionListsChangedEventArgsTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 namespace System.ComponentModel.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerActionMethodItemTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerActionMethodItemTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Collections.Specialized;
 using System.Reflection;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerActionPropertyItemTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerActionPropertyItemTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Collections.Specialized;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerActionServiceTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerActionServiceTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Collections;
 using System.Collections.Specialized;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerActionTextItemTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerActionTextItemTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Collections.Specialized;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerActionUIStateChangeEventArgsTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerActionUIStateChangeEventArgsTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 namespace System.ComponentModel.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerCommandSetTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerCommandSetTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using Moq;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerHostTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerHostTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Collections;
 using System.ComponentModel.Design.Serialization;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerVerbCollectionTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerVerbCollectionTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 namespace System.ComponentModel.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ExceptionCollectionTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ExceptionCollectionTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Collections;
 using System.Runtime.Serialization;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ExtenderProviderServiceTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ExtenderProviderServiceTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using Moq;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/InheritanceServiceTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/InheritanceServiceTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 namespace System.ComponentModel.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/LoadedEventArgsTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/LoadedEventArgsTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Collections;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/MultilineStringEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/MultilineStringEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Drawing.Design;
 using System.Windows.Forms.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ObjectSelectorEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ObjectSelectorEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Drawing.Design;
 using System.Windows.Forms.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ProjectTargetFrameworkAttributeTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ProjectTargetFrameworkAttributeTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 namespace System.ComponentModel.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationServiceTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationServiceTests.cs
@@ -1,7 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // #define DUMP_STATE
+
+#nullable disable
 
 using System.CodeDom;
 using System.Collections;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/CodeDomSerializerExceptionTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/CodeDomSerializerExceptionTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.CodeDom;
 using System.ComponentModel.Design.Serialization;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/DesignerSerializationManagerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/DesignerSerializationManagerTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Collections;
 using Moq;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/ExpressionContextTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/ExpressionContextTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.CodeDom;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/RootContextTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/RootContextTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.CodeDom;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/SerializeAbsoluteContextTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/SerializeAbsoluteContextTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 namespace System.ComponentModel.Design.Serialization.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/StatementContextTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/StatementContextTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 namespace System.ComponentModel.Design.Serialization.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/SiteNestedContainerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/SiteNestedContainerTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel.Design.Serialization;
 using Moq;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/UndoUnitTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/UndoUnitTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel.Design.Serialization;
 using Moq;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/BitmapEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/BitmapEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel;
 using System.Drawing.Imaging;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ColorEditorTests.CustomColorDialogTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ColorEditorTests.CustomColorDialogTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 namespace System.Drawing.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ColorEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ColorEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel;
 using System.Windows.Forms.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/CursorEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/CursorEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel;
 using System.Windows.Forms.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/FontEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/FontEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel;
 using System.Windows.Forms.TestUtilities;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/FontNameEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/FontNameEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel;
 using System.Windows.Forms.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ImageEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ImageEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel;
 using System.Drawing.Imaging;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/MetafileEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/MetafileEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel;
 using System.Drawing.Imaging;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ToolboxComponentsCreatedEventArgsTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ToolboxComponentsCreatedEventArgsTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ToolboxComponentsCreatingEventArgsTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ToolboxComponentsCreatingEventArgsTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel.Design;
 using Moq;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ToolboxItemCollectionTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ToolboxItemCollectionTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 namespace System.Drawing.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ToolboxItemTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ToolboxItemTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Collections;
 using System.ComponentModel;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Resources/Tools/CodeDomCompileHelper.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Resources/Tools/CodeDomCompileHelper.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.CodeDom.Compiler;
 using Microsoft.CodeAnalysis;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Resources/Tools/StronglyTypedResourceBuilderTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Resources/Tools/StronglyTypedResourceBuilderTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.CodeDom;
 using System.CodeDom.Compiler;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/AnchorEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/AnchorEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel;
 using System.Drawing.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/AxImporterTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/AxImporterTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using static System.Windows.Forms.Design.AxImporter;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/BaseContextMenuStripTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/BaseContextMenuStripTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Drawing;
 using Moq;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/Behavior/BehaviorDragDropEventArgsTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/Behavior/BehaviorDragDropEventArgsTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Collections;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/Behavior/SnapLineTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/Behavior/SnapLineTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 namespace System.Windows.Forms.Design.Behavior.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/BindingSourceDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/BindingSourceDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using Moq;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/BorderSidesEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/BorderSidesEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel;
 using System.Drawing.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/CollectionEditVerbManagerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/CollectionEditVerbManagerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ColumnHeaderCollectionEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ColumnHeaderCollectionEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ComboBoxDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ComboBoxDesignerTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/CommandSetTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/CommandSetTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using Moq;
 using System.ComponentModel;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ComponentDocumentDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ComponentDocumentDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ContentAlignmentEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ContentAlignmentEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Drawing.Design;
 using System.Reflection;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ContextMenuStripActionListTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ContextMenuStripActionListTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel.Design;
 using System.ComponentModel;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ContextMenuStripGroupCollectionTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ContextMenuStripGroupCollectionTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ContextMenuStripGroupTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ContextMenuStripGroupTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ControlCodeDomSerializerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ControlCodeDomSerializerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.CodeDom;
 using System.ComponentModel;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ControlDesigner.DesignerControlCollectionTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ControlDesigner.DesignerControlCollectionTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.Collections;
 using System.ComponentModel;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ControlDesigner.TransparentBehaviorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ControlDesigner.TransparentBehaviorTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.Drawing;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ControlDesignerAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ControlDesignerAccessibleObjectTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using Moq;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/CustomMenuItemCollectionTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/CustomMenuItemCollectionTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataGridViewAddColumnDialogTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataGridViewAddColumnDialogTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataGridViewCellStyleBuilderTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataGridViewCellStyleBuilderTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using Moq;
 using System.ComponentModel;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataGridViewCellStyleEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataGridViewCellStyleEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Drawing.Design;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataGridViewColumnCollectionEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataGridViewColumnCollectionEditorTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using Moq;
 using System.ComponentModel;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataGridViewColumnDataPropertyNameEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataGridViewColumnDataPropertyNameEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel;
 using System.Drawing.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataGridViewColumnDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataGridViewColumnDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using Moq;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataGridViewComponentPropertyGridSiteTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataGridViewComponentPropertyGridSiteTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using Moq;
 using System.ComponentModel;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataMemberFieldConverterTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataMemberFieldConverterTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataMemberListEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataMemberListEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel;
 using System.Drawing.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataSourceDescriptorCollectionTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataSourceDescriptorCollectionTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.Drawing;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataSourceGroupCollectionTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataSourceGroupCollectionTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.Drawing;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DateTimePickerDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DateTimePickerDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignBindingTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignBindingTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignerExtendersTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignerExtendersTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using Moq;
 using System.ComponentModel;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignerFrameTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignerFrameTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel;
 using System.Drawing;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignerOptionsTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignerOptionsTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Drawing;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignerToolStripControlHostTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignerToolStripControlHostTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignerVerbToolStripMenuItemTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignerVerbToolStripMenuItemTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel.Design;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DockEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DockEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel;
 using System.Drawing.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/EmbeddedResourceTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/EmbeddedResourceTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Drawing;
 using System.Reflection;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/EventHandlerServiceTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/EventHandlerServiceTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/FileNameEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/FileNameEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel;
 using System.Drawing.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/FlowPanelDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/FlowPanelDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using Moq;
 using System.ComponentModel;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/FolderNameEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/FolderNameEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel;
 using System.Drawing.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/FormatControlTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/FormatControlTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 namespace System.Windows.Forms.Design.Tests;
 public class FormatControlTests : IDisposable

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/FormatStringDialogTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/FormatStringDialogTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel;
 using Moq;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/FormatStringEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/FormatStringEditorTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/GroupedContextMenuStripTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/GroupedContextMenuStripTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ImageCollectionCodeDomSerializerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ImageCollectionCodeDomSerializerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.CodeDom;
 using System.ComponentModel;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ImageIndexEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ImageIndexEditorTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel;
 using System.Drawing;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ImageListActionListTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ImageListActionListTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel.Design;
 using System.Drawing;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ImageListDesignerOriginalImageCollectionTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ImageListDesignerOriginalImageCollectionTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.Drawing;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ImageListDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ImageListDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ImageListImageEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ImageListImageEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Drawing;
 using System.Drawing.Imaging;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ImageListImageTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ImageListImageTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.Drawing;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/InheritanceUITests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/InheritanceUITests.cs
@@ -58,7 +58,7 @@ public sealed class InheritanceUITests : IDisposable
         }
 
         ToolTip toolTip = _inheritanceUI.TestAccessor().Dynamic._toolTip;
-        string text = toolTip.GetToolTip(trayControl);
+        string? text = toolTip.GetToolTip(trayControl);
         text.Should().Be(expectedText);
     }
 
@@ -83,11 +83,9 @@ public sealed class InheritanceUITests : IDisposable
         _inheritanceUI.RemoveInheritedControl(trayControl);
 
         ToolTip toolTip = _inheritanceUI.TestAccessor().Dynamic._toolTip;
-        string text = toolTip.GetToolTip(trayControl);
+        string? text = toolTip.GetToolTip(trayControl);
         text.Should().BeEmpty();
     }
-
-#nullable enable
 
     [Fact]
     public void InheritanceGlyph_And_InheritanceGlyphRectangle_ShouldReturnExpectedValues()

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/InheritedPropertyDescriptorTestExtensions.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/InheritedPropertyDescriptorTestExtensions.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel.Design;
 using System.ComponentModel;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/InheritedPropertyDescriptorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/InheritedPropertyDescriptorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel.Design;
 using System.Drawing;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ItemTypeToolStripMenuItemTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ItemTypeToolStripMenuItemTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.Drawing;
 using System.Drawing.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/LabelDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/LabelDesignerTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/LinkAreaEditor.LinkAreaUITests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/LinkAreaEditor.LinkAreaUITests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using Moq;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/LinkAreaEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/LinkAreaEditorTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using Moq;
 using System.ComponentModel;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ListAdapterTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ListAdapterTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.Collections;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ListBoxDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ListBoxDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ListControlStringCollectionEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ListControlStringCollectionEditorTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using Moq;
 using System.ComponentModel;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ListControlUnboundActionListTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ListControlUnboundActionListTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ListViewActionListTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ListViewActionListTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel.Design;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskDescriptorComparerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskDescriptorComparerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskDescriptorTemplateTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskDescriptorTemplateTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.Globalization;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskDescriptorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskDescriptorTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.Globalization;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskDesignerDialogTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskDesignerDialogTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel.Design;
 using Moq;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskPropertyEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskPropertyEditorTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel;
 using System.Drawing.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskedTextBoxDesignerActionListTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskedTextBoxDesignerActionListTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using Moq;
 using System.ComponentModel;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskedTextBoxDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskedTextBoxDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskedTextBoxTextEditorDropDownTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskedTextBoxTextEditorDropDownTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 namespace System.Windows.Forms.Design.Tests;
 
@@ -43,13 +41,13 @@ public class MaskedTextBoxTextEditorDropDownTests
     [Fact]
     public void MaskInputRejected_SetsError_WhenInputRejected()
     {
-        using MaskedTextBox maskedTextBox = new("00：00");
+        using MaskedTextBox maskedTextBox = new("00:00");
         using MaskedTextBoxTextEditorDropDown dropDown = new(maskedTextBox);
         using ErrorProvider errorProvider = dropDown.TestAccessor().Dynamic._errorProvider;
 
         // No error when setting a correct format value.
         using MaskedTextBox dropDownMaskedTextBox = dropDown.TestAccessor().Dynamic._cloneMtb;
-        dropDownMaskedTextBox.Text = "12：20";
+        dropDownMaskedTextBox.Text = "12:20";
         errorProvider.GetError(dropDownMaskedTextBox).Should().Be(string.Empty);
 
         // Incorrectly formatted values will result in the error "Error at position 0: expected number".

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskedTextBoxTextEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskedTextBoxTextEditorTests.cs
@@ -1,11 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
 using System.Drawing.Design;
 using Moq;
-
-#nullable enable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MenuCommandsTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MenuCommandsTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel.Design;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MonthCalendarDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MonthCalendarDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/NotifyIconDesignerActionListTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/NotifyIconDesignerActionListTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel.Design;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/NotifyIconDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/NotifyIconDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/PanelDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/PanelDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/PictureBoxActionListTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/PictureBoxActionListTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel.Design;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/PictureBoxDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/PictureBoxDesignerTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/PrintDialogDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/PrintDialogDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/RadioButtonDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/RadioButtonDesignerTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/RichTextBoxActionListTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/RichTextBoxActionListTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/RichTextBoxDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/RichTextBoxDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/SRDisplayNameAttributeTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/SRDisplayNameAttributeTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/SelectionUIHandlerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/SelectionUIHandlerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ShortcutKeysEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ShortcutKeysEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel;
 using System.Drawing.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/SplitterDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/SplitterDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/SplitterPanelDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/SplitterPanelDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using Moq;
 using System.Collections;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TabControlDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TabControlDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.Collections;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TabPageDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TabPageDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel.Design;
 using Moq;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TextBoxActionListTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TextBoxActionListTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel.Design;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TextBoxBaseDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TextBoxBaseDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using Moq;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TextBoxDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TextBoxDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.Collections;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripActionListTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripActionListTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using Moq;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripCollectionEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripCollectionEditorTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel;
 using Moq;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripContainerDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripContainerDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripContentPanelDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripContentPanelDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.Windows.Forms.Design.Behavior;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripCustomTypeDescriptorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripCustomTypeDescriptorTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripDesignerUtilsTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripDesignerUtilsTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.Collections;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripMenuItemCodeDomSerializerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripMenuItemCodeDomSerializerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using Moq;
 using System.ComponentModel;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripPanelDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripPanelDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TreeViewDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TreeViewDesignerTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/UpDownBaseDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/UpDownBaseDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/UserControlDocumentDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/UserControlDocumentDesignerTests.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel.Design;
 using System.ComponentModel.Design.Serialization;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/VsPropertyGridTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/VsPropertyGridTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Drawing;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/WindowsFormsDesignerOptionServiceTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/WindowsFormsDesignerOptionServiceTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/SystemDesignMetadataReader.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/SystemDesignMetadataReader.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel.Design;
 using System.Reflection;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/TestControlDesigner.Mocks.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/TestControlDesigner.Mocks.cs
@@ -1,7 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#nullable enable
 
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/TestControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/TestControlDesigner.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel;
 using System.Drawing;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/ToolStripDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/ToolStripDesignerTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel.Design;
 using System.Drawing;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/ToolStripDropDownDesignerTest.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/ToolStripDropDownDesignerTest.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.ComponentModel.Design;
 using System.ComponentModel;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/ToolStripDropDownItemDesignerTest.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/ToolStripDropDownItemDesignerTest.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/ToolStripMenuItemDesignerTest.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/ToolStripMenuItemDesignerTest.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 using System.Collections;
 using System.ComponentModel;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/TreeNodeCollectionEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/TreeNodeCollectionEditorTests.cs
@@ -1,5 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
 
 namespace System.Windows.Forms.Design.Editors.Tests;
 


### PR DESCRIPTION
Enables nullable by default in SWFDT. See #13063 for more context.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13064)