### PR TITLE
Add proper working `ToolStripMenuItem` controls to `DropDownItems`

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
@@ -303,6 +303,10 @@ public partial class MainForm : Form
                         topMenuItem1.Text = "TopMenuItem1";
                         ToolStripMenuItem topMenuItem2 = surface.CreateComponent<ToolStripMenuItem>();
                         topMenuItem2.Text = "TopMenuItem2";
+                        ToolStripMenuItem dropDownItem1 = surface.CreateComponent<ToolStripMenuItem>();
+                        dropDownItem1.Text = "DropDownItem1";
+                        ToolStripMenuItem dropDownItem2 = surface.CreateComponent<ToolStripMenuItem>();
+                        dropDownItem2.Text = "DropDownItem2";
                         ToolStripMenuItem bottomMenuItem1 = surface.CreateComponent<ToolStripMenuItem>();
                         bottomMenuItem1.Text = "BottomMenuItem1";
                         ToolStripMenuItem bottomMenuItem2 = surface.CreateComponent<ToolStripMenuItem>();
@@ -313,8 +317,8 @@ public partial class MainForm : Form
                         menuStrip2.Items.Add(bottomMenuItem1);
                         menuStrip2.Items.Add(bottomMenuItem2);
 
-                        topMenuItem1.DropDownItems.Add("DropDownItem1");
-                        topMenuItem2.DropDownItems.Add("DropDownItem12");
+                        topMenuItem1.DropDownItems.Add(dropDownItem1);
+                        topMenuItem2.DropDownItems.Add(dropDownItem2);
 
                         ToolStripPanel topToolStripPanel = surface.CreateControl<ToolStripPanel>(new(50, 50), new(0, 0));
                         topToolStripPanel = toolStripContainer.TopToolStripPanel;


### PR DESCRIPTION
Fixes #12987

## Root Cause

- Added strings to `DropDownItems` instead of adding controls.

## Proposed changes

- Add proper working `ToolStripMenuItem` controls to `DropDownItems`.

## Customer Impact

- Interaction with `DemoConsole` fixed `DropDownItems` will be possible.

## Regression?

- No

## Risk

- Minimal

## Screenshots

### Before
![before](https://github.com/user-attachments/assets/f075fc68-2b5d-4e68-acf8-b1a9ad37cb25)

### After
![after](https://github.com/user-attachments/assets/e95cd551-b002-423d-809f-edafdb376b53)

## Test methodology

- Manual

## Test environment(s)

- 10.0.100-preview.3.25125.5
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13065)