### PR TITLE
Correct the spelling of DataGridViewCellToolTip in the resource file

### DIFF
--- a/src/System.Windows.Forms/Resources/SR.resx
+++ b/src/System.Windows.Forms/Resources/SR.resx
@@ -2607,19 +2607,19 @@ To replace this default dialog please handle the DataError event.</value>
   <data name="DefManifestNotFound" xml:space="preserve">
     <value>Default manifest file required to enable visual styles cannot be found.</value>
   </data>
-  <data name="DefaultDataGridViewButtonCellTollTipText" xml:space="preserve">
+  <data name="DefaultDataGridViewButtonCellToolTipText" xml:space="preserve">
     <value>Button</value>
   </data>
-  <data name="DefaultDataGridViewComboBoxCellTollTipText" xml:space="preserve">
+  <data name="DefaultDataGridViewComboBoxCellToolTipText" xml:space="preserve">
     <value>ComboBox</value>
   </data>
   <data name="DefaultDataGridViewImageCellToolTipText" xml:space="preserve">
     <value>Image</value>
   </data>
-  <data name="DefaultDataGridViewLinkCellTollTipText" xml:space="preserve">
+  <data name="DefaultDataGridViewLinkCellToolTipText" xml:space="preserve">
     <value>Link</value>
   </data>
-  <data name="DefaultDataGridViewTextBoxCellTollTipText" xml:space="preserve">
+  <data name="DefaultDataGridViewTextBoxCellToolTipText" xml:space="preserve">
     <value>Edit</value>
   </data>
   <data name="DescriptionBindingNavigator" xml:space="preserve">

--- a/src/System.Windows.Forms/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.cs.xlf
@@ -4389,12 +4389,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Default manifest file required to enable visual styles cannot be found.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+      <trans-unit id="DefaultDataGridViewButtonCellToolTipText">
         <source>Button</source>
         <target state="new">Button</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewComboBoxCellToolTipText">
         <source>ComboBox</source>
         <target state="new">ComboBox</target>
         <note />
@@ -4404,12 +4404,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Image</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+      <trans-unit id="DefaultDataGridViewLinkCellToolTipText">
         <source>Link</source>
         <target state="new">Link</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewTextBoxCellToolTipText">
         <source>Edit</source>
         <target state="new">Edit</target>
         <note />

--- a/src/System.Windows.Forms/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.de.xlf
@@ -4389,12 +4389,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Default manifest file required to enable visual styles cannot be found.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+      <trans-unit id="DefaultDataGridViewButtonCellToolTipText">
         <source>Button</source>
         <target state="new">Button</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewComboBoxCellToolTipText">
         <source>ComboBox</source>
         <target state="new">ComboBox</target>
         <note />
@@ -4404,12 +4404,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Image</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+      <trans-unit id="DefaultDataGridViewLinkCellToolTipText">
         <source>Link</source>
         <target state="new">Link</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewTextBoxCellToolTipText">
         <source>Edit</source>
         <target state="new">Edit</target>
         <note />

--- a/src/System.Windows.Forms/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.es.xlf
@@ -4389,12 +4389,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Default manifest file required to enable visual styles cannot be found.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+      <trans-unit id="DefaultDataGridViewButtonCellToolTipText">
         <source>Button</source>
         <target state="new">Button</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewComboBoxCellToolTipText">
         <source>ComboBox</source>
         <target state="new">ComboBox</target>
         <note />
@@ -4404,12 +4404,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Image</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+      <trans-unit id="DefaultDataGridViewLinkCellToolTipText">
         <source>Link</source>
         <target state="new">Link</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewTextBoxCellToolTipText">
         <source>Edit</source>
         <target state="new">Edit</target>
         <note />

--- a/src/System.Windows.Forms/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.fr.xlf
@@ -4389,12 +4389,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Default manifest file required to enable visual styles cannot be found.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+      <trans-unit id="DefaultDataGridViewButtonCellToolTipText">
         <source>Button</source>
         <target state="new">Button</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewComboBoxCellToolTipText">
         <source>ComboBox</source>
         <target state="new">ComboBox</target>
         <note />
@@ -4404,12 +4404,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Image</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+      <trans-unit id="DefaultDataGridViewLinkCellToolTipText">
         <source>Link</source>
         <target state="new">Link</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewTextBoxCellToolTipText">
         <source>Edit</source>
         <target state="new">Edit</target>
         <note />

--- a/src/System.Windows.Forms/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.it.xlf
@@ -4389,12 +4389,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Default manifest file required to enable visual styles cannot be found.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+      <trans-unit id="DefaultDataGridViewButtonCellToolTipText">
         <source>Button</source>
         <target state="new">Button</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewComboBoxCellToolTipText">
         <source>ComboBox</source>
         <target state="new">ComboBox</target>
         <note />
