### PR TITLE
Remove extra dot at the end of resource string

### DIFF
--- a/src/System.Windows.Forms.Design/src/Resources/SR.resx
+++ b/src/System.Windows.Forms.Design/src/Resources/SR.resx
@@ -1369,7 +1369,7 @@ Press Ctrl+Enter to accept Text.</value>
     <value>Vertical Splitter Orientation.</value>
   </data>
   <data name="DesignerShortcutHorizontalOrientation" xml:space="preserve">
-    <value>Horizontal Splitter Orientation.</value>
+    <value>Horizontal Splitter Orientation</value>
   </data>
   <data name="TabControlAdd" xml:space="preserve">
     <value>Add Tab</value>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.cs.xlf
@@ -1156,8 +1156,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutHorizontalOrientation">
-        <source>Horizontal Splitter Orientation.</source>
-        <target state="translated">Orientace vodorovného rozdělovače.</target>
+        <source>Horizontal Splitter Orientation</source>
+        <target state="needs-review-translation">Orientace vodorovného rozdělovače.</target>
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutReparentControls">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.de.xlf
@@ -1156,8 +1156,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutHorizontalOrientation">
-        <source>Horizontal Splitter Orientation.</source>
-        <target state="translated">Horizontale Teilungsausrichtung.</target>
+        <source>Horizontal Splitter Orientation</source>
+        <target state="needs-review-translation">Horizontale Teilungsausrichtung.</target>
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutReparentControls">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.es.xlf
@@ -1156,8 +1156,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutHorizontalOrientation">
-        <source>Horizontal Splitter Orientation.</source>
-        <target state="translated">Orientación del divisor horizontal.</target>
+        <source>Horizontal Splitter Orientation</source>
+        <target state="needs-review-translation">Orientación del divisor horizontal.</target>
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutReparentControls">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.fr.xlf
@@ -1156,8 +1156,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutHorizontalOrientation">
-        <source>Horizontal Splitter Orientation.</source>
-        <target state="translated">Orientation du séparateur horizontal.</target>
+        <source>Horizontal Splitter Orientation</source>
+        <target state="needs-review-translation">Orientation du séparateur horizontal.</target>
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutReparentControls">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.it.xlf
@@ -1156,8 +1156,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutHorizontalOrientation">
-        <source>Horizontal Splitter Orientation.</source>
-        <target state="translated">Barra di divisione orizzontale.</target>
+        <source>Horizontal Splitter Orientation</source>
+        <target state="needs-review-translation">Barra di divisione orizzontale.</target>
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutReparentControls">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ja.xlf
@@ -1156,8 +1156,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutHorizontalOrientation">
-        <source>Horizontal Splitter Orientation.</source>
-        <target state="translated">上下スプリッターの方向。</target>
+        <source>Horizontal Splitter Orientation</source>
+        <target state="needs-review-translation">上下スプリッターの方向。</target>
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutReparentControls">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ko.xlf
@@ -1156,8 +1156,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutHorizontalOrientation">
-        <source>Horizontal Splitter Orientation.</source>
-        <target state="translated">가로 분할자 방향입니다.</target>
+        <source>Horizontal Splitter Orientation</source>
+        <target state="needs-review-translation">가로 분할자 방향입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutReparentControls">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pl.xlf
@@ -1156,8 +1156,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutHorizontalOrientation">
-        <source>Horizontal Splitter Orientation.</source>
-        <target state="translated">Pozioma orientacja rozdzielacza.</target>
+        <source>Horizontal Splitter Orientation</source>
+        <target state="needs-review-translation">Pozioma orientacja rozdzielacza.</target>
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutReparentControls">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pt-BR.xlf
@@ -1156,8 +1156,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutHorizontalOrientation">
-        <source>Horizontal Splitter Orientation.</source>
-        <target state="translated">Orientação Horizontal do Divisor.</target>
+        <source>Horizontal Splitter Orientation</source>
+        <target state="needs-review-translation">Orientação Horizontal do Divisor.</target>
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutReparentControls">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ru.xlf
@@ -1156,8 +1156,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutHorizontalOrientation">
-        <source>Horizontal Splitter Orientation.</source>
-        <target state="translated">Горизонтальная ориентация разделителя</target>
+        <source>Horizontal Splitter Orientation</source>
+        <target state="needs-review-translation">Горизонтальная ориентация разделителя</target>
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutReparentControls">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.tr.xlf
@@ -1156,8 +1156,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutHorizontalOrientation">
-        <source>Horizontal Splitter Orientation.</source>
-        <target state="translated">Yatay Bölümlendirici Yönü.</target>
+        <source>Horizontal Splitter Orientation</source>
+        <target state="needs-review-translation">Yatay Bölümlendirici Yönü.</target>
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutReparentControls">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hans.xlf
@@ -1156,8 +1156,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutHorizontalOrientation">
-        <source>Horizontal Splitter Orientation.</source>
-        <target state="translated">水平拆分器方向。</target>
+        <source>Horizontal Splitter Orientation</source>
+        <target state="needs-review-translation">水平拆分器方向。</target>
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutReparentControls">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hant.xlf
@@ -1156,8 +1156,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutHorizontalOrientation">
-        <source>Horizontal Splitter Orientation.</source>
-        <target state="translated">水平的分隔器方向。</target>
+        <source>Horizontal Splitter Orientation</source>
+        <target state="needs-review-translation">水平的分隔器方向。</target>
         <note />
       </trans-unit>
       <trans-unit id="DesignerShortcutReparentControls">


### PR DESCRIPTION
Fixes #12983

## Root Cause

- Extra dot at the end of resource string `Horizontal Splitter Orientation`

## Proposed changes

- Remove extra dot at the end of resource string `Horizontal Splitter Orientation`

## Customer Impact

- None

## Regression?

- No

## Risk

- Minimal

## Screenshots

### Before

![before](https://github.com/user-attachments/assets/586a5a9d-9701-4006-90f1-cb5c980650e7)

### After

![after](https://github.com/user-attachments/assets/4476f3fd-9475-4762-91ea-b8608bca7b68)

## Test methodology

- Manual

## Accessibility testing

## Test environment(s)

- 10.0.100-preview.3.25125.5


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13091)