### PR TITLE
We didn't use WFO5000 warning ID, removing it from internal docs

### DIFF
--- a/docs/analyzers/Experimental.Help.md
+++ b/docs/analyzers/Experimental.Help.md
@@ -5,6 +5,5 @@ are automatically referenced for Window Forms .NET applications.
 
 | Diagnostic ID  | Description |
 | :------------- | :---------- |
-|  __`WFO5000`__ | Functionality around Visual Styling is experimental in .NET 9. |
 |  __`WFO5001`__ | Functionality around Dark Mode Colors is experimental in .NET 9. |
 |  __`WFO5002`__ | New ASync APIs for e.g. consuming Windows projected APIs, WebView2 or AI/LLM Libs are experimental in .NET 9. |


### PR DESCRIPTION
I searched all files from the repo root and didn't find any references. It's also not documented.