@@ -4404,12 +4404,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Image</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+      <trans-unit id="DefaultDataGridViewLinkCellToolTipText">
         <source>Link</source>
         <target state="new">Link</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewTextBoxCellToolTipText">
         <source>Edit</source>
         <target state="new">Edit</target>
         <note />

--- a/src/System.Windows.Forms/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.ja.xlf
@@ -4389,12 +4389,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Default manifest file required to enable visual styles cannot be found.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+      <trans-unit id="DefaultDataGridViewButtonCellToolTipText">
         <source>Button</source>
         <target state="new">Button</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewComboBoxCellToolTipText">
         <source>ComboBox</source>
         <target state="new">ComboBox</target>
         <note />
@@ -4404,12 +4404,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Image</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+      <trans-unit id="DefaultDataGridViewLinkCellToolTipText">
         <source>Link</source>
         <target state="new">Link</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewTextBoxCellToolTipText">
         <source>Edit</source>
         <target state="new">Edit</target>
         <note />

--- a/src/System.Windows.Forms/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.ko.xlf
@@ -4389,12 +4389,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Default manifest file required to enable visual styles cannot be found.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+      <trans-unit id="DefaultDataGridViewButtonCellToolTipText">
         <source>Button</source>
         <target state="new">Button</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewComboBoxCellToolTipText">
         <source>ComboBox</source>
         <target state="new">ComboBox</target>
         <note />
@@ -4404,12 +4404,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Image</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+      <trans-unit id="DefaultDataGridViewLinkCellToolTipText">
         <source>Link</source>
         <target state="new">Link</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewTextBoxCellToolTipText">
         <source>Edit</source>
         <target state="new">Edit</target>
         <note />

--- a/src/System.Windows.Forms/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.pl.xlf
@@ -4389,12 +4389,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Default manifest file required to enable visual styles cannot be found.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+      <trans-unit id="DefaultDataGridViewButtonCellToolTipText">
         <source>Button</source>
         <target state="new">Button</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewComboBoxCellToolTipText">
         <source>ComboBox</source>
         <target state="new">ComboBox</target>
         <note />
@@ -4404,12 +4404,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Image</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+      <trans-unit id="DefaultDataGridViewLinkCellToolTipText">
         <source>Link</source>
         <target state="new">Link</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewTextBoxCellToolTipText">
         <source>Edit</source>
         <target state="new">Edit</target>
         <note />

--- a/src/System.Windows.Forms/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.pt-BR.xlf
@@ -4389,12 +4389,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Default manifest file required to enable visual styles cannot be found.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+      <trans-unit id="DefaultDataGridViewButtonCellToolTipText">
         <source>Button</source>
         <target state="new">Button</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewComboBoxCellToolTipText">
         <source>ComboBox</source>
         <target state="new">ComboBox</target>
         <note />
@@ -4404,12 +4404,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Image</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+      <trans-unit id="DefaultDataGridViewLinkCellToolTipText">
         <source>Link</source>
         <target state="new">Link</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewTextBoxCellToolTipText">
         <source>Edit</source>
         <target state="new">Edit</target>
         <note />

--- a/src/System.Windows.Forms/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.ru.xlf
@@ -4389,12 +4389,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Default manifest file required to enable visual styles cannot be found.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+      <trans-unit id="DefaultDataGridViewButtonCellToolTipText">
         <source>Button</source>
         <target state="new">Button</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewComboBoxCellToolTipText">
         <source>ComboBox</source>
         <target state="new">ComboBox</target>
         <note />
@@ -4404,12 +4404,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Image</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+      <trans-unit id="DefaultDataGridViewLinkCellToolTipText">
         <source>Link</source>
         <target state="new">Link</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewTextBoxCellToolTipText">
         <source>Edit</source>
         <target state="new">Edit</target>
         <note />

--- a/src/System.Windows.Forms/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.tr.xlf
@@ -4389,12 +4389,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Default manifest file required to enable visual styles cannot be found.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+      <trans-unit id="DefaultDataGridViewButtonCellToolTipText">
         <source>Button</source>
         <target state="new">Button</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewComboBoxCellToolTipText">
         <source>ComboBox</source>
         <target state="new">ComboBox</target>
         <note />
@@ -4404,12 +4404,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Image</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+      <trans-unit id="DefaultDataGridViewLinkCellToolTipText">
         <source>Link</source>
         <target state="new">Link</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewTextBoxCellToolTipText">
         <source>Edit</source>
         <target state="new">Edit</target>
         <note />

--- a/src/System.Windows.Forms/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.zh-Hans.xlf
@@ -4389,12 +4389,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Default manifest file required to enable visual styles cannot be found.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+      <trans-unit id="DefaultDataGridViewButtonCellToolTipText">
         <source>Button</source>
         <target state="new">Button</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewComboBoxCellToolTipText">
         <source>ComboBox</source>
         <target state="new">ComboBox</target>
         <note />
