### PR TITLE
Add unit tests for StatusCommandUI

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/StatusCommandUITests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/StatusCommandUITests.cs
@@ -35,7 +35,7 @@ public class StatusCommandUITests
     [Fact]
     public void SetStatusInformation_WithNullComponent_ShouldNotInvokeCommand()
     {
-        _statusCommandUI.SetStatusInformation(null);
+        _statusCommandUI.SetStatusInformation(selectedComponent: null);
         _mockMenuCommand.Verify(mc => mc.Invoke(It.IsAny<Rectangle>()), Times.Never);
     }
 
@@ -44,6 +44,7 @@ public class StatusCommandUITests
     {
         using Control control = new() { Bounds = new(10, 20, 30, 40) };
         TestSetStatusInformation(() => _statusCommandUI.SetStatusInformation(control), new(10, 20, 30, 40));
+        control.IsHandleCreated.Should().BeFalse();
     }
 
     [Fact]
@@ -123,10 +124,10 @@ public class StatusCommandUITests
     private void VerifyInvoke(Rectangle expectedRectangle)
     {
         _mockMenuCommand.Verify(mc => mc.Invoke(It.Is<Rectangle>(r =>
-            r.X == expectedRectangle.X &&
-            r.Y == expectedRectangle.Y &&
-            r.Width == expectedRectangle.Width &&
-            r.Height == expectedRectangle.Height)), Times.Once);
+              r.X == expectedRectangle.X
+           && r.Y == expectedRectangle.Y
+           && r.Width == expectedRectangle.Width
+           && r.Height == expectedRectangle.Height)), Times.Once);
     }
 
     private class CustomComponent : Component

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/StatusCommandUITests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/StatusCommandUITests.cs
@@ -91,7 +91,7 @@ public class StatusCommandUITests
     }
 
     [Fact]
