### PR TITLE
Update OnSelectedItemName_Paint: When selectedItem.Site is null, only show selectedItem type in Items Collection Editor

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripCollectionEditor.ToolStripItemEditorForm.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripCollectionEditor.ToolStripItemEditorForm.cs
@@ -590,8 +590,8 @@ internal partial class ToolStripCollectionEditor
                 {
                     if (ex.IsCriticalException())
                     {
-                    throw;
-                }
+                        throw;
+                    }
                 }
 
                 PropertyDescriptor imageProperty = TypeDescriptor.GetProperties(newItem)[nameof(Image)];
@@ -885,32 +885,29 @@ internal partial class ToolStripCollectionEditor
                     selectedItem = _listBoxItems.SelectedItem is ToolStrip strip ? strip : (ToolStripItem)_listBoxItems.SelectedItem;
 
                     string className = "&" + selectedItem.GetType().Name;
-                    if (selectedItem.Site is not null)
+                    // Erase background
+                    e.Graphics.FillRectangle(SystemBrushes.Control, bounds);
+                    string itemName = selectedItem.Site?.Name ?? string.Empty;
+
+                    if (label is not null)
                     {
-                        // Erase background
-                        e.Graphics.FillRectangle(SystemBrushes.Control, bounds);
-                        string itemName = selectedItem.Site.Name;
-
-                        if (label is not null)
-                        {
-                            label.Text = className + itemName;
-                        }
-
-                        int classWidth = 0;
-                        classWidth = (int)e.Graphics.MeasureString(className, boldFont).Width;
-                        e.Graphics.DrawString(className, boldFont, SystemBrushes.WindowText, bounds, stringFormat);
-                        int itemTextWidth = (int)e.Graphics.MeasureString(itemName, _selectedItemName.Font).Width;
-                        Rectangle textRect = new(classWidth + GdiPlusExtraSpace, 0, bounds.Width - (classWidth + GdiPlusExtraSpace), bounds.Height);
-                        label.AutoEllipsis = itemTextWidth > textRect.Width;
-
-                        TextFormatFlags flags = TextFormatFlags.EndEllipsis | TextFormatFlags.PreserveGraphicsTranslateTransform | TextFormatFlags.PreserveGraphicsClipping;
-                        if (rightToLeft)
-                        {
-                            flags |= TextFormatFlags.RightToLeft;
-                        }
-
-                        TextRenderer.DrawText(e.Graphics, itemName, _selectedItemName.Font, textRect, SystemColors.WindowText, flags);
+                        label.Text = className + itemName;
                     }
+
+                    int classWidth = 0;
+                    classWidth = (int)e.Graphics.MeasureString(className, boldFont).Width;
+                    e.Graphics.DrawString(className, boldFont, SystemBrushes.WindowText, bounds, stringFormat);
+                    int itemTextWidth = (int)e.Graphics.MeasureString(itemName, _selectedItemName.Font).Width;
+                    Rectangle textRect = new(classWidth + GdiPlusExtraSpace, 0, bounds.Width - (classWidth + GdiPlusExtraSpace), bounds.Height);
+                    label.AutoEllipsis = itemTextWidth > textRect.Width;
+
+                    TextFormatFlags flags = TextFormatFlags.EndEllipsis | TextFormatFlags.PreserveGraphicsTranslateTransform | TextFormatFlags.PreserveGraphicsClipping;
+                    if (rightToLeft)
+                    {
+                        flags |= TextFormatFlags.RightToLeft;
+                    }
+
+                    TextRenderer.DrawText(e.Graphics, itemName, _selectedItemName.Font, textRect, SystemColors.WindowText, flags);
 
                     break;
                 case 0:


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13040


## Proposed changes

- Update method `OnSelectedItemName_Paint`: When `selectedItem.Site` is null, only show selectedItem type in Items Collection Editor

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

-  The right type name can be show in the  Items Collection Editor

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
The wrong type name show in the Items Collection Editor
![image](https://github.com/user-attachments/assets/873bf817-1165-4a5d-972c-3b9054959b82)

### After
The type name `ToolStripDropDownMenu` can be show correctly, and the item name is empty
![image](https://github.com/user-attachments/assets/222bb269-7229-40cf-96a8-3c176f8aae84)



## Test methodology <!-- How did you ensure quality? -->

- Manually



## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-preview.3.25152.4


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13078)