@@ -4404,12 +4404,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Image</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+      <trans-unit id="DefaultDataGridViewLinkCellToolTipText">
         <source>Link</source>
         <target state="new">Link</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewTextBoxCellToolTipText">
         <source>Edit</source>
         <target state="new">Edit</target>
         <note />

--- a/src/System.Windows.Forms/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.zh-Hant.xlf
@@ -4389,12 +4389,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Default manifest file required to enable visual styles cannot be found.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewButtonCellTollTipText">
+      <trans-unit id="DefaultDataGridViewButtonCellToolTipText">
         <source>Button</source>
         <target state="new">Button</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewComboBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewComboBoxCellToolTipText">
         <source>ComboBox</source>
         <target state="new">ComboBox</target>
         <note />
@@ -4404,12 +4404,12 @@ To replace this default dialog please handle the DataError event.</target>
         <target state="new">Image</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewLinkCellTollTipText">
+      <trans-unit id="DefaultDataGridViewLinkCellToolTipText">
         <source>Link</source>
         <target state="new">Link</target>
         <note />
       </trans-unit>
-      <trans-unit id="DefaultDataGridViewTextBoxCellTollTipText">
+      <trans-unit id="DefaultDataGridViewTextBoxCellToolTipText">
         <source>Edit</source>
         <target state="new">Edit</target>
         <note />

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.cs
@@ -206,12 +206,9 @@ public partial class DataGridViewButtonCell : DataGridViewCell
 
     private protected override string? GetDefaultToolTipText()
     {
-        if (string.IsNullOrEmpty(Value?.ToString()?.Trim(' ')) || Value is DBNull)
-        {
-            return SR.DefaultDataGridViewButtonCellTollTipText;
-        }
-
-        return null;
+        return string.IsNullOrEmpty(Value?.ToString()?.Trim(' ')) || Value is DBNull
+            ? SR.DefaultDataGridViewButtonCellToolTipText
+            : null;
     }
 
     protected override Rectangle GetErrorIconBounds(Graphics graphics, DataGridViewCellStyle cellStyle, int rowIndex)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.cs
@@ -812,12 +812,9 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
 
     private protected override string? GetDefaultToolTipText()
     {
-        if (string.IsNullOrEmpty(Value?.ToString()?.Trim(' ')) || Value is DBNull)
-        {
-            return SR.DefaultDataGridViewComboBoxCellTollTipText;
-        }
-
-        return null;
+        return string.IsNullOrEmpty(Value?.ToString()?.Trim(' ')) || Value is DBNull
+            ? SR.DefaultDataGridViewComboBoxCellToolTipText
+            : null;
     }
 
     private int GetDropDownButtonHeight(Graphics graphics, DataGridViewCellStyle cellStyle)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewLinkCell.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewLinkCell.cs
@@ -479,12 +479,9 @@ public partial class DataGridViewLinkCell : DataGridViewCell
 
     private protected override string? GetDefaultToolTipText()
     {
-        if (string.IsNullOrEmpty(Value?.ToString()?.Trim(' ')) || Value is DBNull)
-        {
-            return SR.DefaultDataGridViewLinkCellTollTipText;
-        }
-
-        return null;
+        return string.IsNullOrEmpty(Value?.ToString()?.Trim(' ')) || Value is DBNull
+            ? SR.DefaultDataGridViewLinkCellToolTipText
+            : null;
     }
 
     protected override Rectangle GetErrorIconBounds(Graphics graphics, DataGridViewCellStyle cellStyle, int rowIndex)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewTextBoxCell.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewTextBoxCell.cs
@@ -315,12 +315,9 @@ public partial class DataGridViewTextBoxCell : DataGridViewCell
 
     private protected override string? GetDefaultToolTipText()
     {
-        if (string.IsNullOrEmpty(Value?.ToString()?.Trim(' ')) || Value is DBNull)
-        {
-            return SR.DefaultDataGridViewTextBoxCellTollTipText;
-        }
-
-        return null;
+        return string.IsNullOrEmpty(Value?.ToString()?.Trim(' ')) || Value is DBNull
+            ? SR.DefaultDataGridViewTextBoxCellToolTipText
+            : null;
     }
 
     protected override Rectangle GetErrorIconBounds(Graphics graphics, DataGridViewCellStyle cellStyle, int rowIndex)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Correct the spelling of `DefaultDataGridViewButtonCellTollTipText`, `DefaultDataGridViewComboBoxCellTollTipText`, `DefaultDataGridViewLinkCellTollTipText`,  `DefaultDataGridViewTextBoxCellTollTipText` in the SR.resx file

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13128)