### PR TITLE
ensured that help urls are set up for our analyzers

### DIFF
--- a/docs/analyzers/AppManifestAnalyzer.Help.md
+++ b/docs/analyzers/AppManifestAnalyzer.Help.md
@@ -7,10 +7,10 @@ are automatically referenced for Window Forms .NET applications.
 
 `AppManifestAnalyzer` is automatically invoked when a Windows Forms application (`OutputType=Exe` or `OutputType=WinExe`) has a custom app.manifest.
 
-## [WFO0003](https://learn.microsoft.com/dotnet/desktop/winforms/compiler-messages/wfo0003): Unsupported high DPI configuration.
+## [WFO0003](https://aka.ms/winforms-warnings/wfo0003): Unsupported high DPI configuration.
 
 Windows Forms applications should specify application DPI-awareness via the [application configuration](https://aka.ms/applicationconfiguration) or
-[`Application.SetHighDpiMode` API](https://docs.microsoft.com/dotnet/api/system.windows.forms.application.sethighdpimode).
+[`Application.SetHighDpiMode` API](https://learn.microsoft.com/dotnet/api/system.windows.forms.application.sethighdpimode).
 
 In NET6.0 the same warning was shipped with ID `WFAC010`.
 

--- a/docs/analyzers/ApplicationConfigurationGenerator.Help.md
+++ b/docs/analyzers/ApplicationConfigurationGenerator.Help.md
@@ -18,7 +18,7 @@ public static void Initialize()
 
 For more information on application configuration refer to https://aka.ms/applicationconfiguration.
 
-## [WFO0001](https://learn.microsoft.com/dotnet/desktop/winforms/compiler-messages/wfo0001): Unsupported project type.
+## [WFO0001](https://aka.ms/winforms-warnings/wfo0001): Unsupported project type.
 
 Only projects with `OutputType` set to "Exe" or "WinExe" are supported, because only applications projects define an application entry point,
 where the application bootstrap code must reside.
@@ -35,7 +35,7 @@ In NET6.0 the same error was shipped with ID `WFAC001`.
 
 ---
 
-## [WFO0002](https://learn.microsoft.com/dotnet/desktop/winforms/compiler-messages/wfo0002): Unsupported property value.
+## [WFO0002](https://aka.ms/winforms-warnings/wfo0002): Unsupported property value.
 
 The specified project property cannot be set to the given value.
 In NET6.0 the same error was shipped with ID `WFAC002`.

--- a/docs/analyzers/WinFormsCSharpAnalyzers.Help.md
+++ b/docs/analyzers/WinFormsCSharpAnalyzers.Help.md
@@ -8,7 +8,7 @@ are automatically referenced for Window Forms .NET applications.
 `MissingPropertySerializationConfiguration` checks for missing `DesignerSerializationVisibilityAttribute` on properties of classes which are
 derived from `Control` and could potentially serialize design-time data by the designer without the user being aware of it.
 
-### [WFO1000](https://learn.microsoft.com/dotnet/desktop/winforms/compiler-messages/wfo1000): Missing property serialization configuration.
+### [WFO1000](https://aka.ms/winforms-warnings/wfo1000): Missing property serialization configuration.
 
 Properties of classes derived from `Control` should have `DesignerSerializationVisibilityAttribute` 
 set to `DesignerSerializationVisibility.Content` or `DesignerSerializationVisibility.Visible`.
@@ -27,7 +27,7 @@ set to `DesignerSerializationVisibility.Content` or `DesignerSerializationVisibi
 
 `AvoidPassingFuncReturningTaskWithoutCancellationToken` checks parameters passed to `Control.InvokeAsync`. It suggests to use a cancellation token when passing a task to these methods.
 
-### [WFO2001](https://learn.microsoft.com/dotnet/desktop/winforms/compiler-messages/wfo2001): Task is being passed to InvokeAsync without a cancellation token.
+### [WFO2001](https://aka.ms/winforms-warnings/wfo2001): Task is being passed to InvokeAsync without a cancellation token.
 
 Avoid passing a `Func<T>` to `InvokeAsync` where `T` is a `Task` or `ValueTask`, unless your intention is for the delegate to simply be kicked off as an unsupervised task. Instead, use `Func<CancellationToken, ValueTask>` or `Func<CancellationToken, ValueTask<T>>`, so that the delegate passed to `InvokeAsync` can be awaited, allowing exceptions to be properly handled. 
 
@@ -45,7 +45,7 @@ Avoid passing a `Func<T>` to `InvokeAsync` where `T` is a `Task` or `ValueTask`,
 
 `ImplementITypedDataObject` checks custom implementations of the managed `IDataObject` interface and suggests to also implement the `ITypedDataObject` interface.
 
-### [WFO1001](https://github.com/dotnet/winforms/blob/main/docs/analyzers/WinFormsCSharpAnalyzers.Help.md#implementitypeddataobject): `IDataObject` type does not implement `ITypedDataObject`.
+### [WFO1001](https://aka.ms/winforms-warnings/wfo1001): `IDataObject` type does not implement `ITypedDataObject`.
 
 Types should implement `ITypedDataObject` to support best practices when interacting with data. Types will not work with typed APIs in Clipboard and other data exchange scenarios if they only implement `IDataObject`.
 

--- a/docs/analyzers/WinFormsVisualBasicAnalyzers.Help.md
+++ b/docs/analyzers/WinFormsVisualBasicAnalyzers.Help.md
@@ -8,7 +8,7 @@ are automatically referenced for Window Forms .NET applications.
 `MissingPropertySerializationConfiguration` checks for missing `DesignerSerializationVisibilityAttribute` on properties of classes which are 
 derived from `Control` and could potentially serialize design-time data by the designer without the user being aware of it.
 
-### [WFO1000](https://learn.microsoft.com/dotnet/desktop/winforms/compiler-messages/wfo1000): Missing property serialization configuration.
+### [WFO1000](https://aka.ms/winforms-warnings/wfo1000): Missing property serialization configuration.
 
 Properties of classes derived from `Control` should have `DesignerSerializationVisibilityAttribute` 
 set to `DesignerSerializationVisibility.Content` or `DesignerSerializationVisibility.Visible`.
@@ -27,7 +27,7 @@ set to `DesignerSerializationVisibility.Content` or `DesignerSerializationVisibi
 
 `AvoidPassingFuncReturningTaskWithoutCancellationToken` checks parameters passed to `Control.InvokeAsync`. It suggests to use a cancellation token when passing a task to these methods.
 
-### [WFO2001](https://learn.microsoft.com/dotnet/desktop/winforms/compiler-messages/wfo2001): Task is being passed to InvokeAsync without a cancellation token.
+### [WFO2001](https://aka.ms/winforms-warnings/wfo2001): Task is being passed to InvokeAsync without a cancellation token.
 
 Avoid passing a `Func<T>` to `InvokeAsync` where `T` is a `Task` or `ValueTask`, unless your intention is for the delegate to simply be kicked off as an unsupervised task. Instead, use `Func<CancellationToken, ValueTask>` or `Func<CancellationToken, ValueTask<T>>`, so that the delegate passed to `InvokeAsync` can be awaited, allowing exceptions to be properly handled. 
 
@@ -45,7 +45,7 @@ Avoid passing a `Func<T>` to `InvokeAsync` where `T` is a `Task` or `ValueTask`,
 
 `ImplementITypedDataObject` checks custom implementations of the managed `IDataObject` interface and suggests to also implement the `ITypedDataObject` interface.
 
-### [WFO1001](https://github.com/dotnet/winforms/blob/main/docs/analyzers/WinFormsCSharpAnalyzers.Help.md#implementitypeddataobject): `IDataObject` type does not implement `ITypedDataObject`.
+### [WFO1001](https://aka.ms/winforms-warnings/wfo1001): `IDataObject` type does not implement `ITypedDataObject`.
 
 Types should implement `ITypedDataObject` to support best practices when interacting with data. Types will not work with typed APIs in Clipboard and other data exchange scenarios if they only implement `IDataObject`.
 

--- a/docs/list-of-diagnostics.md
+++ b/docs/list-of-diagnostics.md
@@ -1,5 +1,7 @@
 # List of Diagnostics Produced by Windows Forms .NET
 
+We have 3 kinds of diagnostic messages: obsoletions, code analyzer diagnostics, and experimental feature compiler errors.
+
 ## Obsoletions
 
 Per the [Better Obsoletion](https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/better-obsoletion.md) design and similar to the [runtime diagnostics](https://github.com/dotnet/runtime/blob/main/docs/project/list-of-diagnostics.md), we now have a strategy for marking existing APIs as `[Obsolete]`. This takes advantage of the new diagnostic ID and URL template mechanisms introduced to `ObsoleteAttribute` in .NET 5.
@@ -16,7 +18,7 @@ The diagnostic ID values reserved for obsoletions are `WFDEV001` through `WFDEV9
 3. **If adding `<Obsolete>` attribute to Microsoft.VisualBasic.Forms assembly**, edit `src\Microsoft.VisualBasic.Forms\src\Obsoletions.vb` file.
 4. **Annotate `src` files by referring to the constants defined from `Obsoletions.cs`**:
     - Specify the `UrlFormat = Obsoletions.SharedUrlFormat`.
-    - Example: 
+    - Example:
         ```C#
         [Obsolete(
             Obsoletions.DomainUpDownAccessibleObjectMessage,
@@ -27,56 +29,82 @@ The diagnostic ID values reserved for obsoletions are `WFDEV001` through `WFDEV9
         ```xml
         <Compile Include="..\..\Common\src\Obsoletions.cs" Link="Common\Obsoletions.cs" />
         ```
-5. **Apply the `:book: documentation: breaking` label** to the PR that introduces the obsoletion.
-6. **Document the breaking change**
+5. **Associate the corresponding `aka.ms` link** with our repo's local help file in the `docs` folder, that describes your analyzer until the `learn` site docs are completed.
+6. **Apply the `:book: documentation: breaking` label** to the PR that introduces the obsoletion.
+7. **Document the breaking change**
     - In the breaking-change issue filed in [dotnet/docs](https://github.com/dotnet/docs), specifically mention that this breaking change is an obsoletion with a `WFDEV` diagnostic ID.
-    - Create another issue to add warning documentation to the learn web site [here](https://github.com/dotnet/docs-desktop/issues/new?template=diagnostic-compiler.yml)
-    - The documentation team will produce a PR that adds the obsoletion to the [WFDEV warnings](https://learn.microsoft.com/dotnet/desktop/winforms/wfdev-diagnostics/wfdev003) page and we will review it.
-    - Once the docs PR is published, get the newly create link to the doc and associate it with the corresponding `aka.ms` name in [redirection manager](https://akalinkmanager.trafficmanager.net/am/redirection/home?options=host:aka.ms )
+    - Create another issue to add documentation to the `learn` web site [in dotnet/docs-desktop repo](https://github.com/dotnet/docs-desktop/issues/new?template=diagnostic-compiler.yml)
+    - The documentation team will produce a PR that adds the warning or error documentation to the ["learn" site](https://learn.microsoft.com/dotnet/desktop/winforms/wfdev-diagnostics/wfdev003) page and we will review it.
+    - Once the docs PR is published, get the newly created link to the doc and associate it with the corresponding `aka.ms` name in [redirection manager](https://akalinkmanager.trafficmanager.net/am/redirection/home?options=host:aka.ms )
     - Connect with `@gewarren`, `@adegeo` or `@merriemcgaw` with any questions.
 
 ### Obsoletion Diagnostics (`WFDEV001` - `WFDEV999`)
 
-| Diagnostic ID     | Description |
-| :---------------- | :---------- |
-| `WFDEV001` | Casting to/from IntPtr is unsafe, use `WParamInternal`. |
-| `WFDEV001` | Casting to/from IntPtr is unsafe, use `LParamInternal`. |
-| `WFDEV001` | Casting to/from IntPtr is unsafe, use `ResultInternal`. |
-| `WFDEV002` | `DomainUpDown.DomainUpDownAccessibleObject` is no longer used to provide accessible support for `DomainUpDown` controls. Use `ControlAccessibleObject` instead. |
-| `WFDEV003` | `DomainUpDown.DomainItemAccessibleObject` is no longer used to provide accessible support for `DomainUpDown` items. |
-| `WFDEV004` | `Form.OnClosing`, `Form.OnClosed` and the corresponding events are obsolete. Use `Form.OnFormClosing`, `Form.OnFormClosed`, `Form.FormClosing` and `Form.FormClosed` instead. |
-| `WFDEV005` | `Clipboard.GetData(string)` method is obsolete. Use `Clipboard.TryGetData<T>` methods instead. |
-| `WFDEV005` | `DataObject.GetData` methods are obsolete. Use the corresponding `DataObject.TryGetData<T>` instead. |
-| `WFDEV005` | `ClipboardProxy.GetData(As String)` method is obsolete. Use `ClipboardProxy.TryGetData(Of T)(As String, As T)` instead. |
-| `WFDEV006` | `ContextMenu` is provided for binary compatibility with .NET Framework and is not intended to be used directly from your code. Use `ContextMenuStrip` instead. |
-| `WFDEV006` | `DataGrid` is provided for binary compatibility with .NET Framework and is not intended to be used directly from your code. Use `DataGridView` instead. |
-| `WFDEV006` | `MainMenu` is provided for binary compatibility with .NET Framework and is not intended to be used directly from your code. Use `MenuStrip` instead. |
-| `WFDEV006` | `Menu` is provided for binary compatibility with .NET Framework and is not intended to be used directly from your code. Use `ToolStripDropDown` and `ToolStripDropDownMenu` instead. |
-| `WFDEV006` | `StatusBar` is provided for binary compatibility with .NET Framework and is not intended to be used directly from your code. Use `StatusStrip` instead. |
-| `WFDEV006` | `ToolBar` is provided for binary compatibility with .NET Framework and is not intended to be used directly from your code. Use `ToolStrip` instead. |
+| Diagnostic ID | Introduced | Description |
+| :-------------| :--------- | :---------- |
+| `WFDEV001`    | NET?.0     | Casting to/from IntPtr is unsafe, use `WParamInternal`. |
+| `WFDEV001`    | NET?.0     | Casting to/from IntPtr is unsafe, use `LParamInternal`. |
+| `WFDEV001`    | NET?.0     | Casting to/from IntPtr is unsafe, use `ResultInternal`. |
+| `WFDEV002`    | NET?.0     | `DomainUpDown.DomainUpDownAccessibleObject` is no longer used to provide accessible support for `DomainUpDown` controls. Use `ControlAccessibleObject` instead. |
+| `WFDEV003`    | NET?.0     | `DomainUpDown.DomainItemAccessibleObject` is no longer used to provide accessible support for `DomainUpDown` items. |
+| `WFDEV004`    | NET10.0    | `Form.OnClosing`, `Form.OnClosed` and the corresponding events are obsolete. Use `Form.OnFormClosing`, `Form.OnFormClosed`, `Form.FormClosing` and `Form.FormClosed` instead. |
+| `WFDEV005`    | NET10.0    | `Clipboard.GetData(string)` method is obsolete. Use `Clipboard.TryGetData<T>` methods instead. |
+| `WFDEV005`    | NET10.0    | `DataObject.GetData` methods are obsolete. Use the corresponding `DataObject.TryGetData<T>` instead. |
+| `WFDEV005`    | NET10.0    | `ClipboardProxy.GetData(As String)` method is obsolete. Use `ClipboardProxy.TryGetData(Of T)(As String, As T)` instead. |
+| `WFDEV006`    | NET10.0    | `ContextMenu` is provided for binary compatibility with .NET Framework and is not intended to be used directly from your code. Use `ContextMenuStrip` instead. |
+| `WFDEV006`    | NET10.0    | `DataGrid` is provided for binary compatibility with .NET Framework and is not intended to be used directly from your code. Use `DataGridView` instead. |
+| `WFDEV006`    | NET10.0    | `MainMenu` is provided for binary compatibility with .NET Framework and is not intended to be used directly from your code. Use `MenuStrip` instead. |
+| `WFDEV006`    | NET10.0    | `Menu` is provided for binary compatibility with .NET Framework and is not intended to be used directly from your code. Use `ToolStripDropDown` and `ToolStripDropDownMenu` instead. |
+| `WFDEV006`    | NET10.0    | `StatusBar` is provided for binary compatibility with .NET Framework and is not intended to be used directly from your code. Use `StatusStrip` instead. |
+| `WFDEV006`    | NET10.0    | `ToolBar` is provided for binary compatibility with .NET Framework and is not intended to be used directly from your code. Use `ToolStrip` instead. |
 
-## Analyzer Diagnostics in the order they were shipped.
+## Analyzer Diagnostics.
 
-The current IDs are defined in [DiagnosticIDs.cs](https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms.Analyzers/src/System/Windows/Forms/Analyzers/Diagnostics/DiagnosticIDs.cs). A complete list of IDs, including those that were shipped and then replaced, is available in the `AnalyzerReleases.Shipped.md` and `AnalyzerReleases.Unshipped.md` files.
+### When adding a new analyzer
 
-| Diagnostic ID     | Description |
-| :---------------- | :---------- |
-| `WFAC001` | Unsupported project type. |
-| `WFAC002` | Unsupported property value. |
-| `WFAC010` | Unsupported high DPI configuration. |
-| `WFO0001` | Only projects with `OutputType=WindowsApplication` supported. |
-| `WFO0002` | ArgumentException: Project property '{0}' cannot be set to '{1}'|
-| `WFO0002` | ArgumentException: Project property '{0}' cannot be set to '{1}'. Reason: {2}.|
-| `WFO0003` | Remove high DPI settings from {0} and configure via Application.SetHighDpiMode API or '{1}' project property.|
-| `WFO0003` | Remove high DPI settings from {0} and configure via '{1}' property in Application Framework.|
-| `WFO1000` | Property '{0}' does not configure the code serialization for its property content.|
-| `WFO2001` | Task is being passed to `InvokeAsync` without a cancellation token |
-| `WFO1001` | Type `{0}` does not implement `ITypedDataObject` interface|
+1. **Add the diagnostics ID to the table below**.
+    - The current IDs for C#, VB and language-agnostic analyzers are defined in [DiagnosticIDs.cs](https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms.Analyzers/src/System/Windows/Forms/Analyzers/Diagnostics/DiagnosticIDs.cs). A complete list of IDs, including those that were shipped and then replaced, is available in the `AnalyzerReleases.Shipped.md` and `AnalyzerReleases.Unshipped.md` files.
+    - Starting in NET9.0, we are using `WFO####` format for code analyzer diagnostics IDs.
+2. **Create a new Descriptor** in the analyzer code.
+    - C#
+    - VB
+3. **Associate the corresponding `aka.ms` link** with our repo's `.md` file in the `docs` folder that describes your analyzer until the `learn` site docs are completed.
+    - C#
+    - VB
+4. **Follow [documentation steps described for obsoletions](#apply-the-book-documentation-breaking-label-to-the-pr-that-introduces-the-obsoletion)** above.
+
+| Diagnostic ID | Introduced | Description |
+| :-------------| :--------- | :---------- |
+| `WFAC001`     | NET6.0     | Unsupported project type. |
+| `WFAC002`     | NET6.0     | Unsupported property value. |
+| `WFAC010`     | NET6.0     | Unsupported high DPI configuration. |
+| `WFO0001`     | NET9.0     | Only projects with `OutputType=WindowsApplication` supported. |
+| `WFO0002`     | NET9.0     | ArgumentException: Project property '{0}' cannot be set to '{1}'|
+| `WFO0002`     | NET9.0     | ArgumentException: Project property '{0}' cannot be set to '{1}'. Reason: {2}.|
+| `WFO0003`     | NET9.0     | Remove high DPI settings from {0} and configure via Application.SetHighDpiMode API or '{1}' project property.|
+| `WFO0003`     | NET9.0     | Remove high DPI settings from {0} and configure via '{1}' property in Application Framework.|
+| `WFO1000`     | NET9.0     | Property '{0}' does not configure the code serialization for its property content.|
+| `WFO2001`     | NET9.0     | Task is being passed to `InvokeAsync` without a cancellation token |
+| `WFO1001`     | NET10.0    | Type `{0}` does not implement `ITypedDataObject` interface |
 
 ## Experimental Feature compiler errors
 
-| Diagnostic ID     | Description |
-| :---------------- | :---------- |
-| `WFO5001` | `System.Windows.Forms.Application.SetColorMode`(System.Windows.Forms.SystemColorMode) is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.|
-| `WFO5001` | `System.Windows.Forms.SystemColorMode` is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.|
-| `WFO5002` | `System.Windows.Forms.Form.ShowAsync` is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.|
+See [Preview APIs - .NET | Microsoft Learn](https://learn.microsoft.com/dotnet/fundamentals/apicompat/preview-apis) for more information.
+
+1. **Add the diagnostics ID to the table below**.
+    - The current IDs for C#, VB and language-agnostic analyzers are defined in [DiagnosticIDs.cs](https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms.Analyzers/src/System/Windows/Forms/Analyzers/Diagnostics/DiagnosticIDs.cs). A complete list of IDs, including those that were shipped and then replaced, is available in the `AnalyzerReleases.Shipped.md` and `AnalyzerReleases.Unshipped.md` files.
+2. **Add a `Experimental` attribute** to your API.
+    - C#
+    - VB
+3. **Associate the corresponding `aka.ms` link** with our repo's `.md` file in the `docs` folder that describes your analyzer until the `learn` site docs are completed.
+    - C#
+    - VB
+4. **Follow [documentation steps described for obsoletions](#apply-the-book-documentation-breaking-label-to-the-pr-that-introduces-the-obsoletion)** above.
+
+
+| Diagnostic ID | Introduced | Removed | Description |
+| :------------ | :--------- | :------ | :---------- |
+| `WFO5001`     | NET9.0     |         | `System.Windows.Forms.Application.SetColorMode`(System.Windows.Forms.SystemColorMode) is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed. |
+| `WFO5001`     | NET9.0     |         | `System.Windows.Forms.SystemColorMode` is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed. |
+| `WFO5002`     | NET9.0     |         | `System.Windows.Forms.Form.ShowAsync` is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed. |
+

--- a/docs/list-of-diagnostics.md
+++ b/docs/list-of-diagnostics.md
@@ -66,7 +66,7 @@ The diagnostic ID values reserved for obsoletions are `WFDEV001` through `WFDEV9
     - The current IDs for C#, VB and language-agnostic analyzers are defined in [DiagnosticIDs.cs](https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms.Analyzers/src/System/Windows/Forms/Analyzers/Diagnostics/DiagnosticIDs.cs). A complete list of IDs, including those that were shipped and then replaced, is available in the `AnalyzerReleases.Shipped.md` and `AnalyzerReleases.Unshipped.md` files.
     - Starting in NET9.0, we are using `WFO####` format for code analyzer diagnostics IDs.
 2. **Create a new Descriptor** in the analyzer code.
-    - C#
+    - C# [CSharpDiagnosticDescriptors.cs](https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/CSharp/Analyzers/Diagnostics/CSharpDiagnosticDescriptors.cs#L10)
     - VB
 3. **Associate the corresponding `aka.ms` link** with our repo's `.md` file in the `docs` folder that describes your analyzer until the `learn` site docs are completed.
     - C#

--- a/docs/list-of-diagnostics.md
+++ b/docs/list-of-diagnostics.md
@@ -1,6 +1,6 @@
 # List of Diagnostics Produced by Windows Forms .NET
 
-We have 3 kinds of diagnostic messages: obsoletions, code analyzer diagnostics, and experimental feature compiler errors.
+We have three kinds of diagnostic messages: obsoletions, code analyzer diagnostics, and experimental feature compiler errors.
 
 ## Obsoletions
 
@@ -11,12 +11,12 @@ The diagnostic ID values reserved for obsoletions are `WFDEV001` through `WFDEV9
 ### Acceptance Criteria for Adding an Obsoletion
 
 1. **Add the obsoletion to the table below**, claiming the next diagnostic ID.
-    - Ensure the description is meaningful within the context of this table, and without requiring the context of the calling code.
+    - Ensure the description is meaningful within the context of this table and without requiring the context of the calling code.
 2. **Add new constants to `src\Common\src\Obsoletions.cs`**, following the existing conventions:
     - A `...Message` const using the same description added to the table below.
     - A `...DiagnosticId` const for the `WFDEV###` ID.
-3. **If adding `<Obsolete>` attribute to Microsoft.VisualBasic.Forms assembly**, edit `src\Microsoft.VisualBasic.Forms\src\Obsoletions.vb` file.
-4. **Annotate `src` files by referring to the constants defined from `Obsoletions.cs`**:
+3. **If adding the `<Obsolete>` attribute to the Microsoft.VisualBasic.Forms assembly**, edit the `src\Microsoft.VisualBasic.Forms\src\Obsoletions.vb` file.
+4. **Annotate `src` files by referring to the constants defined in `Obsoletions.cs`**:
     - Specify the `UrlFormat = Obsoletions.SharedUrlFormat`.
     - Example:
         ```C#
@@ -30,15 +30,15 @@ The diagnostic ID values reserved for obsoletions are `WFDEV001` through `WFDEV9
         <Compile Include="..\..\Common\src\Obsoletions.cs" Link="Common\Obsoletions.cs" />
         ```
 5. **Create the new `aka.ms` link**
-    - Point it to repo's `.md` file in the `docs` folder that describes your analyzer until the `learn` site docs are completed in the [redirection manager](https://akalinkmanager.trafficmanager.net/am/redirection/home)
-    - Set security group to the team alias
+    - Point it to the repo's `.md` file in the `docs` folder that describes your analyzer until the `learn` site docs are completed in the [redirection manager](https://akalinkmanager.trafficmanager.net/am/redirection/home)
+    - Set the security group to the team alias
 6. **Apply the `:book: documentation: breaking` label** to the PR that introduces the obsoletion.
 7. **Document the breaking change**
     - In the breaking-change issue filed in [dotnet/docs](https://github.com/dotnet/docs), specifically mention that this breaking change is an obsoletion with a `WFDEV` diagnostic ID.
-    - Create another issue to add documentation to the `learn` web site [in dotnet/docs-desktop repo](https://github.com/dotnet/docs-desktop/issues/new?template=diagnostic-compiler.yml)
-    - The documentation team will produce a PR that adds the warning or error documentation to the ["learn" site](https://learn.microsoft.com/dotnet/desktop/winforms/wfdev-diagnostics/wfdev003) page and we will review it.
-    - Once the docs PR is published, get the newly created link to the doc and associate it with the corresponding `aka.ms` name in [redirection manager](https://akalinkmanager.trafficmanager.net/am/redirection/home?options=host:aka.ms )
-    - Connect with `@gewarren`, `@adegeo` or `@merriemcgaw` with any questions.
+    - Create another issue to add documentation to the `learn` website in the [dotnet/docs-desktop repo](https://github.com/dotnet/docs-desktop/issues/new?template=diagnostic-compiler.yml)
+    - The documentation team will produce a PR that adds the warning or error documentation to the [`learn` site](https://learn.microsoft.com/dotnet/desktop/winforms/wfdev-diagnostics/wfdev003) page, and we will review it.
+    - Once the docs PR is published, get the newly created link to the doc and associate it with the corresponding `aka.ms` name in the [redirection manager](https://akalinkmanager.trafficmanager.net/am/redirection/home?options=host:aka.ms)
+    - Connect with `@gewarren`, `@adegeo`, or `@merriemcgaw` with any questions.
 
 ### Obsoletion Diagnostics (`WFDEV001` - `WFDEV999`)
 
@@ -60,16 +60,16 @@ The diagnostic ID values reserved for obsoletions are `WFDEV001` through `WFDEV9
 | `WFDEV006`    | NET10.0    | `StatusBar` is provided for binary compatibility with .NET Framework and is not intended to be used directly from your code. Use `StatusStrip` instead. |
 | `WFDEV006`    | NET10.0    | `ToolBar` is provided for binary compatibility with .NET Framework and is not intended to be used directly from your code. Use `ToolStrip` instead. |
 
-## Analyzer Diagnostics.
+## Analyzer Diagnostics
 
 ### When adding a new analyzer
 
 1. **Add the diagnostic ID to the table below**.
-    - The current IDs for C#, VB and language-agnostic analyzers are defined in [DiagnosticIDs.cs](https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms.Analyzers/src/System/Windows/Forms/Analyzers/Diagnostics/DiagnosticIDs.cs). Complete list of IDs, including those that were shipped and then replaced, is available in the `AnalyzerReleases.Shipped.md` and `AnalyzerReleases.Unshipped.md` files.
-    - Starting in NET9.0, we are using `WFO####` format for code analyzer diagnostic IDs.
-2. **Create a new Descriptor** in the analyzer code using [DiagnosticDescriptorHelper.Create](https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/CSharp/Analyzers/Diagnostics/DiagnosticDescriptorHelper.cs#L10)
-    - this method will generate the help link in https://aka.ms/winforms-warnings/WFO#### format.
-3. **Follow [documentation steps 5-7 described for obsoletions](#create-the-new-aka.ms-link)** above.
+    - The current IDs for C#, VB, and language-agnostic analyzers are defined in [DiagnosticIDs.cs](https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms.Analyzers/src/System/Windows/Forms/Analyzers/Diagnostics/DiagnosticIDs.cs). A complete list of IDs, including those that were shipped and then replaced, is available in the `AnalyzerReleases.Shipped.md` and `AnalyzerReleases.Unshipped.md` files.
+    - Starting in NET9.0, we are using the `WFO####` format for code analyzer diagnostic IDs.
+2. **Create a new Descriptor** in the analyzer code by calling [DiagnosticDescriptorHelper.Create](https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/CSharp/Analyzers/Diagnostics/DiagnosticDescriptorHelper.cs#L10)
+    - This method will generate the help link in the https://aka.ms/winforms-warnings/WFO#### format.
+3. **Follow the [documentation steps 5-7 described for obsoletions](#create-the-new-aka.ms-link)** above.
 
 | Diagnostic ID | Introduced | Description |
 | :-------------| :--------- | :---------- |
@@ -85,19 +85,19 @@ The diagnostic ID values reserved for obsoletions are `WFDEV001` through `WFDEV9
 | `WFO2001`     | NET9.0     | Task is being passed to `InvokeAsync` without a cancellation token |
 | `WFO1001`     | NET10.0    | Type `{0}` does not implement `ITypedDataObject` interface |
 
-## Experimental Feature compiler errors
+## Experimental Feature Compiler Errors
 
 See [Preview APIs - .NET | Microsoft Learn](https://learn.microsoft.com/dotnet/fundamentals/apicompat/preview-apis) for more information.
 Documentation for experimental features is available in the [Experimental Help](https://github.com/dotnet/winforms/blob/main/docs/analyzers/Experimental.Help.md) file.
 
 1. **Add the diagnostic ID to the table below**.
-        - The current IDs for C#, VB and language-agnostic analyzers are defined in [DiagnosticIDs.cs](https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms.Analyzers/src/System/Windows/Forms/Analyzers/Diagnostics/DiagnosticIDs.cs). Complete list of IDs, including those that were shipped and then replaced, is available in the `AnalyzerReleases.Shipped.md` and `AnalyzerReleases.Unshipped.md` files.
+    - The current IDs are defined in [DiagnosticIDs.cs](https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms.Analyzers/src/System/Windows/Forms/Analyzers/Diagnostics/DiagnosticIDs.cs).
 2. **Add an `[Experimental](https://learn.microsoft.com/dotnet/api/system.diagnostics.codeanalysis.experimentalattribute)` attribute** to your API.
     - Example:
     ```c#
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     ```
-3. **Follow [documentation steps 5-7 described for obsoletions](#create-the-new-aka.ms-link)** above.
+3. **Follow the [documentation steps 5-7 described for obsoletions](#create-the-new-aka.ms-link)** above.
 
 | Diagnostic ID | Introduced | Removed | Description |
 | :------------ | :--------- | :------ | :---------- |

--- a/docs/list-of-diagnostics.md
+++ b/docs/list-of-diagnostics.md
@@ -29,7 +29,9 @@ The diagnostic ID values reserved for obsoletions are `WFDEV001` through `WFDEV9
         ```xml
         <Compile Include="..\..\Common\src\Obsoletions.cs" Link="Common\Obsoletions.cs" />
         ```
-5. **Associate the corresponding `aka.ms` link** with our repo's local help file in the `docs` folder, that describes your analyzer until the `learn` site docs are completed.
+5. **Create the new `aka.ms` link**
+    - Point it to repo's `.md` file in the `docs` folder that describes your analyzer until the `learn` site docs are completed in the [redirection manager](https://akalinkmanager.trafficmanager.net/am/redirection/home)
+    - Set security group to the team alias
 6. **Apply the `:book: documentation: breaking` label** to the PR that introduces the obsoletion.
 7. **Document the breaking change**
     - In the breaking-change issue filed in [dotnet/docs](https://github.com/dotnet/docs), specifically mention that this breaking change is an obsoletion with a `WFDEV` diagnostic ID.
@@ -42,11 +44,11 @@ The diagnostic ID values reserved for obsoletions are `WFDEV001` through `WFDEV9
 
 | Diagnostic ID | Introduced | Description |
 | :-------------| :--------- | :---------- |
-| `WFDEV001`    | NET?.0     | Casting to/from IntPtr is unsafe, use `WParamInternal`. |
-| `WFDEV001`    | NET?.0     | Casting to/from IntPtr is unsafe, use `LParamInternal`. |
-| `WFDEV001`    | NET?.0     | Casting to/from IntPtr is unsafe, use `ResultInternal`. |
-| `WFDEV002`    | NET?.0     | `DomainUpDown.DomainUpDownAccessibleObject` is no longer used to provide accessible support for `DomainUpDown` controls. Use `ControlAccessibleObject` instead. |
-| `WFDEV003`    | NET?.0     | `DomainUpDown.DomainItemAccessibleObject` is no longer used to provide accessible support for `DomainUpDown` items. |
+| `WFDEV001`    | NET7.0     | Casting to/from IntPtr is unsafe, use `WParamInternal`. |
+| `WFDEV001`    | NET7.0     | Casting to/from IntPtr is unsafe, use `LParamInternal`. |
+| `WFDEV001`    | NET7.0     | Casting to/from IntPtr is unsafe, use `ResultInternal`. |
+| `WFDEV002`    | NET8.0     | `DomainUpDown.DomainUpDownAccessibleObject` is no longer used to provide accessible support for `DomainUpDown` controls. Use `ControlAccessibleObject` instead. |
+| `WFDEV003`    | NET8.0     | `DomainUpDown.DomainItemAccessibleObject` is no longer used to provide accessible support for `DomainUpDown` items. |
 | `WFDEV004`    | NET10.0    | `Form.OnClosing`, `Form.OnClosed` and the corresponding events are obsolete. Use `Form.OnFormClosing`, `Form.OnFormClosed`, `Form.FormClosing` and `Form.FormClosed` instead. |
 | `WFDEV005`    | NET10.0    | `Clipboard.GetData(string)` method is obsolete. Use `Clipboard.TryGetData<T>` methods instead. |
 | `WFDEV005`    | NET10.0    | `DataObject.GetData` methods are obsolete. Use the corresponding `DataObject.TryGetData<T>` instead. |
@@ -62,16 +64,12 @@ The diagnostic ID values reserved for obsoletions are `WFDEV001` through `WFDEV9
 
 ### When adding a new analyzer
 
-1. **Add the diagnostics ID to the table below**.
-    - The current IDs for C#, VB and language-agnostic analyzers are defined in [DiagnosticIDs.cs](https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms.Analyzers/src/System/Windows/Forms/Analyzers/Diagnostics/DiagnosticIDs.cs). A complete list of IDs, including those that were shipped and then replaced, is available in the `AnalyzerReleases.Shipped.md` and `AnalyzerReleases.Unshipped.md` files.
-    - Starting in NET9.0, we are using `WFO####` format for code analyzer diagnostics IDs.
-2. **Create a new Descriptor** in the analyzer code.
-    - C# [CSharpDiagnosticDescriptors.cs](https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/CSharp/Analyzers/Diagnostics/CSharpDiagnosticDescriptors.cs#L10)
-    - VB
-3. **Associate the corresponding `aka.ms` link** with our repo's `.md` file in the `docs` folder that describes your analyzer until the `learn` site docs are completed.
-    - C#
-    - VB
-4. **Follow [documentation steps described for obsoletions](#apply-the-book-documentation-breaking-label-to-the-pr-that-introduces-the-obsoletion)** above.
+1. **Add the diagnostic ID to the table below**.
+    - The current IDs for C#, VB and language-agnostic analyzers are defined in [DiagnosticIDs.cs](https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms.Analyzers/src/System/Windows/Forms/Analyzers/Diagnostics/DiagnosticIDs.cs). Complete list of IDs, including those that were shipped and then replaced, is available in the `AnalyzerReleases.Shipped.md` and `AnalyzerReleases.Unshipped.md` files.
+    - Starting in NET9.0, we are using `WFO####` format for code analyzer diagnostic IDs.
+2. **Create a new Descriptor** in the analyzer code using [DiagnosticDescriptorHelper.Create](https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/CSharp/Analyzers/Diagnostics/DiagnosticDescriptorHelper.cs#L10)
+    - this method will generate the help link in https://aka.ms/winforms-warnings/WFO#### format.
+3. **Follow [documentation steps 5-7 described for obsoletions](#create-the-new-aka.ms-link)** above.
 
 | Diagnostic ID | Introduced | Description |
 | :-------------| :--------- | :---------- |
@@ -90,21 +88,19 @@ The diagnostic ID values reserved for obsoletions are `WFDEV001` through `WFDEV9
 ## Experimental Feature compiler errors
 
 See [Preview APIs - .NET | Microsoft Learn](https://learn.microsoft.com/dotnet/fundamentals/apicompat/preview-apis) for more information.
+Documentation for experimental features is available in the [Experimental Help](https://github.com/dotnet/winforms/blob/main/docs/analyzers/Experimental.Help.md) file.
 
-1. **Add the diagnostics ID to the table below**.
-    - The current IDs for C#, VB and language-agnostic analyzers are defined in [DiagnosticIDs.cs](https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms.Analyzers/src/System/Windows/Forms/Analyzers/Diagnostics/DiagnosticIDs.cs). A complete list of IDs, including those that were shipped and then replaced, is available in the `AnalyzerReleases.Shipped.md` and `AnalyzerReleases.Unshipped.md` files.
-2. **Add a `Experimental` attribute** to your API.
-    - C#
-    - VB
-3. **Associate the corresponding `aka.ms` link** with our repo's `.md` file in the `docs` folder that describes your analyzer until the `learn` site docs are completed.
-    - C#
-    - VB
-4. **Follow [documentation steps described for obsoletions](#apply-the-book-documentation-breaking-label-to-the-pr-that-introduces-the-obsoletion)** above.
-
+1. **Add the diagnostic ID to the table below**.
+        - The current IDs for C#, VB and language-agnostic analyzers are defined in [DiagnosticIDs.cs](https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms.Analyzers/src/System/Windows/Forms/Analyzers/Diagnostics/DiagnosticIDs.cs). Complete list of IDs, including those that were shipped and then replaced, is available in the `AnalyzerReleases.Shipped.md` and `AnalyzerReleases.Unshipped.md` files.
+2. **Add an `[Experimental](https://learn.microsoft.com/dotnet/api/system.diagnostics.codeanalysis.experimentalattribute)` attribute** to your API.
+    - Example:
+    ```c#
+    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
+    ```
+3. **Follow [documentation steps 5-7 described for obsoletions](#create-the-new-aka.ms-link)** above.
 
 | Diagnostic ID | Introduced | Removed | Description |
 | :------------ | :--------- | :------ | :---------- |
 | `WFO5001`     | NET9.0     |         | `System.Windows.Forms.Application.SetColorMode`(System.Windows.Forms.SystemColorMode) is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed. |
 | `WFO5001`     | NET9.0     |         | `System.Windows.Forms.SystemColorMode` is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed. |
 | `WFO5002`     | NET9.0     |         | `System.Windows.Forms.Form.ShowAsync` is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed. |
-

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/ApplyApplicationDefaultsEventArgs.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/ApplyApplicationDefaultsEventArgs.vb
@@ -34,7 +34,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
         '''  Setting this property inside the event handler determines the
         '''  <see cref="Application.ColorMode"/> for the application.
         ''' </summary>
-        <Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat:=WindowsFormsApplicationBase.WinFormsExperimentalUrl)>
+        <Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat:=DiagnosticIDs.UrlFormat)>
         Public Property ColorMode As SystemColorMode
 
         ''' <summary>

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
@@ -122,8 +122,6 @@ Namespace Microsoft.VisualBasic.ApplicationServices
         ' Milliseconds.
         Friend Const MinimumSplashExposureDefault As Integer = 2000
 
-        Friend Const WinFormsExperimentalUrl As String = "https://aka.ms/winforms-experimental/{0}"
-
         ' Used to marshal a call to Dispose on the Splash Screen.
         Private Delegate Sub DisposeDelegate()
 
@@ -196,7 +194,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
         ''' <value>
         '''  The <see cref="SystemColorMode"/> that the application is running in.
         ''' </value>
-        <Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat:=WinFormsExperimentalUrl)>
+        <Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat:=DiagnosticIDs.UrlFormat)>
         <EditorBrowsable(EditorBrowsableState.Never)>
         Protected Property ColorMode As SystemColorMode
             Get

--- a/src/System.Windows.Forms.Analyzers.CSharp/src/AnalyzerReleases.Shipped.md
+++ b/src/System.Windows.Forms.Analyzers.CSharp/src/AnalyzerReleases.Shipped.md
@@ -7,8 +7,8 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
-WFAC001 | ApplicationConfiguration | Error | ApplicationConfigurationGenerator, [Documentation](https://learn.microsoft.com/dotnet/desktop/winforms/wfdev-diagnostics/wfac001)
-WFAC002 | ApplicationConfiguration | Error | ApplicationConfigurationGenerator, [Documentation](https://learn.microsoft.com/dotnet/desktop/winforms/wfdev-diagnostics/wfac002)
+WFAC001 | ApplicationConfiguration | Error | ApplicationConfigurationGenerator, [Documentation](https://aka.ms/winforms-warnings/wfac001)
+WFAC002 | ApplicationConfiguration | Error | ApplicationConfigurationGenerator, [Documentation](https://aka.ms/winforms-warnings/wfac002)
 
 ## Release 9.0.0
 
@@ -16,17 +16,17 @@ WFAC002 | ApplicationConfiguration | Error | ApplicationConfigurationGenerator, 
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-WFO0001 | Application Configuration | Error | ApplicationConfigurationGenerator, [Documentation](https://learn.microsoft.com/dotnet/desktop/winforms/wfdev-diagnostics/wfac001)
-WFO0002 | Application Configuration | Error | ApplicationConfigurationGenerator, [Documentation](https://learn.microsoft.com/dotnet/desktop/winforms/wfdev-diagnostics/wfac002)
-WFO1000 | WinForms Security | Error | CSharpDiagnosticDescriptors, [Documentation](https://learn.microsoft.com/dotnet/desktop/winforms/compiler-messages/wfo1000)
-WFO2001 | WinForms Usage | Warning | CSharpDiagnosticDescriptors, [Documentation](https://learn.microsoft.com/dotnet/desktop/winforms/compiler-messages/wfo2001)
+WFO0001 | Application Configuration | Error | ApplicationConfigurationGenerator, [Documentation](https://aka.ms/winforms-warnings/wfo0001)
+WFO0002 | Application Configuration | Error | ApplicationConfigurationGenerator, [Documentation](https://aka.ms/winforms-warnings/wfo0002)
+WFO1000 | WinForms Security | Error | CSharpDiagnosticDescriptors, [Documentation](https://aka.ms/winforms-warnings/wfo1000)
+WFO2001 | WinForms Usage | Warning | CSharpDiagnosticDescriptors, [Documentation](https://aka.ms/winforms-warnings/wfo2001)
 
 ### Removed Rules
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
-WFAC001 | Application Configuration | Error | ApplicationConfigurationGenerator, [Documentation](https://learn.microsoft.com/dotnet/desktop/winforms/wfdev-diagnostics/wfac001)
-WFAC002 | Application Configuration | Error | ApplicationConfigurationGenerator, [Documentation](https://learn.microsoft.com/dotnet/desktop/winforms/wfdev-diagnostics/wfac002)
+WFAC001 | Application Configuration | Error | ApplicationConfigurationGenerator, [Documentation](https://aka.ms/winforms-warnings/wfac001)
+WFAC002 | Application Configuration | Error | ApplicationConfigurationGenerator, [Documentation](https://aka.ms/winforms-warnings/wfac002)
 
 ## Release 10.0.0
 
@@ -34,4 +34,4 @@ WFAC002 | Application Configuration | Error | ApplicationConfigurationGenerator,
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-WFO1001 | WinForms Security | Warning | CSharpDiagnosticDescriptors, [Documentation](https://github.com/dotnet/winforms/blob/main/docs/analyzers/WinFormsCSharpAnalyzers.Help.md#implementitypeddataobject)
+WFO1001 | WinForms Security | Warning | CSharpDiagnosticDescriptors, [Documentation](https://aka.ms/winforms-warnings/wfo1001)

--- a/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/CSharp/Analyzers/Diagnostics/CSharpDiagnosticDescriptors.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/CSharp/Analyzers/Diagnostics/CSharpDiagnosticDescriptors.cs
@@ -9,32 +9,37 @@ namespace System.Windows.Forms.CSharp.Analyzers.Diagnostics;
 
 internal static class CSharpDiagnosticDescriptors
 {
+    // WFO0001
     public static readonly DiagnosticDescriptor s_errorUnsupportedProjectType =
-        new(id: DiagnosticIDs.UnsupportedProjectType,
+        DiagnosticDescriptorHelper.Create(
+            id: DiagnosticIDs.UnsupportedProjectType,
             title: new LocalizableResourceString(nameof(SR.WFO0001Title), SR.ResourceManager, typeof(SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.WFO0001Message), SR.ResourceManager, typeof(SR)),
             category: DiagnosticCategories.ApplicationConfiguration,
-            defaultSeverity: DiagnosticSeverity.Error,
-            isEnabledByDefault: true);
+            defaultSeverity: DiagnosticSeverity.Error);
 
+    // WFO0002
     public static readonly DiagnosticDescriptor s_propertyCantBeSetToValue =
-        new(id: DiagnosticIDs.PropertyCantBeSetToValue,
+        DiagnosticDescriptorHelper.Create(
+            id: DiagnosticIDs.PropertyCantBeSetToValue,
             title: new LocalizableResourceString(nameof(SR.WFO0002Title), SR.ResourceManager, typeof(SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.WFO0002Message), SR.ResourceManager, typeof(SR)),
             category: DiagnosticCategories.ApplicationConfiguration,
-            defaultSeverity: DiagnosticSeverity.Error,
-            isEnabledByDefault: true);
+            defaultSeverity: DiagnosticSeverity.Error);
 
+    // WFO0002
     public static readonly DiagnosticDescriptor s_propertyCantBeSetToValueWithReason =
-        new(id: DiagnosticIDs.PropertyCantBeSetToValue,
+        DiagnosticDescriptorHelper.Create(
+            id: DiagnosticIDs.PropertyCantBeSetToValue,
             title: new LocalizableResourceString(nameof(SR.WFO0002Title), SR.ResourceManager, typeof(SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.WFO0002MessageWithReason), SR.ResourceManager, typeof(SR)),
             category: DiagnosticCategories.ApplicationConfiguration,
-            defaultSeverity: DiagnosticSeverity.Error,
-            isEnabledByDefault: true);
+            defaultSeverity: DiagnosticSeverity.Error);
 
+    // WFO1000
     public static readonly DiagnosticDescriptor s_missingPropertySerializationConfiguration =
-        new(id: DiagnosticIDs.MissingPropertySerializationConfiguration,
+        DiagnosticDescriptorHelper.Create(
+            id: DiagnosticIDs.MissingPropertySerializationConfiguration,
             title: new LocalizableResourceString(nameof(SR.WFO1000AnalyzerTitle), SR.ResourceManager, typeof(SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.WFO1000AnalyzerMessageFormat), SR.ResourceManager, typeof(SR)),
             category: DiagnosticCategories.WinFormsSecurity,
@@ -42,8 +47,10 @@ internal static class CSharpDiagnosticDescriptors
             isEnabledByDefault: true,
             description: new LocalizableResourceString(nameof(SR.WFO1000AnalyzerDescription), SR.ResourceManager, typeof(SR)));
 
+    // WFO1001
     public static readonly DiagnosticDescriptor s_implementITypedDataObjectInAdditionToIDataObject =
-        new(id: DiagnosticIDs.ImplementITypedDataObject,
+        DiagnosticDescriptorHelper.Create(
+            id: DiagnosticIDs.ImplementITypedDataObject,
             title: new LocalizableResourceString(nameof(SR.WFO1001AnalyzerTitle), SR.ResourceManager, typeof(SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.WFO1001AnalyzerMessageFormat), SR.ResourceManager, typeof(SR)),
             category: DiagnosticCategories.WinFormsSecurity,
@@ -51,8 +58,10 @@ internal static class CSharpDiagnosticDescriptors
             isEnabledByDefault: true,
             description: new LocalizableResourceString(nameof(SR.WFO1001AnalyzerDescription), SR.ResourceManager, typeof(SR)));
 
+    // WFO20001
     public static readonly DiagnosticDescriptor s_avoidPassingFuncReturningTaskWithoutCancellationToken =
-        new(DiagnosticIDs.AvoidPassingFuncReturningTaskWithoutCancellationToken,
+        DiagnosticDescriptorHelper.Create(
+            DiagnosticIDs.AvoidPassingFuncReturningTaskWithoutCancellationToken,
             title: new LocalizableResourceString(nameof(SR.WFO2001AnalyzerTitle), SR.ResourceManager, typeof(SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.WFO2001AnalyzerMessageFormat), SR.ResourceManager, typeof(SR)),
             DiagnosticCategories.WinFormsUsage,

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System.Windows.Forms.Analyzers.CSharp.Tests.csproj
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System.Windows.Forms.Analyzers.CSharp.Tests.csproj
@@ -33,28 +33,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="**\TestData\*.*">
+    <Content Include="**\TestData\*.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="Analyzers\WFO1001\TestData\DerivedFromUntyped.cs" />
-    <Content Include="Analyzers\WFO1001\TestData\TwoInterfaces.cs" />
-    <Content Include="Analyzers\WFO1001\TestData\TypedInterface.cs" />
-    <Content Include="Analyzers\WFO1001\TestData\TypedWithAlias.cs" />
-    <Content Include="Analyzers\WFO1001\TestData\TypedWithNamespace.cs" />
-    <Content Include="Analyzers\WFO1001\TestData\UnrelatedIDataObject.cs" />
-    <Content Include="Analyzers\WFO1001\TestData\UntypedInterface.cs" />
-    <Content Include="Analyzers\WFO1001\TestData\UntypedUnimplemented.cs" />
-    <Content Include="Analyzers\WFO1001\TestData\UntypedWithAlias.cs" />
-    <Content Include="Analyzers\WFO1001\TestData\UntypedWithNamespace.cs" />
-    <Content Include="Generators\ApplicationConfigurationGenerator\TestData\ApplicationConfigurationGeneratorTests.GenerateInitialize_default_boilerplate.cs" />
-    <Content Include="Generators\ApplicationConfigurationGenerator\TestData\ApplicationConfigurationGeneratorTests.GenerateInitialize_default_top_level.cs" />
-    <Content Include="Generators\ApplicationConfigurationGenerator\TestData\ApplicationConfigurationGeneratorTests.GenerateInitialize_user_settings_boilerplate.cs" />
-    <Content Include="Generators\ApplicationConfigurationGenerator\TestData\ApplicationConfigurationGeneratorTests.GenerateInitialize_user_top_level.cs" />
-    <Content Include="Generators\ApplicationConfigurationGenerator\TestData\ApplicationConfigurationInitializeBuilderTests.default_boilerplate.cs" />
-    <Content Include="Generators\ApplicationConfigurationGenerator\TestData\ApplicationConfigurationInitializeBuilderTests.default_top_level.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/System.Windows.Forms.Analyzers.VisualBasic/src/AnalyzerReleases.Shipped.md
+++ b/src/System.Windows.Forms.Analyzers.VisualBasic/src/AnalyzerReleases.Shipped.md
@@ -6,8 +6,8 @@
 ### New Rules
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-WFO1000 | WinForms Security | Error | VisualBasicDiagnosticDescriptors, [Documentation](https://learn.microsoft.com/dotnet/desktop/winforms/compiler-messages/wfo1000)
-WFO2001 | WinForms Security | Warning | VisualBasicDiagnosticDescriptors, [Documentation](https://learn.microsoft.com/dotnet/desktop/winforms/compiler-messages/wfo2001)
+WFO1000 | WinForms Security | Error | VisualBasicDiagnosticDescriptors, [Documentation](https://aka.ms/winforms-warnings/wfo1000)
+WFO2001 | WinForms Security | Warning | VisualBasicDiagnosticDescriptors, [Documentation](https://aka.ms/winforms-warnings/wfo2001)
 
 ## Release 10.0.0
 
@@ -15,4 +15,4 @@ WFO2001 | WinForms Security | Warning | VisualBasicDiagnosticDescriptors, [Docum
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-WFO1001 | WinForms Security | Warning | VisualBasicDiagnosticDescriptors, [Documentation](https://github.com/dotnet/winforms/blob/main/docs/analyzers/WinFormsCSharpAnalyzers.Help.md#implementitypeddataobject)
+WFO1001 | WinForms Security | Warning | VisualBasicDiagnosticDescriptors, [Documentation](https://aka.ms/winforms-warnings/wfo1001)

--- a/src/System.Windows.Forms.Analyzers.VisualBasic/src/Diagnostic/VisualBasicDiagnosticDescriptors.vb
+++ b/src/System.Windows.Forms.Analyzers.VisualBasic/src/Diagnostic/VisualBasicDiagnosticDescriptors.vb
@@ -7,7 +7,8 @@ Imports System.Windows.Forms.Analyzers.VisualBasic.Resources
 
 Friend Module VisualBasicDiagnosticDescriptors
 
-    Public ReadOnly s_missingPropertySerializationConfiguration As New DiagnosticDescriptor(
+    ' WFO1000
+    Public ReadOnly s_missingPropertySerializationConfiguration As DiagnosticDescriptor = DiagnosticDescriptorHelper.Create(
             id:=DiagnosticIDs.MissingPropertySerializationConfiguration,
             title:=New LocalizableResourceString(NameOf(SR.WFO1000AnalyzerTitle), SR.ResourceManager, GetType(SR)),
             messageFormat:=New LocalizableResourceString(NameOf(SR.WFO1000AnalyzerMessageFormat), SR.ResourceManager, GetType(SR)),
@@ -16,7 +17,8 @@ Friend Module VisualBasicDiagnosticDescriptors
             isEnabledByDefault:=True,
             description:=New LocalizableResourceString(NameOf(SR.WFO1000AnalyzerDescription), SR.ResourceManager, GetType(SR)))
 
-    Public ReadOnly s_implementITypedDataObjectInAdditionToIDataObject As New DiagnosticDescriptor(
+    ' WFO1001
+    Public ReadOnly s_implementITypedDataObjectInAdditionToIDataObject As DiagnosticDescriptor = DiagnosticDescriptorHelper.Create(
             id:=DiagnosticIDs.ImplementITypedDataObject,
             title:=New LocalizableResourceString(NameOf(SR.WFO1001AnalyzerTitle), SR.ResourceManager, GetType(SR)),
             messageFormat:=New LocalizableResourceString(NameOf(SR.WFO1001AnalyzerMessageFormat), SR.ResourceManager, GetType(SR)),
@@ -25,7 +27,8 @@ Friend Module VisualBasicDiagnosticDescriptors
             isEnabledByDefault:=True,
             description:=New LocalizableResourceString(NameOf(SR.WFO1001AnalyzerDescription), SR.ResourceManager, GetType(SR)))
 
-    Public ReadOnly s_avoidFuncReturningTaskWithoutCancellationToken As New DiagnosticDescriptor(
+    ' WFO2001
+    Public ReadOnly s_avoidFuncReturningTaskWithoutCancellationToken As DiagnosticDescriptor = DiagnosticDescriptorHelper.Create(
             id:=DiagnosticIDs.AvoidPassingFuncReturningTaskWithoutCancellationToken,
             title:=New LocalizableResourceString(NameOf(SR.WFO2001AnalyzerTitle), SR.ResourceManager, GetType(SR)),
             messageFormat:=New LocalizableResourceString(NameOf(SR.WFO2001AnalyzerMessageFormat), SR.ResourceManager, GetType(SR)),

--- a/src/System.Windows.Forms.Analyzers/src/AnalyzerReleases.Shipped.md
+++ b/src/System.Windows.Forms.Analyzers/src/AnalyzerReleases.Shipped.md
@@ -7,7 +7,7 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
-WFAC010 | ApplicationConfiguration | Warning | AppManifestAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/desktop/winforms/wfdev-diagnostics/wfac010)
+WFAC010 | ApplicationConfiguration | Warning | AppManifestAnalyzer, [Documentation](https://aka.ms/winforms-warnings/wfac010)
 
 ## Release 9.0.0
 
@@ -15,7 +15,7 @@ WFAC010 | ApplicationConfiguration | Warning | AppManifestAnalyzer, [Documentati
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-WFO0003 | Application Configuration | Warning | SharedDiagnosticDescriptors, [Documentation](https://learn.microsoft.com/dotnet/desktop/winforms/compiler-messages/wfo0003)
+WFO0003 | Application Configuration | Warning | SharedDiagnosticDescriptors, [Documentation](https://aka.ms/winforms-warnings/wfo0003)
 
 ### Removed Rules
 

--- a/src/System.Windows.Forms.Analyzers/src/System.Windows.Forms.Analyzers.csproj
+++ b/src/System.Windows.Forms.Analyzers/src/System.Windows.Forms.Analyzers.csproj
@@ -26,10 +26,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="..\..\..\docs\analyzers\akams.txt" Link="docs\akams.txt" />
-  </ItemGroup>
-
-  <ItemGroup>
     <EmbeddedResource Update="Resources\SR.resx">
       <GenerateSource>true</GenerateSource>
       <Namespace>System.Windows.Forms.Analyzers.Resources</Namespace>

--- a/src/System.Windows.Forms.Analyzers/src/System/Windows/Forms/Analyzers/Diagnostics/DiagnosticDescriptorHelper.cs
+++ b/src/System.Windows.Forms.Analyzers/src/System/Windows/Forms/Analyzers/Diagnostics/DiagnosticDescriptorHelper.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis;
+
+namespace System.Windows.Forms.Analyzers.Diagnostics;
+
+internal static class DiagnosticDescriptorHelper
+{
+    public static DiagnosticDescriptor Create(
+        string id,
+        LocalizableString title,
+        LocalizableString messageFormat,
+        string category,
+        DiagnosticSeverity defaultSeverity,
+        bool isEnabledByDefault = true,
+        LocalizableString? description = null,
+        params string[] customTags) => new DiagnosticDescriptor(
+            id,
+            title,
+            messageFormat,
+            category,
+            defaultSeverity,
+            isEnabledByDefault,
+            description,
+            string.Format(DiagnosticIDs.UrlFormat, id.ToLowerInvariant()),
+            customTags);
+}

--- a/src/System.Windows.Forms.Analyzers/src/System/Windows/Forms/Analyzers/Diagnostics/DiagnosticIDs.cs
+++ b/src/System.Windows.Forms.Analyzers/src/System/Windows/Forms/Analyzers/Diagnostics/DiagnosticIDs.cs
@@ -5,7 +5,6 @@ namespace System.Windows.Forms.Analyzers.Diagnostics;
 
 internal static class DiagnosticIDs
 {
-    // Vanity URLs are used with the experimental feature errors only.
     public const string UrlFormat = "https://aka.ms/winforms-warnings/{0}";
 
     // Application Configuration, number group 0001+

--- a/src/System.Windows.Forms.Analyzers/src/System/Windows/Forms/Analyzers/Diagnostics/SharedDiagnosticDescriptors.cs
+++ b/src/System.Windows.Forms.Analyzers/src/System/Windows/Forms/Analyzers/Diagnostics/SharedDiagnosticDescriptors.cs
@@ -8,19 +8,21 @@ namespace System.Windows.Forms.Analyzers.Diagnostics;
 
 internal static partial class SharedDiagnosticDescriptors
 {
+    // WFO0003
     internal static readonly DiagnosticDescriptor s_cSharpMigrateHighDpiSettings =
-        new(id: DiagnosticIDs.MigrateHighDpiSettings,
+        DiagnosticDescriptorHelper.Create(
+            id: DiagnosticIDs.MigrateHighDpiSettings,
             title: new LocalizableResourceString(nameof(SR.WFO0003Title), SR.ResourceManager, typeof(SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.WFO0003Message_CS), SR.ResourceManager, typeof(SR)),
             category: DiagnosticCategories.ApplicationConfiguration,
-            defaultSeverity: DiagnosticSeverity.Warning,
-            isEnabledByDefault: true);
+            defaultSeverity: DiagnosticSeverity.Warning);
 
+    // WFO0003
     internal static readonly DiagnosticDescriptor s_visualBasicMigrateHighDpiSettings =
-        new(id: DiagnosticIDs.MigrateHighDpiSettings,
+        DiagnosticDescriptorHelper.Create(
+            id: DiagnosticIDs.MigrateHighDpiSettings,
             title: new LocalizableResourceString(nameof(SR.WFO0003Title), SR.ResourceManager, typeof(SR)),
             messageFormat: new LocalizableResourceString(nameof(SR.WFO0003Message_VB), SR.ResourceManager, typeof(SR)),
             category: DiagnosticCategories.ApplicationConfiguration,
-            defaultSeverity: DiagnosticSeverity.Warning,
-            isEnabledByDefault: true);
+            defaultSeverity: DiagnosticSeverity.Warning);
 }

--- a/src/System.Windows.Forms.Analyzers/tests/UnitTests/Analyzers/AppManifestAnalyzer/AppManifestAnalyzerTests.cs
+++ b/src/System.Windows.Forms.Analyzers/tests/UnitTests/Analyzers/AppManifestAnalyzer/AppManifestAnalyzerTests.cs
@@ -35,6 +35,7 @@ public class AppManifestAnalyzerTests
         await new CSharpAnalyzerTest<AppManifestAnalyzer, DefaultVerifier>()
         {
             TestCode = CSharpCode,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net90Windows,
             TestState =
             {
                 AdditionalFiles = { }
@@ -50,6 +51,7 @@ public class AppManifestAnalyzerTests
         await new CSharpAnalyzerTest<AppManifestAnalyzer, DefaultVerifier>()
         {
             TestCode = CSharpCode,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net90Windows,
             TestState =
             {
                  AdditionalFiles = { (@"C:\temp\app.manifest", manifestFile) }
@@ -66,6 +68,7 @@ public class AppManifestAnalyzerTests
         await new CSharpAnalyzerTest<AppManifestAnalyzer, DefaultVerifier>()
         {
             TestCode = CSharpCode,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net90Windows,
             TestState =
             {
                  AdditionalFiles = { (@"C:\temp\app.manifest", manifestFile) }
@@ -84,6 +87,7 @@ public class AppManifestAnalyzerTests
         await new CSharpAnalyzerTest<AppManifestAnalyzer, DefaultVerifier>()
         {
             TestCode = CSharpCode,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net90Windows,
             TestState =
             {
                  AdditionalFiles = { (manifestFilePath, manifestFile) }
@@ -107,6 +111,7 @@ public class AppManifestAnalyzerTests
         await new VisualBasicAnalyzerTest<AppManifestAnalyzer, DefaultVerifier>()
         {
             TestCode = VbCode,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net90Windows,
             TestState =
             {
                  AdditionalFiles = { (manifestFilePath, manifestFile) }
@@ -130,6 +135,7 @@ public class AppManifestAnalyzerTests
         await new CSharpAnalyzerTest<AppManifestAnalyzer, DefaultVerifier>()
         {
             TestCode = CSharpCode,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net90Windows,
             TestState =
             {
                 AdditionalFiles = { (manifestFilePath, manifestFile) },
@@ -149,6 +155,7 @@ public class AppManifestAnalyzerTests
         await new VisualBasicAnalyzerTest<AppManifestAnalyzer, DefaultVerifier>()
         {
             TestCode = VbCode,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net90Windows,
             TestState =
             {
                 AdditionalFiles = { (manifestFilePath, manifestFile) },


### PR DESCRIPTION
Main change is the addition of DiagnosticDescriptorHelper.Create method that sets up the help link following the common pattern. I'm using the new aka.ms links in the documentation files.

Steps to create links and set them up with the diagnostic descriptors are in the list-of-diagnostics.md

We had a special "experimental" URL pattern used in VB with 2 APIs, I replaced it with the common one for the NET10, the old link still works for NET9

Potential follow up - combine ObsoletionIDs with DiagnosticIDs and move the resulting file to the Primitives assembly(to make it visible to VB) and Common folder(for Drawing)

Changes are logically grouped in commits, I plan to rebase-merge this PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13097)