### PR TITLE
Use Path.Join instead of Path.Combine

### DIFF
--- a/src/Common/tests/TestUtilities/FileCleanupTestBase.cs
+++ b/src/Common/tests/TestUtilities/FileCleanupTestBase.cs
@@ -16,7 +16,7 @@ public abstract class FileCleanupTestBase : IDisposable
         {
             if (_testDirectory is null)
             {
-                _testDirectory = Path.Combine(Path.GetTempPath(), GetUniqueName());
+                _testDirectory = Path.Join(Path.GetTempPath(), GetUniqueName());
                 Directory.CreateDirectory(_testDirectory);
             }
 
@@ -43,7 +43,7 @@ public abstract class FileCleanupTestBase : IDisposable
         }
     }
 
-    public string GetTestFilePath() => Path.Combine(TestDirectory, GetTestFileName());
+    public string GetTestFilePath() => Path.Join(TestDirectory, GetTestFileName());
 
     public static string GetTestFileName() => GetUniqueName();
 

--- a/src/Common/tests/TestUtilities/TempFile.cs
+++ b/src/Common/tests/TestUtilities/TempFile.cs
@@ -81,6 +81,6 @@ public sealed class TempFile : IDisposable
     private static string GetFilePath(string? memberName, int lineNumber)
     {
         string file = $"{IO.Path.GetRandomFileName()}_{memberName}_{lineNumber}";
-        return IO.Path.Combine(IO.Path.GetTempPath(), file);
+        return IO.Path.Join(IO.Path.GetTempPath(), file);
     }
 }

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Logging/FileLogTraceListener.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Logging/FileLogTraceListener.vb
@@ -166,7 +166,7 @@ Namespace Microsoft.VisualBasic.Logging
                         Debug.Fail("Unrecognized LogFileCreationSchedule")
                 End Select
 
-                Return Path.Combine(basePath, fileName)
+                Return Path.Join(basePath, fileName)
             End Get
         End Property
 

--- a/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/FileLogTraceListenerTests.vb
+++ b/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/FileLogTraceListenerTests.vb
@@ -45,7 +45,7 @@ Namespace Microsoft.VisualBasic.Forms.Tests
                         listener.DiskSpaceExhaustedBehavior = DiskSpaceExhaustedOption.ThrowException
                         listener.DiskSpaceExhaustedBehavior.Should.Be(DiskSpaceExhaustedOption.ThrowException)
 
-                        listener.FullLogFileName.Should.BeEquivalentTo(Path.Combine(testDirectory, $"{expectedBaseFileName}.log"))
+                        listener.FullLogFileName.Should.BeEquivalentTo(Path.Join(testDirectory, $"{expectedBaseFileName}.log"))
 
                         listener.LogFileCreationSchedule.Should.Be(LogFileCreationScheduleOption.None)
                         listener.LogFileCreationSchedule = LogFileCreationScheduleOption.Daily

--- a/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/VbFileCleanupTestBaseTests.vb
+++ b/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/VbFileCleanupTestBaseTests.vb
@@ -32,7 +32,7 @@ Namespace Microsoft.VisualBasic.Forms.Tests
 
         <WinFormsFact>
         Public Sub DirectoryIsAccessibleWithNonexistentPath()
-            Dim directoryPath As String = Path.Combine(CreateTempDirectory(), GetUniqueFileName)
+            Dim directoryPath As String = Path.Join(CreateTempDirectory(), GetUniqueFileName)
             DirectoryIsAccessible(directoryPath).Should.BeFalse()
         End Sub
 

--- a/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/TestUtilities/VbFileCleanupTestBase.vb
+++ b/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/TestUtilities/VbFileCleanupTestBase.vb
@@ -9,7 +9,7 @@ Namespace Microsoft.VisualBasic.Forms.Tests
     Public MustInherit Class VbFileCleanupTestBase
         Implements IDisposable
 
-        Private Shared ReadOnly s_baseTempPath As String = Path.Combine(Path.GetTempPath, "DownLoadTest9d9e3a8-7a46-4333-a0eb-4faf76994801")
+        Private Shared ReadOnly s_baseTempPath As String = Path.Join(Path.GetTempPath, "DownLoadTest9d9e3a8-7a46-4333-a0eb-4faf76994801")
         Friend Const DefaultFileName As String = "Testing.Txt"
         Friend ReadOnly _testDirectories As New HashSet(Of String)
 
@@ -46,7 +46,7 @@ Namespace Microsoft.VisualBasic.Forms.Tests
         '''  If size = -1 no file is create but the full path is returned.
         ''' </returns>
         Friend Shared Function CreateTempFile(sourceDirectoryName As String, Optional filename As String = DefaultFileName, Optional size As Integer = -1) As String
-            Dim filenameWithPath As String = Path.Combine(sourceDirectoryName, filename)
+            Dim filenameWithPath As String = Path.Join(sourceDirectoryName, filename)
 
             If size >= 0 Then
                 Using destinationStream As FileStream = File.Create(filenameWithPath)
@@ -68,7 +68,7 @@ Namespace Microsoft.VisualBasic.Forms.Tests
                 If Not info.Exists Then
                     Return False
                 End If
-                Dim path As String = IO.Path.Combine(directoryPath, GetUniqueFileName())
+                Dim path As String = IO.Path.Join(directoryPath, GetUniqueFileName())
                 Using stream As FileStream = File.Create(path)
                     stream.Close()
                 End Using
@@ -82,7 +82,7 @@ Namespace Microsoft.VisualBasic.Forms.Tests
         End Function
 
         Friend Shared Function GetUniqueFileNameWithPath(testDirectory As String) As String