-    public void SetStatusInformation_WithComponentWithoutBoundsAndLocation_ShouldInvokeWithEmptyRectangle()
+    public void SetStatusInformation_WithComponentHavingLocationButNoBounds_ShouldInvokeWithEmptyRectangle()
     {
         using Component component = new();
         Point location = new(50, 60);

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/StatusCommandUITests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/StatusCommandUITests.cs
@@ -1,0 +1,136 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+using System.ComponentModel.Design;
+using System.Drawing;
+using Moq;
+
+namespace System.Windows.Forms.Design.Tests;
+
+public class StatusCommandUITests
+{
+    private readonly Mock<IServiceProvider> _mockServiceProvider;
+    private readonly Mock<IMenuCommandService> _mockMenuCommandService;
+    private readonly Mock<MenuCommand> _mockMenuCommand;
+    private readonly StatusCommandUI _statusCommandUI;
+
+    public StatusCommandUITests()
+    {
+        _mockServiceProvider = new();
+        _mockMenuCommandService = new();
+        _mockMenuCommand = new(null!, null!);
+
+        _mockServiceProvider
+            .Setup(sp => sp.GetService(typeof(IMenuCommandService)))
+            .Returns(_mockMenuCommandService.Object);
+
+        _mockMenuCommandService
+            .Setup(mcs => mcs.FindCommand(MenuCommands.SetStatusRectangle))
+            .Returns(_mockMenuCommand.Object);
+
+        _statusCommandUI = new(_mockServiceProvider.Object);
+    }
+
+    [Fact]
+    public void SetStatusInformation_WithNullComponent_ShouldNotInvokeCommand()
+    {
+        _statusCommandUI.SetStatusInformation(null);
+        _mockMenuCommand.Verify(mc => mc.Invoke(It.IsAny<Rectangle>()), Times.Never);
+    }
+
+    [Fact]
+    public void SetStatusInformation_WithControlComponent_ShouldInvokeWithOriginalBounds()
+    {
+        using Control control = new() { Bounds = new(10, 20, 30, 40) };
+        TestSetStatusInformation(() => _statusCommandUI.SetStatusInformation(control), new(10, 20, 30, 40));
+    }
+
+    [Fact]
+    public void SetStatusInformation_WithCustomComponentHavingBounds_ShouldInvokeWithOriginalBounds()
+    {
+        using CustomComponent component = new() { Bounds = new(10, 20, 30, 40) };
+        TestSetStatusInformation(() => _statusCommandUI.SetStatusInformation(component), new(10, 20, 30, 40));
+    }
+
+    [Fact]
+    public void SetStatusInformation_WithComponentWithoutBounds_ShouldInvokeWithEmptyRectangle()
+    {
+        using Component component = new();
+        TestSetStatusInformation(() => _statusCommandUI.SetStatusInformation(component), Rectangle.Empty);
+    }
+
+    [Fact]
+    public void SetStatusInformation_WithRectangle_ShouldInvokeWithSameRectangle()
+    {
+        Rectangle bounds = new(10, 20, 30, 40);
+        TestSetStatusInformation(() => _statusCommandUI.SetStatusInformation(bounds), bounds);
+    }
+
+    [Fact]
+    public void SetStatusInformation_WithEmptyRectangle_ShouldInvokeWithEmptyRectangle()
+    {
+        Rectangle bounds = Rectangle.Empty;
+        TestSetStatusInformation(() => _statusCommandUI.SetStatusInformation(bounds), bounds);
+    }
+
+    [Fact]
+    public void SetStatusInformation_WithControlAndLocation_ShouldInvokeWithUpdatedBounds()
+    {
+        using Control control = new() { Bounds = new(10, 20, 30, 40) };
+        Point location = new(50, 60);
+        TestSetStatusInformation(() => _statusCommandUI.SetStatusInformation(control, location), new(50, 60, 30, 40));
+    }
+
+    [Fact]
+    public void SetStatusInformation_WithComponentHavingBoundsAndLocation_ShouldInvokeWithUpdatedBounds()
+    {
+        using CustomComponent component = new() { Bounds = new(10, 20, 30, 40) };
+        Point location = new(50, 60);
+        TestSetStatusInformation(() => _statusCommandUI.SetStatusInformation(component, location), new(50, 60, 30, 40));
+    }
+
+    [Fact]
+    public void SetStatusInformation_WithComponentWithoutBoundsAndLocation_ShouldInvokeWithEmptyRectangle()
+    {
+        using Component component = new();
+        Point location = new(50, 60);
+        _statusCommandUI.SetStatusInformation(component, location);
+        _mockMenuCommand.Verify(cmd => cmd.Invoke(new Rectangle(50, 60, 0, 0)), Times.Once);
+    }
+
+    [Fact]
+    public void SetStatusInformation_WithLocationAsEmpty_ShouldNotChangeBounds()
+    {
+        using Control control = new() { Bounds = new(10, 20, 30, 40) };
+        Point location = Point.Empty;
+        TestSetStatusInformation(() => _statusCommandUI.SetStatusInformation(control, location), new(10, 20, 30, 40));
+    }
+
+    [Fact]
+    public void SetStatusInformation_NullComponentWithLocation_ShouldNotInvokeCommand()
+    {
+        _statusCommandUI.SetStatusInformation(null, new Point(10, 10));
+        _mockMenuCommand.Verify(cmd => cmd.Invoke(It.IsAny<Rectangle>()), Times.Never);
+    }
+
+    private void TestSetStatusInformation(Action action, Rectangle expectedRectangle)
+    {
+        action.Invoke();
+        VerifyInvoke(expectedRectangle);
+    }
+
+    private void VerifyInvoke(Rectangle expectedRectangle)
+    {
+        _mockMenuCommand.Verify(mc => mc.Invoke(It.Is<Rectangle>(r =>
+            r.X == expectedRectangle.X &&
+            r.Y == expectedRectangle.Y &&
+            r.Width == expectedRectangle.Width &&
+            r.Height == expectedRectangle.Height)), Times.Once);
+    }
+
+    private class CustomComponent : Component
+    {
+        public Rectangle Bounds { get; set; }
+    }
+}


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773


## Proposed changes

- Add unit test StatusCommandUITests.cs for public method of the StatusCommandUI.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13121)