### PR TITLE
[release/9.0] Scale errorProvider Icon to DeviceDPI 

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
@@ -420,6 +420,17 @@ internal static partial class ScaleHelper
     }
 
     /// <summary>
+    ///  Get X, Y metrics at DPI, IF icon is not already that size, create and return a new one.
+    /// </summary>
+    internal static Icon ScaleSmallIconToDpi(Icon icon, int dpi)
+    {
+        int width = PInvoke.GetCurrentSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)dpi);
+        int height = PInvoke.GetCurrentSystemMetrics(SYSTEM_METRICS_INDEX.SM_CYSMICON, (uint)dpi);
+
+        return (icon.Width == width && icon.Height == height) ? icon : new(icon, width, height);
+    }
+
+    /// <summary>
     ///  Sets the requested DPI mode. If the current OS does not support the requested mode,
     /// </summary>
     /// <returns><see langword="true"/> if the mode was successfully set.</returns>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.ErrorWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.ErrorWindow.cs
@@ -454,7 +454,8 @@ public partial class ErrorProvider
             }
 
             double factor = ((double)currentDpi) / _parent._deviceDpi;
-            using Icon icon = _provider.Icon;
+            Icon icon = _provider.Icon;
+            _provider.CurrentDpi = currentDpi;
             _provider.Icon = new Icon(icon, (int)(icon.Width * factor), (int)(icon.Height * factor));
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.IconRegion.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.IconRegion.cs
@@ -15,9 +15,9 @@ public partial class ErrorProvider
         private Region? _region;
         private readonly Icon _icon;
 
-        public IconRegion(Icon icon)
+        public IconRegion(Icon icon, int currentDpi)
         {
-            _icon = new Icon(icon, ScaleHelper.LogicalSmallSystemIconSize);
+            _icon = ScaleHelper.ScaleSmallIconToDpi(icon, currentDpi);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.cs
@@ -24,8 +24,9 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
 {
     private readonly Dictionary<Control, ControlItem> _items = [];
     private readonly Dictionary<Control, ErrorWindow> _windows = [];
-    private Icon _icon = DefaultIcon;
+    private Icon? _icon;
     private IconRegion? _region;
+    private int _currentDpi;
     private int _itemIdCounter;
     private int _blinkRate;
     private ErrorBlinkStyle _blinkStyle;
@@ -80,7 +81,6 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
         : this()
     {
         ArgumentNullException.ThrowIfNull(container);
-
         container.Add(this);
     }
 
@@ -308,7 +308,7 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
         {
             if (_parentControl is not null && _parentControl.BindingContext is not null && value is not null && !string.IsNullOrEmpty(_dataMember))
             {
-                // Let's check if the datamember exists in the new data source
+                // Let's check if the data member exists in the new data source
                 try
                 {
                     _errorManager = _parentControl.BindingContext[value, _dataMember];
@@ -546,10 +546,8 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
                 if (t_defaultIcon is null)
                 {
                     // Error provider uses small Icon.
-                    int width = PInvokeCore.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON);
-                    int height = PInvokeCore.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CYSMICON);
-                    using Icon defaultIcon = new(typeof(ErrorProvider), "Error");
-                    t_defaultIcon = new Icon(defaultIcon, width, height);
+                    Icon defaultIcon = new(typeof(ErrorProvider), "Error");
+                    t_defaultIcon = ScaleHelper.ScaleSmallIconToDpi(defaultIcon, ScaleHelper.InitialSystemDpi);
                 }
             }
 
@@ -567,10 +565,7 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
     [SRDescription(nameof(SR.ErrorProviderIconDescr))]
     public Icon Icon
     {
-        get
-        {
-            return _icon;
-        }
+        get => _icon ??= DefaultIcon;
         set
         {
             _icon = value.OrThrowIfNull();
@@ -584,9 +579,20 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
     }
 
     /// <summary>
+    ///  Gets or sets the DPI at which the current error is displayed.
+    ///  If currentDpi is not set, it defaults to _parentControl.DeviceDpi
+    ///  or the system DPI.
+    /// </summary>
+    private int CurrentDpi
+    {
+        get => _currentDpi != 0 ? _currentDpi : _parentControl?.DeviceDpi ?? ScaleHelper.InitialSystemDpi;
+        set => _currentDpi = value;
+    }
+
+    /// <summary>
     ///  Create the icon region on demand.
     /// </summary>
-    internal IconRegion Region => _region ??= new IconRegion(Icon);
+    internal IconRegion Region => _region ??= new IconRegion(Icon, CurrentDpi);
 
     /// <summary>
     ///  Begin bulk member initialization - deferring binding to data source until EndInit is reached
@@ -761,7 +767,7 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
     [SRDescription(nameof(SR.ErrorProviderIconPaddingDescr))]
     public int GetIconPadding(Control control) => EnsureControlItem(control).IconPadding;
 
-    private void ResetIcon() => Icon = DefaultIcon;
+    private void ResetIcon() => _icon = null;
 
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     protected virtual void OnRightToLeftChanged(EventArgs e)
@@ -814,5 +820,5 @@ public partial class ErrorProvider : Component, IExtenderProvider, ISupportIniti
         EnsureControlItem(control).IconPadding = padding;
     }
 
-    private bool ShouldSerializeIcon() => Icon != DefaultIcon;
+    private bool ShouldSerializeIcon() => _icon is not null && _icon != DefaultIcon;
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

BackPort PR https://github.com/dotnet/winforms/pull/12947 to 9.0
Fixes #12939

## Proposed changes

- Calculate the display size of the ErrorProvide Icon according to the DPI of the current device

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The icon of errorProvider is not scaled well on HDPI screen

## Regression?

- Yes.  it's fine in dotnet 8. This is due to https://github.com/dotnet/winforms/pull/10850, the initial loaded size of the ErrorProvider IconRegion is scaled to 100% DPI even on HDPI screens.

## Risk

- Low – because the change only change ErrorProvider icon's display size when it run in HDPI screen.

<!-- end TELL-MODE -->

## Testing

- Manual testing with the user-provided project
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13079)