### PR TITLE
Ensure that System.Drawing facade assembly is built before the tests that consume it are.

### DIFF
--- a/src/Microsoft.VisualBasic.Forms/tests/UnitTests/Microsoft.VisualBasic.Forms.Tests.vbproj
+++ b/src/Microsoft.VisualBasic.Forms/tests/UnitTests/Microsoft.VisualBasic.Forms.Tests.vbproj
@@ -17,17 +17,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\System.Design\src\System.Design.Facade.csproj" />
     <ProjectReference Include="..\..\..\System.Drawing.Common\src\System.Drawing.Common.csproj" />
-    <ProjectReference Include="..\..\..\System.Drawing.Design\src\System.Drawing.Design.Facade.csproj" />
     <ProjectReference Include="..\..\..\System.Windows.Forms.Primitives\tests\TestUtilities\System.Windows.Forms.Primitives.TestUtilities.csproj" />
     <ProjectReference Include="..\..\..\test\util\System.Windows.Forms\System.Windows.Forms.TestUtilities.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.VisualBasic.Forms.vbproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- workaround for https://github.com/dotnet/sdk/issues/3254 -->
-    <Reference Include="$(BaseOutputPath)..\System.Drawing.Facade\$(Configuration)\$(SourceTargetFramework)\System.Drawing.dll" />
   </ItemGroup>
 
 </Project>

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System.Windows.Forms.Design.Tests.csproj
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System.Windows.Forms.Design.Tests.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <!-- workaround for https://github.com/dotnet/sdk/issues/3254 -->
-    <Reference Include="$(BaseOutputPath)..\System.Design.Facade\$(Configuration)\$(SourceTargetFramework)\System.Design.dll" />
+    <Reference Include="$(ArtifactsBinDir)\System.Design.Facade\$(Configuration)\$(SourceTargetFramework)\System.Design.dll" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/System/Windows/Forms/DataBinding/ControlBindingsCollection.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/DataBinding/ControlBindingsCollection.cs
@@ -10,7 +10,7 @@ namespace System.Windows.Forms;
 ///  Represents the collection of data bindings for a control.
 /// </summary>
 [DefaultEvent(nameof(CollectionChanged))]
-[Editor($"System.Drawing.Design.UITypeEditor, {(Assemblies.SystemDrawing)}", typeof(UITypeEditor))]
+[Editor($"System.Drawing.Design.UITypeEditor, {Assemblies.SystemDrawing}", typeof(UITypeEditor))]
 [TypeConverter($"System.Windows.Forms.Design.ControlBindingsConverter, {Assemblies.SystemDesign}")]
 public class ControlBindingsCollection : BindingsCollection
 {

--- a/src/test/unit/System.Windows.Forms/System.Windows.Forms.Tests.csproj
+++ b/src/test/unit/System.Windows.Forms/System.Windows.Forms.Tests.csproj
@@ -31,6 +31,8 @@
     <ProjectReference Include="..\..\..\System.Private.Windows.Core\tests\System.Private.Windows.Core.Tests\System.Private.Windows.Core.Tests.csproj" />
     <ProjectReference Include="..\..\..\System.Windows.Forms\System.Windows.Forms.csproj" />
     <ProjectReference Include="..\..\..\System.Design\src\System.Design.Facade.csproj" />
+    <!-- This facade assembly is required to resolve UITypeEditor type from NETFX that is referenced in EditorAttributes -->
+    <ProjectReference Include="..\..\..\System.Drawing\src\System.Drawing.Facade.csproj" />
     <ProjectReference Include="..\..\..\System.Drawing.Design\src\System.Drawing.Design.Facade.csproj" />
     <ProjectReference Include="..\..\integration\System.Windows.Forms.IntegrationTests.Common\System.Windows.Forms.IntegrationTests.Common.csproj" />
     <ProjectReference Include="..\..\util\System.Windows.Forms\System.Windows.Forms.TestUtilities.csproj" />
@@ -38,7 +40,7 @@
 
   <ItemGroup>
     <!-- workaround for https://github.com/dotnet/sdk/issues/3254 -->
-    <Reference Include="$(BaseOutputPath)..\System.Drawing.Facade\$(Configuration)\$(SourceTargetFramework)\System.Drawing.dll" />
+    <Reference Include="$(ArtifactsBinDir)\System.Drawing.Facade\$(Configuration)\$(SourceTargetFramework)\System.Drawing.dll" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/Design/DesignerAttributeTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/Design/DesignerAttributeTests.cs
@@ -171,7 +171,7 @@ public class DesignerAttributeTests
     [MemberData(nameof(GetAttributeOfTypeAndProperty_TestData), Assemblies.SystemWindowsForms, typeof(EditorAttribute))]
     public void EditorAttribute_TypeExists(string subject, EditorAttribute attribute)
     {
-        var type = Type.GetType(attribute.EditorTypeName, false);
+        var type = Type.GetType(attribute.EditorTypeName, throwOnError: false);
         _output.WriteLine($"{subject}: {attribute.EditorTypeName} --> {type?.Name}");
 
         if (SkipList.Contains(attribute.EditorTypeName))


### PR DESCRIPTION
This is an attempt to fix intermittent MSB3106 failures like this one that appeared after we removed project reference to the System.Drawing facade assembly from the System.Windows.Forms.Tests and Microsoft.VisualBasic.Forms.Tests projects.
https://dnceng.visualstudio.com/internal/_build/results?buildId=2660881&view=results

```
D:\a\_work\1\s\.dotnet\sdk\10.0.100-preview.3.25125.5\Microsoft.Common.CurrentVersion.targets(2424,5): error MSB3106: Assembly strong name "D:\a\_work\1\s\artifacts\bin\Microsoft.VisualBasic.Forms.Tests\..\System.Drawing.Facade\Release\net10.0\System.Drawing.dll" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\). [D:\a\_work\1\s\src\Microsoft.VisualBasic.Forms\tests\UnitTests\Microsoft.VisualBasic.Forms.Tests.vbproj]
##[error].dotnet\sdk\10.0.100-preview.3.25125.5\Microsoft.Common.CurrentVersion.targets(2424,5): error MSB3106: (NETCORE_ENGINEERING_TELEMETRY=Build) Assembly strong name "D:\a\_work\1\s\artifacts\bin\Microsoft.VisualBasic.Forms.Tests\..\System.Drawing.Facade\Release\net10.0\System.Drawing.dll" is either a path which could not be found or it is a full assembly name which is badly formed. If it is a full assembly name it may contain characters that need to be escaped with backslash(\). Those characters are Equals(=), Comma(,), Quote("), Apostrophe('), Backslash(\).

```

* MS.VB.Forms.Tests is not testing design time scenarios, removing DT dependencies.
* replaced BaseOutputPath with ArtifactsBinDir in projects
* restored workaround to reference the right instance of System.Drawing facade assembly from tests

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13119)