### PR TITLE
Supress a code analyzer warning because VMR repo is behind us in the SDK version

### DIFF
--- a/src/System.Private.Windows.Core/src/System.Private.Windows.Core.csproj
+++ b/src/System.Private.Windows.Core/src/System.Private.Windows.Core.csproj
@@ -14,6 +14,8 @@
       cross that bridge when we hit it (if ever).
     -->
     <NoWarn>$(NoWarn);CS8981</NoWarn>
+    <!-- Reenable when VRM SDK version contains fis for "reference-like" types -->
+    <NoWarn Condition="'$(DotNetBuild)' == 'true'">$(NoWarn);IDE0059</NoWarn>
     <!--
       CS3016: We don't care about CLS compliance since everything here is internal and we want to match native types.
       SYSLIB5005: System.Formats.Nrbf is experimental


### PR DESCRIPTION
tracking bug - https://github.com/dotnet/winforms/issues/12997