-            Return Path.Combine(testDirectory, GetUniqueFileName())
+            Return Path.Join(testDirectory, GetUniqueFileName())
         End Function
 
         ''' <summary>
@@ -96,9 +96,9 @@ Namespace Microsoft.VisualBasic.Forms.Tests
         Friend Function CreateTempDirectory(<CallerMemberName> Optional memberName As String = Nothing, Optional lineNumber As Integer = -1) As String
             Dim folder As String
             If lineNumber > 0 Then
-                folder = Path.Combine(BaseTempPath, $"{memberName}{lineNumber}")
+                folder = Path.Join(BaseTempPath, $"{memberName}{lineNumber}")
             Else
-                folder = Path.Combine(BaseTempPath, memberName)
+                folder = Path.Join(BaseTempPath, memberName)
             End If
 
             If _testDirectories.Add(folder) Then

--- a/src/Microsoft.VisualBasic/tests/IntegrationTests/Microsoft.VisualBasic.IntegrationTests/InteractionTests.cs
+++ b/src/Microsoft.VisualBasic/tests/IntegrationTests/Microsoft.VisualBasic.IntegrationTests/InteractionTests.cs
@@ -104,7 +104,7 @@ public class InteractionTests
     [Fact]
     public void Shell_FileNotFoundException()
     {
-        string path = Path.Combine(Path.GetTempPath(), GetUniqueName());
+        string path = Path.Join(Path.GetTempPath(), GetUniqueName());
         // Exception.ToString() called to verify message is constructed successfully.
         _ = Assert.Throws<FileNotFoundException>(() => Interaction.Shell(path)).ToString();
     }

--- a/src/Microsoft.VisualBasic/tests/UnitTests/Microsoft/VisualBasic/Devices/AudioTests.cs
+++ b/src/Microsoft.VisualBasic/tests/UnitTests/Microsoft/VisualBasic/Devices/AudioTests.cs
@@ -49,7 +49,7 @@ public class AudioTests
     [InvalidEnumData<AudioPlayMode>]
     public void PlayModeInvalid_Throws(AudioPlayMode audioPlayMode)
     {
-        string location = Path.Combine(Path.GetTempPath(), GetUniqueName());
+        string location = Path.Join(Path.GetTempPath(), GetUniqueName());
         Audio audio = new();
         Action testCode = () => audio.Play(location, audioPlayMode);
         testCode.Should().Throw<InvalidEnumArgumentException>();

--- a/src/Microsoft.VisualBasic/tests/UnitTests/Microsoft/VisualBasic/MyServices/FileSystemProxyTests.cs
+++ b/src/Microsoft.VisualBasic/tests/UnitTests/Microsoft/VisualBasic/MyServices/FileSystemProxyTests.cs
@@ -37,7 +37,7 @@ public class FileSystemProxyTests : FileCleanupTestBase
     {
         var TestDirInfo = new DirectoryInfo(TestDirectory);
         string Root = TestDirInfo.Root.Name;
-        Assert.Equal(_fileSystem.CombinePath(Root, "Test2"), Path.Combine(Root, "Test2"));
+        Assert.Equal(_fileSystem.CombinePath(Root, "Test2"), Path.Join(Root, "Test2"));
     }
 
     [Fact]
@@ -45,20 +45,20 @@ public class FileSystemProxyTests : FileCleanupTestBase
     {
         Assert.Equal(_fileSystem.CombinePath(TestDirectory, null), TestDirectory);
         Assert.Equal(_fileSystem.CombinePath(TestDirectory, ""), TestDirectory);
-        Assert.Equal(_fileSystem.CombinePath(TestDirectory, "Test"), Path.Combine(TestDirectory, "Test"));
+        Assert.Equal(_fileSystem.CombinePath(TestDirectory, "Test"), Path.Join(TestDirectory, "Test"));
     }
 
     [Fact]
     public void CopyDirectory_SourceDirectoryName_DestinationDirectoryName()
     {
-        string FullPathToSourceDirectory = Path.Combine(TestDirectory, "SourceDirectory");
+        string FullPathToSourceDirectory = Path.Join(TestDirectory, "SourceDirectory");
         Directory.CreateDirectory(FullPathToSourceDirectory);
         for (int i = 0; i < 6; i++)
         {
             CreateTestFile(SourceData, PathFromBase: "SourceDirectory", TestFileName: $"NewFile{i}");
         }
 
-        string FullPathToTargetDirectory = Path.Combine(TestDirectory, "TargetDirectory");
+        string FullPathToTargetDirectory = Path.Join(TestDirectory, "TargetDirectory");
         _fileSystem.CopyDirectory(FullPathToSourceDirectory, FullPathToTargetDirectory);
         Assert.Equal(Directory.GetFiles(FullPathToSourceDirectory).Length, Directory.GetFiles(FullPathToTargetDirectory).Length);
         foreach (string CurrentFile in Directory.GetFiles(FullPathToTargetDirectory))
@@ -76,8 +76,8 @@ public class FileSystemProxyTests : FileCleanupTestBase
     [Fact]
     public void CopyDirectory_SourceDirectoryName_DestinationDirectoryName_OverwriteFalse()
     {
-        string FullPathToSourceDirectory = Path.Combine(TestDirectory, "SourceDirectory");
-        string FullPathToTargetDirectory = Path.Combine(TestDirectory, "TargetDirectory");
+        string FullPathToSourceDirectory = Path.Join(TestDirectory, "SourceDirectory");
+        string FullPathToTargetDirectory = Path.Join(TestDirectory, "TargetDirectory");
         Directory.CreateDirectory(FullPathToSourceDirectory);
         for (int i = 0; i < 6; i++)
         {
@@ -106,8 +106,8 @@ public class FileSystemProxyTests : FileCleanupTestBase
     [Fact]
     public void CopyDirectory_SourceDirectoryName_DestinationDirectoryName_OverwriteTrue()
     {
-        string FullPathToSourceDirectory = Path.Combine(TestDirectory, "SourceDirectory");
-        string FullPathToTargetDirectory = Path.Combine(TestDirectory, "TargetDirectory");
+        string FullPathToSourceDirectory = Path.Join(TestDirectory, "SourceDirectory");
+        string FullPathToTargetDirectory = Path.Join(TestDirectory, "TargetDirectory");
         Directory.CreateDirectory(FullPathToSourceDirectory);
         Directory.CreateDirectory(FullPathToTargetDirectory);
         for (int i = 0; i < 6; i++)
@@ -179,7 +179,7 @@ public class FileSystemProxyTests : FileCleanupTestBase
     [Fact]
     public void CreateDirectory_Directory()
     {
-        string FullPathToNewDirectory = Path.Combine(TestDirectory, "NewDirectory");
+        string FullPathToNewDirectory = Path.Join(TestDirectory, "NewDirectory");
         Assert.False(Directory.Exists(FullPathToNewDirectory));
         _fileSystem.CreateDirectory(FullPathToNewDirectory);
         Assert.True(Directory.Exists(FullPathToNewDirectory));
@@ -205,7 +205,7 @@ public class FileSystemProxyTests : FileCleanupTestBase
     [Fact]
     public void DeleteDirectory_Directory_DeleteAllContents()
     {
-        string FullPathToNewDirectory = Path.Combine(TestDirectory, "NewDirectory");
+        string FullPathToNewDirectory = Path.Join(TestDirectory, "NewDirectory");
         Directory.CreateDirectory(FullPathToNewDirectory);
         Assert.True(Directory.Exists(FullPathToNewDirectory));
         string testFileSource = CreateTestFile(SourceData, PathFromBase: "NewDirectory", TestFileName: "TestFile");
@@ -217,7 +217,7 @@ public class FileSystemProxyTests : FileCleanupTestBase
     [Fact]
     public void DeleteDirectory_Directory_ThrowIfDirectoryNonEmpty()
     {
-        string FullPathToNewDirectory = Path.Combine(TestDirectory, "NewDirectory");
+        string FullPathToNewDirectory = Path.Join(TestDirectory, "NewDirectory");
         _fileSystem.CreateDirectory(FullPathToNewDirectory);
         Assert.True(Directory.Exists(FullPathToNewDirectory));
         string testFileSource = CreateTestFile(SourceData, PathFromBase: "NewDirectory", TestFileName: "TestFile");
@@ -242,7 +242,7 @@ public class FileSystemProxyTests : FileCleanupTestBase
     public void DirectoryExists_Directory()
     {
         Assert.True(_fileSystem.DirectoryExists(TestDirectory));
-        Assert.False(_fileSystem.DirectoryExists(Path.Combine(TestDirectory, "NewDirectory")));
+        Assert.False(_fileSystem.DirectoryExists(Path.Join(TestDirectory, "NewDirectory")));
     }
 
     // Not tested:
@@ -269,17 +269,17 @@ public class FileSystemProxyTests : FileCleanupTestBase
         Assert.Empty(DirectoryList);
         for (int i = 0; i < 6; i++)
         {
-            Directory.CreateDirectory(Path.Combine(TestDirectory, $"GetDirectories_DirectoryNewSubDirectory{i}"));
+            Directory.CreateDirectory(Path.Join(TestDirectory, $"GetDirectories_DirectoryNewSubDirectory{i}"));
         }
 
         DirectoryList = _fileSystem.GetDirectories(TestDirectory);
         Assert.Equal(6, DirectoryList.Count);
         for (int i = 0; i < 6; i++)
         {
-            Assert.Contains(Path.Combine(TestDirectory, $"GetDirectories_DirectoryNewSubDirectory{i}"), DirectoryList);
+            Assert.Contains(Path.Join(TestDirectory, $"GetDirectories_DirectoryNewSubDirectory{i}"), DirectoryList);
         }
 
-        Directory.CreateDirectory(Path.Combine(TestDirectory, $"GetDirectories_DirectoryNewSubDirectory0", $"NewSubSubDirectory"));
+        Directory.CreateDirectory(Path.Join(TestDirectory, $"GetDirectories_DirectoryNewSubDirectory0", $"NewSubSubDirectory"));
         DirectoryList = _fileSystem.GetDirectories(TestDirectory);
         Assert.Equal(6, DirectoryList.Count);
     }
@@ -291,17 +291,17 @@ public class FileSystemProxyTests : FileCleanupTestBase
         Assert.Empty(DirectoryList);
         for (int i = 0; i < 6; i++)
         {
-            Directory.CreateDirectory(Path.Combine(TestDirectory, $"GetDirectories_Directory_SearchOptionNewSubDirectory{i}"));
+            Directory.CreateDirectory(Path.Join(TestDirectory, $"GetDirectories_Directory_SearchOptionNewSubDirectory{i}"));
         }
 
         DirectoryList = _fileSystem.GetDirectories(TestDirectory, SearchOption.SearchTopLevelOnly);
         Assert.Equal(6, DirectoryList.Count);
         for (int i = 0; i < 6; i++)
         {
-            Assert.Contains(Path.Combine(TestDirectory, $"GetDirectories_Directory_SearchOptionNewSubDirectory{i}"), DirectoryList);
+            Assert.Contains(Path.Join(TestDirectory, $"GetDirectories_Directory_SearchOptionNewSubDirectory{i}"), DirectoryList);
         }
 
-        Directory.CreateDirectory(Path.Combine(TestDirectory, $"GetDirectories_Directory_SearchOptionNewSubDirectory0", $"NewSubSubDirectory"));
+        Directory.CreateDirectory(Path.Join(TestDirectory, $"GetDirectories_Directory_SearchOptionNewSubDirectory0", $"NewSubSubDirectory"));
         DirectoryList = _fileSystem.GetDirectories(TestDirectory, SearchOption.SearchTopLevelOnly);
         Assert.Equal(6, DirectoryList.Count);
         DirectoryList = _fileSystem.GetDirectories(TestDirectory, SearchOption.SearchAllSubDirectories);
@@ -316,18 +316,18 @@ public class FileSystemProxyTests : FileCleanupTestBase
         List<string> CreatedDirectories = [];
         for (int i = 0; i < 6; i++)
         {
-            CreatedDirectories.Add(Directory.CreateDirectory(Path.Combine(TestDirectory, $"NewSubDirectory00{i}")).Name);
+            CreatedDirectories.Add(Directory.CreateDirectory(Path.Join(TestDirectory, $"NewSubDirectory00{i}")).Name);
         }
 
         DirectoryList = _fileSystem.GetDirectories(TestDirectory, SearchOption.SearchTopLevelOnly, "*000", "*001");
         Assert.Equal(2, DirectoryList.Count);
         for (int i = 0; i < 2; i++)
         {
-            string DirectoryName = Path.Combine(TestDirectory, $"NewSubDirectory00{i}");
+            string DirectoryName = Path.Join(TestDirectory, $"NewSubDirectory00{i}");
             Assert.Contains(DirectoryName, DirectoryList);
         }
 
-        Directory.CreateDirectory(Path.Combine(TestDirectory, $"NewSubDirectory000", $"NewSubSubDirectory000"));
+        Directory.CreateDirectory(Path.Join(TestDirectory, $"NewSubDirectory000", $"NewSubSubDirectory000"));
         DirectoryList = _fileSystem.GetDirectories(TestDirectory, SearchOption.SearchTopLevelOnly, "*000");
         Assert.Single(DirectoryList);
         DirectoryList = _fileSystem.GetDirectories(TestDirectory, SearchOption.SearchAllSubDirectories, "*000");
@@ -339,10 +339,10 @@ public class FileSystemProxyTests : FileCleanupTestBase
     {
         for (int i = 0; i < 6; i++)
         {
-            Directory.CreateDirectory(Path.Combine(TestDirectory, $"NewSubDirectory{i}"));
+            Directory.CreateDirectory(Path.Join(TestDirectory, $"NewSubDirectory{i}"));
         }
 
-        Directory.CreateDirectory(Path.Combine(TestDirectory, $"NewSubDirectory0", $"NewSubSubDirectory"));
+        Directory.CreateDirectory(Path.Join(TestDirectory, $"NewSubDirectory0", $"NewSubSubDirectory"));
         var info = _fileSystem.GetDirectoryInfo(TestDirectory);
         var infoFromIO = new DirectoryInfo(TestDirectory);
         Assert.Equal(info.CreationTime, infoFromIO.CreationTime);
@@ -400,10 +400,10 @@ public class FileSystemProxyTests : FileCleanupTestBase
         Assert.Equal(6, FileList.Count);
         for (int i = 0; i < 6; i++)
         {
-            Assert.Contains(Path.Combine(TestDirectory, $"NewFile{i}"), FileList);
+            Assert.Contains(Path.Join(TestDirectory, $"NewFile{i}"), FileList);
         }
 
-        Directory.CreateDirectory(Path.Combine(TestDirectory, "GetFiles_DirectoryNewSubDirectory"));
+        Directory.CreateDirectory(Path.Join(TestDirectory, "GetFiles_DirectoryNewSubDirectory"));
         CreateTestFile(SourceData, PathFromBase: "GetFiles_DirectoryNewSubDirectory", TestFileName: "NewFile");
         FileList = _fileSystem.GetFiles(TestDirectory);
         Assert.Equal(6, FileList.Count);
@@ -412,7 +412,7 @@ public class FileSystemProxyTests : FileCleanupTestBase
     [Fact]
     public void GetFiles_Directory_SearchOption()
     {
-        string NewSubDirectoryPath = Path.Combine(TestDirectory, "GetFiles_Directory_SearchOptionNewSubDirectory");
+        string NewSubDirectoryPath = Path.Join(TestDirectory, "GetFiles_Directory_SearchOptionNewSubDirectory");
         Directory.CreateDirectory(NewSubDirectoryPath);
         CreateTestFile(SourceData, PathFromBase: "GetFiles_Directory_SearchOptionNewSubDirectory", TestFileName: "NewFile");
         var FileList = _fileSystem.GetFiles(TestDirectory);
@@ -427,7 +427,7 @@ public class FileSystemProxyTests : FileCleanupTestBase
         Assert.Equal(6, FileList.Count);
         for (int i = 0; i < 6; i++)
         {
-            Assert.Contains(Path.Combine(TestDirectory, $"NewFile{i}"), FileList);
+            Assert.Contains(Path.Join(TestDirectory, $"NewFile{i}"), FileList);
         }
 
         FileList = _fileSystem.GetFiles(TestDirectory, SearchOption.SearchAllSubDirectories);
@@ -456,7 +456,7 @@ public class FileSystemProxyTests : FileCleanupTestBase
             Assert.Contains(FileList[i], TestFileList);
         }
 
-        string NewSubDirectoryPath = Path.Combine(TestDirectory, "GetFiles_Directory_SearchOption_WildcardsNewSubDirectory");
+        string NewSubDirectoryPath = Path.Join(TestDirectory, "GetFiles_Directory_SearchOption_WildcardsNewSubDirectory");
         Directory.CreateDirectory(NewSubDirectoryPath);
         TestFileList.Add(CreateTestFile(SourceData, PathFromBase: "GetFiles_Directory_SearchOption_WildcardsNewSubDirectory", TestFileName: "NewFile.cs"));
         FileList = _fileSystem.GetFiles(TestDirectory, SearchOption.SearchAllSubDirectories, "*.cs");
@@ -488,8 +488,8 @@ public class FileSystemProxyTests : FileCleanupTestBase
     [Fact]
     public void MoveDirectory_SourceDirectoryName_DestinationDirectoryName()
     {
-        string FullPathToSourceDirectory = Path.Combine(TestDirectory, "SourceDirectory");
-        string FullPathToTargetDirectory = Path.Combine(TestDirectory, "TargetDirectory");
+        string FullPathToSourceDirectory = Path.Join(TestDirectory, "SourceDirectory");
+        string FullPathToTargetDirectory = Path.Join(TestDirectory, "TargetDirectory");
         Directory.CreateDirectory(FullPathToSourceDirectory);
         for (int i = 0; i < 6; i++)
         {
@@ -514,8 +514,8 @@ public class FileSystemProxyTests : FileCleanupTestBase
     [Fact]
     public void MoveDirectory_SourceDirectoryName_DestinationDirectoryName_OverwriteFalse()
     {
-        string FullPathToSourceDirectory = Path.Combine(TestDirectory, "SourceDirectory");
-        string FullPathToTargetDirectory = Path.Combine(TestDirectory, "TargetDirectory");
+        string FullPathToSourceDirectory = Path.Join(TestDirectory, "SourceDirectory");
+        string FullPathToTargetDirectory = Path.Join(TestDirectory, "TargetDirectory");
         Directory.CreateDirectory(FullPathToSourceDirectory);
         for (int i = 0; i < 6; i++)
         {
@@ -552,8 +552,8 @@ public class FileSystemProxyTests : FileCleanupTestBase
     [Fact]
     public void MoveDirectory_SourceDirectoryName_DestinationDirectoryName_OverwriteTrue()
     {
-        string FullPathToSourceDirectory = Path.Combine(TestDirectory, "SourceDirectory");
-        string FullPathToTargetDirectory = Path.Combine(TestDirectory, "TargetDirectory");
+        string FullPathToSourceDirectory = Path.Join(TestDirectory, "SourceDirectory");
+        string FullPathToTargetDirectory = Path.Join(TestDirectory, "TargetDirectory");
         Directory.CreateDirectory(FullPathToSourceDirectory);
         Directory.CreateDirectory(FullPathToTargetDirectory);
         for (int i = 0; i < 6; i++)
@@ -575,7 +575,7 @@ public class FileSystemProxyTests : FileCleanupTestBase
     public void MoveFile_SourceFileName_DestinationFileName()
     {
         string SourceFileNameWithPath = CreateTestFile(SourceData, TestFileName: GetTestFileName());
-        string DestinationFileNameWithPath = Path.Combine(TestDirectory, "NewName");
+        string DestinationFileNameWithPath = Path.Join(TestDirectory, "NewName");
         _fileSystem.MoveFile(SourceFileNameWithPath, DestinationFileNameWithPath);
         Assert.False(File.Exists(SourceFileNameWithPath));
         Assert.True(File.Exists(DestinationFileNameWithPath));
@@ -593,7 +593,7 @@ public class FileSystemProxyTests : FileCleanupTestBase
     public void MoveFile_SourceFileName_DestinationFileName_OverwriteFalse()
     {
         string SourceFileNameWithPath = CreateTestFile(SourceData, TestFileName: GetTestFileName());
-        string DestinationFileNameWithPath = Path.Combine(TestDirectory, "NewName");
+        string DestinationFileNameWithPath = Path.Join(TestDirectory, "NewName");
         _fileSystem.MoveFile(SourceFileNameWithPath, DestinationFileNameWithPath, overwrite: false);
         Assert.False(File.Exists(SourceFileNameWithPath));
         Assert.True(File.Exists(DestinationFileNameWithPath));
@@ -610,7 +610,7 @@ public class FileSystemProxyTests : FileCleanupTestBase
     public void MoveFile_SourceFileName_DestinationFileName_OverwriteTrue()
     {
         string SourceFileNameWithPath = CreateTestFile(SourceData, TestFileName: GetTestFileName());
-        string DestinationFileNameWithPath = Path.Combine(TestDirectory, "NewName");
+        string DestinationFileNameWithPath = Path.Join(TestDirectory, "NewName");
         _fileSystem.MoveFile(SourceFileNameWithPath, DestinationFileNameWithPath, overwrite: true);
         Assert.False(File.Exists(SourceFileNameWithPath));
         Assert.True(File.Exists(DestinationFileNameWithPath));
@@ -638,16 +638,16 @@ public class FileSystemProxyTests : FileCleanupTestBase
     public void RenameDirectory_Directory_NewName()
     {
         // <exception cref="IO.FileNotFoundException">If directory does not point to an existing directory.</exception>
-        Assert.Throws<DirectoryNotFoundException>(() => _fileSystem.RenameDirectory(Path.Combine(TestDirectory, "DoesNotExistDirectory"), "NewDirectory"));
-        string OrigDirectoryWithPath = Path.Combine(TestDirectory, "OriginalDirectory");
+        Assert.Throws<DirectoryNotFoundException>(() => _fileSystem.RenameDirectory(Path.Join(TestDirectory, "DoesNotExistDirectory"), "NewDirectory"));
+        string OrigDirectoryWithPath = Path.Join(TestDirectory, "OriginalDirectory");
         Directory.CreateDirectory(OrigDirectoryWithPath);
         // <exception cref="System.ArgumentException">If newName is null or Empty String.</exception>
         Assert.Throws<ArgumentNullException>(() => _fileSystem.RenameDirectory(OrigDirectoryWithPath, ""));
-        string DirectoryNameWithPath = Path.Combine(TestDirectory, "DoesNotExist");
+        string DirectoryNameWithPath = Path.Join(TestDirectory, "DoesNotExist");
         // <exception cref="System.ArgumentException">If contains path information.</exception>
         Assert.Throws<ArgumentException>(() => _fileSystem.RenameDirectory(OrigDirectoryWithPath, DirectoryNameWithPath));
         _fileSystem.RenameDirectory(OrigDirectoryWithPath, "NewFDirectory");
-        string NewFDirectoryPath = Path.Combine(TestDirectory, "NewFDirectory");
+        string NewFDirectoryPath = Path.Join(TestDirectory, "NewFDirectory");
         Assert.True(Directory.Exists(NewFDirectoryPath));
         Assert.False(Directory.Exists(OrigDirectoryWithPath));
         // <exception cref="IO.IOException">
@@ -662,7 +662,7 @@ public class FileSystemProxyTests : FileCleanupTestBase
     public void RenameFile_File_NewName()
     {
         // <exception cref="IO.FileNotFoundException">If file does not point to an existing file.</exception>
-        Assert.Throws<FileNotFoundException>(() => _fileSystem.RenameFile(Path.Combine(TestDirectory, "DoesNotExistFile"), "NewFile"));
+        Assert.Throws<FileNotFoundException>(() => _fileSystem.RenameFile(Path.Join(TestDirectory, "DoesNotExistFile"), "NewFile"));
         string OrigFileWithPath = CreateTestFile(SourceData, TestFileName: GetTestFileName());
         string ExistingFileWithPath = CreateTestFile(DestData, TestFileName: GetTestFileName());
         // <exception cref="System.ArgumentException">If newName is null or Empty String.</exception>
@@ -670,12 +670,12 @@ public class FileSystemProxyTests : FileCleanupTestBase
         // <exception cref="System.ArgumentException">If contains path information.</exception>
         Assert.Throws<ArgumentException>(() => _fileSystem.RenameFile(OrigFileWithPath, ExistingFileWithPath));
         _fileSystem.RenameFile(OrigFileWithPath, "NewFile");
-        string NewFileWithPath = Path.Combine(TestDirectory, "NewFile");
+        string NewFileWithPath = Path.Join(TestDirectory, "NewFile");
         Assert.True(File.Exists(NewFileWithPath));
         Assert.False(File.Exists(OrigFileWithPath));
         // <exception cref="IO.IOException">If there's an existing directory or an existing file with the same name.</exception>
         Assert.Throws<IOException>(() => _fileSystem.RenameFile(NewFileWithPath, "NewFile"));
-        Directory.CreateDirectory(Path.Combine(TestDirectory, "NewFDirectory"));
+        Directory.CreateDirectory(Path.Join(TestDirectory, "NewFDirectory"));
         Assert.Throws<IOException>(() => _fileSystem.RenameFile(NewFileWithPath, "NewFDirectory"));
     }
 
@@ -698,10 +698,10 @@ public class FileSystemProxyTests : FileCleanupTestBase
         string TempFileNameWithPath = TestDirectory;
         if (!string.IsNullOrEmpty(PathFromBase))
         {
-            TempFileNameWithPath = Path.Combine(TempFileNameWithPath, PathFromBase);
+            TempFileNameWithPath = Path.Join(TempFileNameWithPath, PathFromBase);
         }
 
-        TempFileNameWithPath = Path.Combine(TempFileNameWithPath, TestFileName);
+        TempFileNameWithPath = Path.Join(TempFileNameWithPath, TestFileName);
         Assert.False(File.Exists(TempFileNameWithPath), $"File {TempFileNameWithPath} should not exist!");
         WriteFile(TempFileNameWithPath, TestData);
         return TempFileNameWithPath;

--- a/src/System.Drawing.Common/tests/Helpers.cs
+++ b/src/System.Drawing.Common/tests/Helpers.cs
@@ -25,7 +25,7 @@ public static unsafe class Helpers
     public static string GetTestFontPath(string fileName) => GetTestPath("fonts", fileName);
     public static string GetTestColorProfilePath(string fileName) => GetTestPath("colorProfiles", fileName);
 
-    private static string GetTestPath(string directoryName, string fileName) => Path.Combine(AppContext.BaseDirectory, directoryName, fileName);
+    private static string GetTestPath(string directoryName, string fileName) => Path.Join(AppContext.BaseDirectory, directoryName, fileName);
 
     public static void VerifyBitmap(Bitmap bitmap, Color[][] colors)
     {

--- a/src/System.Drawing.Common/tests/System/Drawing/IconConverterTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/IconConverterTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing.Imaging;
@@ -18,7 +18,7 @@ public class IconConverterTest
 
     public IconConverterTest()
     {
-        _icon = new Icon(Path.Combine("bitmaps", "TestIcon.ico"));
+        _icon = new Icon(Path.Join("bitmaps", "TestIcon.ico"));
         _iconStr = _icon.ToString();
 
         using (MemoryStream destStream = new())

--- a/src/System.Drawing.Common/tests/System/Drawing/ImageAnimator.ManualTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/ImageAnimator.ManualTests.cs
@@ -7,7 +7,7 @@ namespace System.Drawing.Tests;
 
 public class ImageAnimatorManualTests
 {
-    public static string OutputFolder { get; } = Path.Combine(Environment.CurrentDirectory, "ImageAnimatorManualTests", DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss"));
+    public static string OutputFolder { get; } = Path.Join(Environment.CurrentDirectory, "ImageAnimatorManualTests", DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss"));
 
     [Fact(Skip = "Manual Test")]
     public void AnimateAndCaptureFrames()
@@ -44,7 +44,7 @@ public class ImageAnimatorManualTests
 
         foreach (string imageName in images)
         {
-            string testOutputFolder = Path.Combine(OutputFolder, Path.GetFileNameWithoutExtension(imageName));
+            string testOutputFolder = Path.Join(OutputFolder, Path.GetFileNameWithoutExtension(imageName));
             Directory.CreateDirectory(testOutputFolder);
             frameIndexes[imageName] = 0;
 
@@ -57,7 +57,7 @@ public class ImageAnimatorManualTests
                 // a) The images don't get saved as animated gifs again, and just a single frame is saved
                 // b) Saving pngs in this test on Linux was leading to sporadic GDI+ errors; Jpeg is more reliable
                 string timestamp = stopwatch.ElapsedMilliseconds.ToString("000000");
-                animation.Save(Path.Combine(testOutputFolder, $"{++frameIndexes[imageName]}_{timestamp}.jpg"), ImageFormat.Jpeg);
+                animation.Save(Path.Join(testOutputFolder, $"{++frameIndexes[imageName]}_{timestamp}.jpg"), ImageFormat.Jpeg);
             }));
 
             bitmaps[imageName] = new Bitmap(Helpers.GetTestBitmapPath(imageName));

--- a/src/System.Drawing.Common/tests/System/Drawing/ImageConverterTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/ImageConverterTests.cs
@@ -16,7 +16,7 @@ public class ImageConverterTest
 
     public ImageConverterTest()
     {
-        _image = Image.FromFile(Path.Combine("bitmaps", "TestImage.bmp"));
+        _image = Image.FromFile(Path.Join("bitmaps", "TestImage.bmp"));
         _imageStr = _image.ToString();
 
         using (MemoryStream destStream = new())
@@ -46,7 +46,7 @@ public class ImageConverterTest
     [Fact]
     public void ImageWithOleHeader()
     {
-        string path = Path.Combine("bitmaps", "TestImageWithOleHeader.bmp");
+        string path = Path.Join("bitmaps", "TestImageWithOleHeader.bmp");
         using FileStream fileStream = File.Open(path, FileMode.Open);
         using MemoryStream ms = new();
         fileStream.CopyTo(ms);

--- a/src/System.Drawing.Common/tests/System/Drawing/Imaging/ImageFormatTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/Imaging/ImageFormatTests.cs
@@ -71,10 +71,10 @@ public class ImageFormatTests
     {
         get
         {
-            yield return new object[] { Path.Combine("bitmaps", "nature24bits.gif"), "Gif" };
-            yield return new object[] { Path.Combine("bitmaps", "nature24bits.jpg"), "Jpeg" };
-            yield return new object[] { Path.Combine("bitmaps", "VisualPng.ico"), "Icon" };
-            yield return new object[] { Path.Combine("bitmaps", "almogaver32bits.tif"), "Tiff" };
+            yield return new object[] { Path.Join("bitmaps", "nature24bits.gif"), "Gif" };
+            yield return new object[] { Path.Join("bitmaps", "nature24bits.jpg"), "Jpeg" };
+            yield return new object[] { Path.Join("bitmaps", "VisualPng.ico"), "Icon" };
+            yield return new object[] { Path.Join("bitmaps", "almogaver32bits.tif"), "Tiff" };
         }
     }
 

--- a/src/System.Drawing.Common/tests/System/Drawing/Text/PrivateFontCollectionTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/Text/PrivateFontCollectionTests.cs
@@ -41,7 +41,7 @@ public class PrivateFontCollectionTests
         }
 
         using PrivateFontCollection fontCollection = new();
-        string relativePath = Path.Combine("fonts", "CodeNewRoman.ttf");
+        string relativePath = Path.Join("fonts", "CodeNewRoman.ttf");
         fontCollection.AddFontFile(relativePath);
 
         FontFamily fontFamily = Assert.Single(fontCollection.Families);

--- a/src/System.Windows.Forms.Analyzers/tests/UnitTests/CurrentReferences.cs
+++ b/src/System.Windows.Forms.Analyzers/tests/UnitTests/CurrentReferences.cs
@@ -56,11 +56,11 @@ public static class CurrentReferences
             "Release";
 #endif
 
-        WinFormsRefPath = Path.Combine(RepoRootPath, "artifacts", "obj", "System.Windows.Forms", configuration, tfm, "ref", "System.Windows.Forms.dll");
+        WinFormsRefPath = Path.Join(RepoRootPath, "artifacts", "obj", "System.Windows.Forms", configuration, tfm, "ref", "System.Windows.Forms.dll");
 
         // Specify absolute path to the reference assemblies because this version is not necessarily available in the nuget packages cache.
-        string netCoreAppRefPath = Path.Combine(RepoRootPath, ".dotnet", "packs", RefPackageName);
-        if (!Directory.Exists(Path.Combine(netCoreAppRefPath, netCoreRefsVersion)))
+        string netCoreAppRefPath = Path.Join(RepoRootPath, ".dotnet", "packs", RefPackageName);
+        if (!Directory.Exists(Path.Join(netCoreAppRefPath, netCoreRefsVersion)))
         {
             netCoreRefsVersion = GetAvailableVersion(netCoreAppRefPath, $"{netCoreRefsVersion.Split('.')[0]}.");
         }
@@ -71,8 +71,8 @@ public static class CurrentReferences
         NetCoreAppReferences = new ReferenceAssemblies(
             tfm,
             new PackageIdentity(RefPackageName, netCoreRefsVersion),
-            Path.Combine("ref", tfm))
-               .WithNuGetConfigFilePath(Path.Combine(RepoRootPath, "NuGet.Config"));
+            Path.Join("ref", tfm))
+               .WithNuGetConfigFilePath(Path.Join(RepoRootPath, "NuGet.Config"));
     }
 
     private static string GetAvailableVersion(string netCoreAppRefPath, string major)
@@ -98,7 +98,7 @@ public static class CurrentReferences
         }
 
         // First, try to use the local .NET SDK if it's there.
-        string sdkFolderPath = Path.Combine(rootFolderPath, ".dotnet", "sdk", version);
+        string sdkFolderPath = Path.Join(rootFolderPath, ".dotnet", "sdk", version);
         if (!Directory.Exists(sdkFolderPath))
         {
             return false;
@@ -120,7 +120,7 @@ public static class CurrentReferences
 
         while (currentFolderPath is not null)
         {
-            string globalJsonPath = Path.Combine(currentFolderPath, "global.json");
+            string globalJsonPath = Path.Join(currentFolderPath, "global.json");
             if (File.Exists(globalJsonPath))
             {
                 // We've found the repo root.
@@ -137,7 +137,7 @@ public static class CurrentReferences
 
     private static bool TryGetSdkVersion(string rootFolderPath, [NotNullWhen(true)] out string? version)
     {
-        string globalJsonPath = Path.Combine(rootFolderPath, "global.json");
+        string globalJsonPath = Path.Join(rootFolderPath, "global.json");
         string globalJsonString = File.ReadAllText(globalJsonPath);
         JsonObject? jsonObject = JsonNode.Parse(globalJsonString)?.AsObject();
         version = (string?)jsonObject?["sdk"]?["version"];
@@ -150,7 +150,7 @@ public static class CurrentReferences
         [NotNullWhen(true)] out string? tfm,
         [NotNullWhen(true)] out string? version)
     {
-        string configJsonPath = Path.Combine(sdkFolderPath, "dotnet.runtimeconfig.json");
+        string configJsonPath = Path.Join(sdkFolderPath, "dotnet.runtimeconfig.json");
         string configJsonString = File.ReadAllText(configJsonPath);
         JsonObject? jsonObject = JsonNode.Parse(configJsonString)?.AsObject();
         JsonNode? runtimeOptions = jsonObject?["runtimeOptions"];

--- a/src/System.Windows.Forms.Analyzers/tests/UnitTests/TestFileLoader.cs
+++ b/src/System.Windows.Forms.Analyzers/tests/UnitTests/TestFileLoader.cs
@@ -54,7 +54,7 @@ public static class TestFileLoader
         [CallerFilePath] string filePath = "")
     {
         string toolName = Path.GetFileName(Path.GetDirectoryName(filePath))!;
-        return await LoadTestFileAsync(Path.Combine("Analyzers", toolName), testName, SourceLanguage.None).ConfigureAwait(false);
+        return await LoadTestFileAsync(Path.Join("Analyzers", toolName), testName, SourceLanguage.None).ConfigureAwait(false);
     }
 
     public static async Task<string> GetGeneratorTestCodeAsync(
@@ -62,7 +62,7 @@ public static class TestFileLoader
         [CallerFilePath] string filePath = "")
     {
         string toolName = Path.GetFileName(Path.GetDirectoryName(filePath))!;
-        return await LoadTestFileAsync(Path.Combine("Generators", toolName), testName, SourceLanguage.None).ConfigureAwait(false);
+        return await LoadTestFileAsync(Path.Join("Generators", toolName), testName, SourceLanguage.None).ConfigureAwait(false);
     }
 
     public static async Task<string> GetCSAnalyzerTestCodeAsync(
@@ -70,7 +70,7 @@ public static class TestFileLoader
         [CallerFilePath] string filePath = "")
     {
         string toolName = Path.GetFileName(Path.GetDirectoryName(filePath))!;
-        return await LoadTestFileAsync(Path.Combine("Analyzers", toolName), testName).ConfigureAwait(false);
+        return await LoadTestFileAsync(Path.Join("Analyzers", toolName), testName).ConfigureAwait(false);
     }
 
     public static async Task<string> GetVBAnalyzerTestCodeAsync(
@@ -78,6 +78,6 @@ public static class TestFileLoader
         [CallerFilePath] string filePath = "")
     {
         string toolName = Path.GetFileName(Path.GetDirectoryName(filePath))!;
-        return await LoadTestFileAsync(Path.Combine("Analyzers", toolName), testName, SourceLanguage.VisualBasic).ConfigureAwait(false);
+        return await LoadTestFileAsync(Path.Join("Analyzers", toolName), testName, SourceLanguage.VisualBasic).ConfigureAwait(false);
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/PlatformDetection.Windows.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/PlatformDetection.Windows.cs
@@ -52,7 +52,7 @@ public static partial class PlatformDetection
 
     // Windows OneCoreUAP SKU doesn't have httpapi.dll
     public static bool IsNotOneCoreUAP =>
-        File.Exists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "System32", "httpapi.dll"));
+        File.Exists(Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "System32", "httpapi.dll"));
 
     public static bool IsWindowsIoTCore => GetWindowsProductType() is PRODUCT_IOTUAPCOMMERCIAL or PRODUCT_IOTUAP;
 

--- a/src/System.Windows.Forms/System/Resources/ResXDataNode.cs
+++ b/src/System.Windows.Forms/System/Resources/ResXDataNode.cs
@@ -131,7 +131,7 @@ public sealed class ResXDataNode : ISerializable
             if (fileRefDetails is not null && fileRefDetails.Length > 1)
             {
                 _fileRefFullPath = !Path.IsPathRooted(fileRefDetails[0]) && basePath is not null
-                    ? Path.Combine(basePath, fileRefDetails[0])
+                    ? Path.Join(basePath, fileRefDetails[0])
                     : fileRefDetails[0];
 
                 _fileRefType = fileRefDetails[1];

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/WebBrowser.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/WebBrowser.cs
@@ -612,7 +612,7 @@ public unsafe partial class WebBrowser : WebBrowserBase
     {
         get
         {
-            string mshtmlPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "mshtml.dll");
+            string mshtmlPath = Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.System), "mshtml.dll");
             FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(mshtmlPath);
             return new Version(fvi.FileMajorPart, fvi.FileMinorPart, fvi.FileBuildPart, fvi.FilePrivatePart);
         }

--- a/src/test/integration/System.Windows.Forms.IntegrationTests.Common/TestHelpers.cs
+++ b/src/test/integration/System.Windows.Forms.IntegrationTests.Common/TestHelpers.cs
@@ -55,7 +55,7 @@ public static class TestHelpers
             throw new ArgumentNullException(nameof(projectName));
 
         string repoRoot = GetRepoRoot();
-        string exePath = Path.Combine(
+        string exePath = Path.Join(
             repoRoot,
             $"artifacts\\bin\\{projectName}\\{Config}\\{TargetFramework}\\{projectName}.exe");
 
@@ -182,7 +182,7 @@ public static class TestHelpers
         string repoRoot = GetRepoRoot();
 
         // make sure there's a global.json
-        string jsonFile = Path.Combine(repoRoot, "global.json");
+        string jsonFile = Path.Join(repoRoot, "global.json");
         if (!File.Exists(jsonFile))
             throw new FileNotFoundException("global.json does not exist");
 
@@ -205,7 +205,7 @@ public static class TestHelpers
         // Check to see if the matching version is installed
         // The default install location is C:\Program Files\dotnet\sdk
         string defaultSdkRoot = @"C:\Program Files\dotnet\sdk";
-        string sdkPath = Path.Combine(defaultSdkRoot, dotnetVersion);
+        string sdkPath = Path.Join(defaultSdkRoot, dotnetVersion);
         if (!Directory.Exists(sdkPath))
             throw new DirectoryNotFoundException($"dotnet sdk {dotnetVersion} is not installed globally");
 
@@ -247,7 +247,7 @@ public static class TestHelpers
         {
             if (Directory.GetDirectories(currentDirectory, seek, SearchOption.TopDirectoryOnly).Length == 1)
             {
-                string ret = Path.Combine(currentDirectory, seek);
+                string ret = Path.Join(currentDirectory, seek);
                 return ret;
             }
 

--- a/src/test/integration/UIIntegrationTests/DragDropTests.cs
+++ b/src/test/integration/UIIntegrationTests/DragDropTests.cs
@@ -128,7 +128,7 @@ public class DragDropTests : ControlTestBase
         await RunTestAsync(dragDropForm =>
         {
             string dragAcceptRtfDestPath = string.Empty;
-            string dragDropDirectory = Path.Combine(Directory.GetCurrentDirectory(), DragDrop);
+            string dragDropDirectory = Path.Join(Directory.GetCurrentDirectory(), DragDrop);
             RunTest();
 
             unsafe void RunTest()
@@ -138,14 +138,14 @@ public class DragDropTests : ControlTestBase
 
                 try
                 {
-                    string dragAcceptRtfSourcePath = Path.Combine(Directory.GetCurrentDirectory(), Resources, DragAcceptRtf);
+                    string dragAcceptRtfSourcePath = Path.Join(Directory.GetCurrentDirectory(), Resources, DragAcceptRtf);
 
                     if (!Directory.Exists(dragDropDirectory))
                     {
                         Directory.CreateDirectory(dragDropDirectory);
                     }
 
-                    dragAcceptRtfDestPath = Path.Combine(dragDropDirectory, DragAcceptRtf);
+                    dragAcceptRtfDestPath = Path.Join(dragDropDirectory, DragAcceptRtf);
 
                     if (!File.Exists(dragAcceptRtfDestPath))
                     {
@@ -423,7 +423,7 @@ public class DragDropTests : ControlTestBase
     {
         await RunFormWithoutControlAsync(() => new DragImageDropDescriptionForm(TestOutputHelper), async (form) =>
         {
-            string dragAcceptRtfPath = Path.Combine(Directory.GetCurrentDirectory(), Resources, DragAcceptRtf);
+            string dragAcceptRtfPath = Path.Join(Directory.GetCurrentDirectory(), Resources, DragAcceptRtf);
             using RichTextBox richTextBox = new();
             richTextBox.Rtf = File.ReadAllText(dragAcceptRtfPath);
             string dragAcceptRtfContent = richTextBox.Rtf;
@@ -453,7 +453,7 @@ public class DragDropTests : ControlTestBase
     {
         await RunFormWithoutControlAsync(() => new DragImageDropDescriptionForm(TestOutputHelper), async (form) =>
         {
-            string dragAcceptRtfPath = Path.Combine(Directory.GetCurrentDirectory(), Resources, DragAcceptRtf);
+            string dragAcceptRtfPath = Path.Join(Directory.GetCurrentDirectory(), Resources, DragAcceptRtf);
             using RichTextBox richTextBox = new();
             richTextBox.Rtf = File.ReadAllText(dragAcceptRtfPath);
             string dragAcceptRtfContent = richTextBox.Rtf;
@@ -1082,7 +1082,7 @@ public class DragDropTests : ControlTestBase
                 return;
             }
 
-            string dragAcceptRtf = Path.Combine(Directory.GetCurrentDirectory(), Resources, DragAcceptRtf);
+            string dragAcceptRtf = Path.Join(Directory.GetCurrentDirectory(), Resources, DragAcceptRtf);
             if (File.Exists(dragAcceptRtf))
             {
                 string[] dropFiles = [dragAcceptRtf];
@@ -1142,7 +1142,7 @@ public class DragDropTests : ControlTestBase
         {
             _testOutputHelper.WriteLine($"Mouse down on drag source at position ({e.X},{e.Y}).");
 
-            string dragAcceptRtf = Path.Combine(Directory.GetCurrentDirectory(), Resources, DragAcceptRtf);
+            string dragAcceptRtf = Path.Join(Directory.GetCurrentDirectory(), Resources, DragAcceptRtf);
             if (File.Exists(dragAcceptRtf))
             {
                 string[] dropFiles = [dragAcceptRtf];

--- a/src/test/integration/UIIntegrationTests/Infra/DataCollectionService.cs
+++ b/src/test/integration/UIIntegrationTests/Infra/DataCollectionService.cs
@@ -234,13 +234,13 @@ internal static class DataCollectionService
             string sanitizedTestName = new(testName.Select(c => char.IsLetterOrDigit(c) ? c : '_').ToArray());
             string sanitizedErrorId = new(errorId.Select(c => char.IsLetterOrDigit(c) ? c : '_').ToArray());
 
-            return Path.Combine(Path.GetFullPath(logDirectory), $"{timestamp:HH.mm.ss}-{testName}-{errorId}{logId}.{extension}");
+            return Path.Join(Path.GetFullPath(logDirectory), $"{timestamp:HH.mm.ss}-{testName}-{errorId}{logId}.{extension}");
         }
     }
 
     internal static string GetLogDirectory()
     {
-        return Path.Combine(GetBaseLogDirectory(), "Screenshots");
+        return Path.Join(GetBaseLogDirectory(), "Screenshots");
     }
 
     private static string GetBaseLogDirectory()
@@ -258,10 +258,10 @@ internal static class DataCollectionService
         if (binPathSeparator > 0)
         {
             string configuration = Path.GetFileName(Path.GetDirectoryName(assemblyDirectory))!;
-            return Path.Combine(assemblyDirectory[..binPathSeparator], "log", configuration);
+            return Path.Join(assemblyDirectory[..binPathSeparator], "log", configuration);
         }
 
-        return Path.Combine(assemblyDirectory, "xUnitResults");
+        return Path.Join(assemblyDirectory, "xUnitResults");
     }
 
     private static string GetAssemblyDirectory()

--- a/src/test/integration/WinformsControlsTest/DragDrop.cs
+++ b/src/test/integration/WinformsControlsTest/DragDrop.cs
@@ -382,7 +382,7 @@ public partial class DragDrop : Form
 
     private void OpenCats()
     {
-        string dragDropDataDirectory = Path.Combine(
+        string dragDropDataDirectory = Path.Join(
             Directory.GetCurrentDirectory(),
             DragDropDataDirectory);
 
@@ -400,7 +400,7 @@ public partial class DragDrop : Form
 
     private string ReadAsciiText()
     {
-        string nyanCatAsciiPath = Path.Combine(
+        string nyanCatAsciiPath = Path.Join(
             Directory.GetCurrentDirectory(),
             DragDropDataDirectory,
             NyanCatAsciiTxt);
@@ -537,7 +537,7 @@ public partial class DragDrop : Form
             DataObject data = new(DataFormats.FileDrop,
                 new string[]
                 {
-                    Path.Combine(Directory.GetCurrentDirectory(),
+                    Path.Join(Directory.GetCurrentDirectory(),
                         DragDropDataDirectory,
                         DragAcceptRtf)
                 });

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/CursorConverterTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/CursorConverterTests.cs
@@ -36,7 +36,7 @@ public class CursorConverterTests
     public void CursorConverter_ConvertFrom_ByteArray_ReturnsExpected()
     {
         CursorConverter converter = new();
-        byte[] data = File.ReadAllBytes(Path.Combine("bitmaps", "10x16_one_entry_32bit.ico"));
+        byte[] data = File.ReadAllBytes(Path.Join("bitmaps", "10x16_one_entry_32bit.ico"));
         using Cursor cursor = Assert.IsType<Cursor>(converter.ConvertFrom(data));
         Assert.NotEqual(IntPtr.Zero, cursor.Handle);
         Assert.Equal(new Point(5, 8), cursor.HotSpot);
@@ -126,7 +126,7 @@ public class CursorConverterTests
     public void CursorConverter_ConvertTo_StreamToByteArray_ReturnsExpected()
     {
         CursorConverter converter = new();
-        byte[] data = File.ReadAllBytes(Path.Combine("bitmaps", "10x16_one_entry_32bit.ico"));
+        byte[] data = File.ReadAllBytes(Path.Join("bitmaps", "10x16_one_entry_32bit.ico"));
         using MemoryStream stream = new(data);
         using Cursor sourceCursor = new(stream);
         Assert.Equal(data, converter.ConvertTo(sourceCursor, typeof(byte[])));
@@ -136,7 +136,7 @@ public class CursorConverterTests
     public void CursorConverter_ConvertTo_FileToByteArray_ReturnsExpected()
     {
         CursorConverter converter = new();
-        string fileName = Path.Combine("bitmaps", "10x16_one_entry_32bit.ico");
+        string fileName = Path.Join("bitmaps", "10x16_one_entry_32bit.ico");
         byte[] data = File.ReadAllBytes(fileName);
         using Cursor sourceCursor = new(fileName);
         Assert.Equal(data, converter.ConvertTo(sourceCursor, typeof(byte[])));

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/CursorTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/CursorTests.cs
@@ -57,8 +57,8 @@ public class CursorTests
 
     public static IEnumerable<object[]> Ctor_ValidFile_TestData()
     {
-        yield return new object[] { Path.Combine("bitmaps", "cursor.cur"), Point.Empty };
-        yield return new object[] { Path.Combine("bitmaps", "10x16_one_entry_32bit.ico"), new Point(5, 8) };
+        yield return new object[] { Path.Join("bitmaps", "cursor.cur"), Point.Empty };
+        yield return new object[] { Path.Join("bitmaps", "10x16_one_entry_32bit.ico"), new Point(5, 8) };
     }
 
     [Theory]
@@ -76,7 +76,7 @@ public class CursorTests
     [Fact]
     public void Cursor_Ctor_Stream_NonStartPosition()
     {
-        using MemoryStream stream = new(File.ReadAllBytes(Path.Combine("bitmaps", "cursor.cur")));
+        using MemoryStream stream = new(File.ReadAllBytes(Path.Join("bitmaps", "cursor.cur")));
         stream.Position = 5;
         using Cursor cursor = new(stream);
         Assert.NotNull(cursor);
@@ -96,13 +96,13 @@ public class CursorTests
 
     public static IEnumerable<object[]> Ctor_InvalidFile_TestData()
     {
-        yield return new object[] { Path.Combine("bitmaps", "nature24bits.jpg") };
-        yield return new object[] { Path.Combine("bitmaps", "nature24bits.gif") };
-        yield return new object[] { Path.Combine("bitmaps", "1bit.png") };
-        yield return new object[] { Path.Combine("bitmaps", "almogaver24bits.bmp") };
-        yield return new object[] { Path.Combine("bitmaps", "telescope_01.wmf") };
-        yield return new object[] { Path.Combine("bitmaps", "milkmateya01.emf") };
-        yield return new object[] { Path.Combine("bitmaps", "EmptyFile") };
+        yield return new object[] { Path.Join("bitmaps", "nature24bits.jpg") };
+        yield return new object[] { Path.Join("bitmaps", "nature24bits.gif") };
+        yield return new object[] { Path.Join("bitmaps", "1bit.png") };
+        yield return new object[] { Path.Join("bitmaps", "almogaver24bits.bmp") };
+        yield return new object[] { Path.Join("bitmaps", "telescope_01.wmf") };
+        yield return new object[] { Path.Join("bitmaps", "milkmateya01.emf") };
+        yield return new object[] { Path.Join("bitmaps", "EmptyFile") };
     }
 
     [Theory]
@@ -326,7 +326,7 @@ public class CursorTests
     [Fact]
     public void Cursor_CopyHandle_Invoke_Success()
     {
-        using Cursor sourceCursor = new(Path.Combine("bitmaps", "10x16_one_entry_32bit.ico"));
+        using Cursor sourceCursor = new(Path.Join("bitmaps", "10x16_one_entry_32bit.ico"));
         IntPtr handle = sourceCursor.CopyHandle();
         Assert.NotEqual(IntPtr.Zero, handle);
         Assert.NotEqual(sourceCursor.Handle, handle);
@@ -341,7 +341,7 @@ public class CursorTests
     [Fact]
     public void Cursor_Dispose_InvokeOwned_Success()
     {
-        Cursor cursor = new(Path.Combine("bitmaps", "10x16_one_entry_32bit.ico"));
+        Cursor cursor = new(Path.Join("bitmaps", "10x16_one_entry_32bit.ico"));
         cursor.Dispose();
         Assert.Throws<ObjectDisposedException>(() => cursor.Handle);
         Assert.Throws<ObjectDisposedException>(() => cursor.HotSpot);
@@ -377,7 +377,7 @@ public class CursorTests
     [MemberData(nameof(Draw_TestData))]
     public void Cursor_Draw_InvokeValidCursor_Success(Rectangle rectangle)
     {
-        using Cursor cursor = new(Path.Combine("bitmaps", "10x16_one_entry_32bit.ico"));
+        using Cursor cursor = new(Path.Join("bitmaps", "10x16_one_entry_32bit.ico"));
         using Bitmap image = new(10, 10);
         using Graphics graphics = Graphics.FromImage(image);
         cursor.Draw(graphics, rectangle);
@@ -414,7 +414,7 @@ public class CursorTests
     [MemberData(nameof(Draw_TestData))]
     public void Cursor_DrawStretched_InvokeValidCursor_Success(Rectangle rectangle)
     {
-        using Cursor cursor = new(Path.Combine("bitmaps", "10x16_one_entry_32bit.ico"));
+        using Cursor cursor = new(Path.Join("bitmaps", "10x16_one_entry_32bit.ico"));
         using Bitmap image = new(10, 10);
         using Graphics graphics = Graphics.FromImage(image);
         cursor.DrawStretched(graphics, rectangle);
@@ -499,7 +499,7 @@ public class CursorTests
     [Fact]
     public void Cursor_ToString_CursorFromFile_ReturnsExpected()
     {
-        using Cursor cursor = new(Path.Combine("bitmaps", "10x16_one_entry_32bit.ico"));
+        using Cursor cursor = new(Path.Join("bitmaps", "10x16_one_entry_32bit.ico"));
         Assert.Equal("[Cursor: System.Windows.Forms.Cursor]", cursor.ToString());
     }
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/InputLanguageTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/InputLanguageTests.cs
@@ -214,7 +214,7 @@ public class InputLanguageTests
 
     private static void InstallUserLanguage(string languageTag)
     {
-        string file = Path.Combine(Path.GetTempPath(), $"install-language-{languageTag}.ps1");
+        string file = Path.Join(Path.GetTempPath(), $"install-language-{languageTag}.ps1");
         string script = $$"""
             $list = Get-WinUserLanguageList
             $list.Add("{{languageTag}}")
@@ -227,7 +227,7 @@ public class InputLanguageTests
 
     private static void UninstallUserLanguage(string languageTag)
     {
-        string file = Path.Combine(Path.GetTempPath(), $"uninstall-language-{languageTag}.ps1");
+        string file = Path.Join(Path.GetTempPath(), $"uninstall-language-{languageTag}.ps1");
         string script = $$"""
             $list = Get-WinUserLanguageList
             $item = $list | Where-Object {$_.LanguageTag -like "{{languageTag}}"}

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/RichTextBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/RichTextBoxTests.cs
@@ -10678,7 +10678,7 @@ public partial class RichTextBoxTests
         using RichTextBox richTextBox2 = new();
 
         string fileName = "SaveRichTextBox.rtf";
-        string projectDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "..", "..");
+        string projectDirectory = Path.Join(AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "..", "..");
         string filePath = $"{projectDirectory}/src/test/unit/System.Windows.Forms/TestResources/Files/{fileName}";
 
         try

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripControlHostTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripControlHostTests.cs
@@ -399,8 +399,8 @@ public class ToolStripControlHostTests
     {
         yield return new object[] { null };
         yield return new object[] { new Bitmap(10, 10) };
-        yield return new object[] { Image.FromFile(Path.Combine("bitmaps", "nature24bits.gif")) };
-        yield return new object[] { Image.FromFile(Path.Combine("bitmaps", "10x16_one_entry_32bit.ico")) };
+        yield return new object[] { Image.FromFile(Path.Join("bitmaps", "nature24bits.gif")) };
+        yield return new object[] { Image.FromFile(Path.Join("bitmaps", "10x16_one_entry_32bit.ico")) };
     }
 
     [WinFormsTheory]
@@ -1210,8 +1210,8 @@ public class ToolStripControlHostTests
         {
             yield return new object[] { imageTransparentColor, null };
             yield return new object[] { imageTransparentColor, new Bitmap(10, 10) };
-            yield return new object[] { imageTransparentColor, Image.FromFile(Path.Combine("bitmaps", "nature24bits.gif")) };
-            yield return new object[] { imageTransparentColor, Image.FromFile(Path.Combine("bitmaps", "10x16_one_entry_32bit.ico")) };
+            yield return new object[] { imageTransparentColor, Image.FromFile(Path.Join("bitmaps", "nature24bits.gif")) };
+            yield return new object[] { imageTransparentColor, Image.FromFile(Path.Join("bitmaps", "10x16_one_entry_32bit.ico")) };
         }
     }
 
@@ -1336,8 +1336,8 @@ public class ToolStripControlHostTests
         {
             yield return new object[] { null, color };
             yield return new object[] { new Bitmap(10, 10), color };
-            yield return new object[] { Image.FromFile(Path.Combine("bitmaps", "nature24bits.gif")), color };
-            yield return new object[] { Image.FromFile(Path.Combine("bitmaps", "10x16_one_entry_32bit.ico")), color };
+            yield return new object[] { Image.FromFile(Path.Join("bitmaps", "nature24bits.gif")), color };
+            yield return new object[] { Image.FromFile(Path.Join("bitmaps", "10x16_one_entry_32bit.ico")), color };
         }
     }
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripItemTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripItemTests.cs
@@ -1768,8 +1768,8 @@ public class ToolStripItemTests
     {
         yield return new object[] { null };
         yield return new object[] { new Bitmap(10, 10) };
-        yield return new object[] { Image.FromFile(Path.Combine("bitmaps", "nature24bits.gif")) };
-        yield return new object[] { Image.FromFile(Path.Combine("bitmaps", "10x16_one_entry_32bit.ico")) };
+        yield return new object[] { Image.FromFile(Path.Join("bitmaps", "nature24bits.gif")) };
+        yield return new object[] { Image.FromFile(Path.Join("bitmaps", "10x16_one_entry_32bit.ico")) };
     }
 
     [WinFormsTheory]
@@ -1864,8 +1864,8 @@ public class ToolStripItemTests
     {
         yield return new object[] { null, 0 };
         yield return new object[] { new Bitmap(10, 10), 1 };
-        yield return new object[] { Image.FromFile(Path.Combine("bitmaps", "nature24bits.gif")), 1 };
-        yield return new object[] { Image.FromFile(Path.Combine("bitmaps", "10x16_one_entry_32bit.ico")), 1 };
+        yield return new object[] { Image.FromFile(Path.Join("bitmaps", "nature24bits.gif")), 1 };
+        yield return new object[] { Image.FromFile(Path.Join("bitmaps", "10x16_one_entry_32bit.ico")), 1 };
     }
 
     [WinFormsTheory]
@@ -3784,8 +3784,8 @@ public class ToolStripItemTests
         {
             yield return new object[] { imageTransparentColor, null };
             yield return new object[] { imageTransparentColor, new Bitmap(10, 10) };
-            yield return new object[] { imageTransparentColor, Image.FromFile(Path.Combine("bitmaps", "nature24bits.gif")) };
-            yield return new object[] { imageTransparentColor, Image.FromFile(Path.Combine("bitmaps", "10x16_one_entry_32bit.ico")) };
+            yield return new object[] { imageTransparentColor, Image.FromFile(Path.Join("bitmaps", "nature24bits.gif")) };
+            yield return new object[] { imageTransparentColor, Image.FromFile(Path.Join("bitmaps", "10x16_one_entry_32bit.ico")) };
         }
     }
 
@@ -3814,8 +3814,8 @@ public class ToolStripItemTests
         {
             yield return new object[] { imageTransparentColor, null, 1 };
             yield return new object[] { imageTransparentColor, new Bitmap(10, 10), -1 };
-            yield return new object[] { imageTransparentColor, Image.FromFile(Path.Combine("bitmaps", "nature24bits.gif")), -1 };
-            yield return new object[] { imageTransparentColor, Image.FromFile(Path.Combine("bitmaps", "10x16_one_entry_32bit.ico")), -1 };
+            yield return new object[] { imageTransparentColor, Image.FromFile(Path.Join("bitmaps", "nature24bits.gif")), -1 };
+            yield return new object[] { imageTransparentColor, Image.FromFile(Path.Join("bitmaps", "10x16_one_entry_32bit.ico")), -1 };
         }
     }
 
@@ -3888,8 +3888,8 @@ public class ToolStripItemTests
         {
             yield return new object[] { imageTransparentColor, null, 0 };
             yield return new object[] { imageTransparentColor, new Bitmap(10, 10), 1 };
-            yield return new object[] { imageTransparentColor, Image.FromFile(Path.Combine("bitmaps", "nature24bits.gif")), 1 };
-            yield return new object[] { imageTransparentColor, Image.FromFile(Path.Combine("bitmaps", "10x16_one_entry_32bit.ico")), 1 };
+            yield return new object[] { imageTransparentColor, Image.FromFile(Path.Join("bitmaps", "nature24bits.gif")), 1 };
+            yield return new object[] { imageTransparentColor, Image.FromFile(Path.Join("bitmaps", "10x16_one_entry_32bit.ico")), 1 };
         }
     }
 
@@ -5602,8 +5602,8 @@ public class ToolStripItemTests
         {
             yield return new object[] { null, color };
             yield return new object[] { new Bitmap(10, 10), color };
-            yield return new object[] { Image.FromFile(Path.Combine("bitmaps", "nature24bits.gif")), color };
-            yield return new object[] { Image.FromFile(Path.Combine("bitmaps", "10x16_one_entry_32bit.ico")), color };
+            yield return new object[] { Image.FromFile(Path.Join("bitmaps", "nature24bits.gif")), color };
+            yield return new object[] { Image.FromFile(Path.Join("bitmaps", "10x16_one_entry_32bit.ico")), color };
         }
     }
 
@@ -5669,10 +5669,10 @@ public class ToolStripItemTests
         yield return new object[] { null, Color.Red, 0 };
         yield return new object[] { new Bitmap(10, 10), Color.Empty, 0 };
         yield return new object[] { new Bitmap(10, 10), Color.Red, 1 };
-        yield return new object[] { Image.FromFile(Path.Combine("bitmaps", "nature24bits.gif")), Color.Empty, 0 };
-        yield return new object[] { Image.FromFile(Path.Combine("bitmaps", "nature24bits.gif")), Color.Red, 1 };
-        yield return new object[] { Image.FromFile(Path.Combine("bitmaps", "10x16_one_entry_32bit.ico")), Color.Empty, 0 };
-        yield return new object[] { Image.FromFile(Path.Combine("bitmaps", "10x16_one_entry_32bit.ico")), Color.Red, 1 };
+        yield return new object[] { Image.FromFile(Path.Join("bitmaps", "nature24bits.gif")), Color.Empty, 0 };
+        yield return new object[] { Image.FromFile(Path.Join("bitmaps", "nature24bits.gif")), Color.Red, 1 };
+        yield return new object[] { Image.FromFile(Path.Join("bitmaps", "10x16_one_entry_32bit.ico")), Color.Empty, 0 };
+        yield return new object[] { Image.FromFile(Path.Join("bitmaps", "10x16_one_entry_32bit.ico")), Color.Red, 1 };
     }
 
     [WinFormsTheory]
@@ -5736,10 +5736,10 @@ public class ToolStripItemTests
         yield return new object[] { null, Color.Red, 1 };
         yield return new object[] { new Bitmap(10, 10), Color.Empty, 0 };
         yield return new object[] { new Bitmap(10, 10), Color.Red, 1 };
-        yield return new object[] { Image.FromFile(Path.Combine("bitmaps", "nature24bits.gif")), Color.Empty, 0 };
-        yield return new object[] { Image.FromFile(Path.Combine("bitmaps", "nature24bits.gif")), Color.Red, 1 };
-        yield return new object[] { Image.FromFile(Path.Combine("bitmaps", "10x16_one_entry_32bit.ico")), Color.Empty, 0 };
-        yield return new object[] { Image.FromFile(Path.Combine("bitmaps", "10x16_one_entry_32bit.ico")), Color.Red, 1 };
+        yield return new object[] { Image.FromFile(Path.Join("bitmaps", "nature24bits.gif")), Color.Empty, 0 };
+        yield return new object[] { Image.FromFile(Path.Join("bitmaps", "nature24bits.gif")), Color.Red, 1 };
+        yield return new object[] { Image.FromFile(Path.Join("bitmaps", "10x16_one_entry_32bit.ico")), Color.Empty, 0 };
+        yield return new object[] { Image.FromFile(Path.Join("bitmaps", "10x16_one_entry_32bit.ico")), Color.Red, 1 };
     }
 
     [WinFormsTheory]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripSeparatorTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripSeparatorTests.cs
@@ -113,8 +113,8 @@ public class ToolStripSeparatorTests
     {
         yield return new object[] { null };
         yield return new object[] { new Bitmap(10, 10) };
-        yield return new object[] { Image.FromFile(Path.Combine("bitmaps", "nature24bits.gif")) };
-        yield return new object[] { Image.FromFile(Path.Combine("bitmaps", "10x16_one_entry_32bit.ico")) };
+        yield return new object[] { Image.FromFile(Path.Join("bitmaps", "nature24bits.gif")) };
+        yield return new object[] { Image.FromFile(Path.Join("bitmaps", "10x16_one_entry_32bit.ico")) };
     }
 
     [WinFormsTheory]
@@ -420,8 +420,8 @@ public class ToolStripSeparatorTests
         {
             yield return new object[] { imageTransparentColor, null };
             yield return new object[] { imageTransparentColor, new Bitmap(10, 10) };
-            yield return new object[] { imageTransparentColor, Image.FromFile(Path.Combine("bitmaps", "nature24bits.gif")) };
-            yield return new object[] { imageTransparentColor, Image.FromFile(Path.Combine("bitmaps", "10x16_one_entry_32bit.ico")) };
+            yield return new object[] { imageTransparentColor, Image.FromFile(Path.Join("bitmaps", "nature24bits.gif")) };
+            yield return new object[] { imageTransparentColor, Image.FromFile(Path.Join("bitmaps", "10x16_one_entry_32bit.ico")) };
         }
     }
 
@@ -530,8 +530,8 @@ public class ToolStripSeparatorTests
         {
             yield return new object[] { null, color };
             yield return new object[] { new Bitmap(10, 10), color };
-            yield return new object[] { Image.FromFile(Path.Combine("bitmaps", "nature24bits.gif")), color };
-            yield return new object[] { Image.FromFile(Path.Combine("bitmaps", "10x16_one_entry_32bit.ico")), color };
+            yield return new object[] { Image.FromFile(Path.Join("bitmaps", "nature24bits.gif")), color };
+            yield return new object[] { Image.FromFile(Path.Join("bitmaps", "10x16_one_entry_32bit.ico")), color };
         }
     }
 

--- a/src/test/unit/accessibility/TestPassApp/CommonControl2.cs
+++ b/src/test/unit/accessibility/TestPassApp/CommonControl2.cs
@@ -13,7 +13,7 @@ public partial class CommonControl2 : Form
 
         string executable = Environment.ProcessPath;
         string executablePath = Path.GetDirectoryName(executable);
-        string page = Path.Combine(executablePath, "HTMLPage1.html");
+        string page = Path.Join(executablePath, "HTMLPage1.html");
         webBrowser1.Url = new Uri($"file://{page}", UriKind.Absolute);
     }
 }


### PR DESCRIPTION
It is faster, and more predictable. Most changes are in test code.

Tweak behavior in AssemblyNamesTypeResolutionService to use API based program files and add separator for proper contains checking. No need to use both paths, it will always be current process specific.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13090)