### PR TITLE
Test if listbox has any items before invoking listBox.Items[e.Index] in ListBoxes.cs of the WinformsControlsTests

### DIFF
--- a/src/test/integration/WinformsControlsTest/ListBoxes.cs
+++ b/src/test/integration/WinformsControlsTest/ListBoxes.cs
@@ -44,8 +44,11 @@ public partial class ListBoxes : Form
             customBrush = Brushes.Red;
         }
 
-        e.Graphics.DrawString(listBox.Items[e.Index].ToString(),
-            e.Font, customBrush, e.Bounds, StringFormat.GenericDefault);
+        if (listBox.Items.Count > 0)
+        {
+            e.Graphics.DrawString(listBox.Items[e.Index].ToString(),
+                e.Font, customBrush, e.Bounds, StringFormat.GenericDefault);
+        }
 
         e.DrawFocusRectangle();
     }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13047


## Proposed changes

- Add a logical judgment before invoking `listBox.Items[e.Index]` in `ListBox_DrawItem` method in `ListBoxes.cs` of the `WinformsControlsTest` application to prevent the exception

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

-  The click event can be done normally on ListBox

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Clicking on ListBox Drawmode.OwnerDrawFixed and ListBox Drawmode.OwnerDrawVariable brings up the exception error window in the WinformsControlsTest application

![Image](https://github.com/user-attachments/assets/2a83311b-9d98-45a6-b45f-8bd741e084b3)


### After
Everything work well on ListBox 
![AfterChange](https://github.com/user-attachments/assets/b12a2cb7-fca7-4828-ba90-5cf547a4c0a6)



## Test methodology <!-- How did you ensure quality? -->

- Manually tested the application


## Test environment(s) <!-- Remove any that don't apply -->

- .net10.0.0-preview.3.25155.12


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13106)