### PR TITLE
Skip 3 localization tests

### DIFF
--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/KeysConverterTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/KeysConverterTests.cs
@@ -25,7 +25,8 @@ public class KeysConverterTests
         Assert.Equal(keys, result);
     }
 
-    [Theory]
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/13117")]
+    [Theory(Skip = "Localization tests, see: https://github.com/dotnet/winforms/issues/13117")]
     [InlineData("fr-FR", "(aucun)", Keys.None)]
     [InlineData("nb-NO", "None", Keys.None)]
     [InlineData("de-DE", "Ende", Keys.End)]
@@ -71,7 +72,8 @@ public class KeysConverterTests
         Assert.Equal(expectedResult, result);
     }
 
-    [Theory]
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/13117")]
+    [Theory(Skip = "Localization tests, see: https://github.com/dotnet/winforms/issues/13117")]
     [InlineData("fr-FR", Keys.None, "(aucun)")]
     [InlineData("de-DE", Keys.End, "Ende")]
     public void ConvertToString_ShouldConvertKeys_Localization(string cultureName, Keys key, string expectedLocalizedKeyName)

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripMenuItemTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripMenuItemTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
@@ -143,7 +143,8 @@ public class ToolStripMenuItemTests
         Assert.Throws<InvalidEnumArgumentException>(() => item.ShortcutKeys = keys);
     }
 
-    [WinFormsTheory]
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/13117")]
+    [WinFormsTheory(Skip = "Localization tests, see: https://github.com/dotnet/winforms/issues/13117")]
     [MemberData(nameof(CultureInfo_Shortcut_TestData))]
     public void ToolStripMenuItem_SetShortcutKeys_ReturnExpectedShortcutText(CultureInfo threadCulture, CultureInfo threadUICulture, string expectedShortcutText)
     {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related #13117


## Proposed changes

- Skip following 3 localization test cases
 1.  System.Windows.Forms.Tests.KeysConverterTests.ConvertFrom_ShouldConvertKeys_Localization
 2.  System.Windows.Forms.Tests.ToolStripMenuItemTests.ToolStripMenuItem_SetShortcutKeys_ReturnExpectedShortcutText
 3.  System.Windows.Forms.Tests.KeysConverterTests.ConvertToString_ShouldConvertKeys_Localization
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13118)