### PR TITLE
Add code coverage for ControlCommandSet.cs file

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ControlCommandSetTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ControlCommandSetTests.cs
@@ -119,7 +119,11 @@ public class ControlCommandSetTests : IDisposable
         try
         {
             _controlCommandSet.TestAccessor().Dynamic.GetSnapInformation(
-                _designerHostMock.Object, childComponent, out Size snapSize, out IComponent snapComponent, out PropertyDescriptor snapProperty);
+                _designerHostMock.Object,
+                childComponent,
+                out Size snapSize,
+                out IComponent snapComponent,
+                out PropertyDescriptor snapProperty);
 
             snapComponent.Should().Be(parentComponent);
             snapProperty.Should().NotBeNull();

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ControlCommandSetTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ControlCommandSetTests.cs
@@ -1,0 +1,97 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+using System.ComponentModel.Design;
+using System.Drawing;
+using Moq;
+
+namespace System.Windows.Forms.Design.Tests;
+
+public class ControlCommandSetTests : IDisposable
+{
+    private readonly Mock<ISite> _siteMock;
+    private readonly Mock<IDesignerHost> _designerHostMock;
+    private readonly Mock<IMenuCommandService> _menuServiceMock;
+    private readonly Mock<IEventHandlerService> _eventHandlerServiceMock;
+    private readonly Mock<ISelectionService> _selectionServiceMock;
+    private readonly Mock<IDictionaryService> _dictionaryServiceMock;
+    private readonly ControlCommandSet _controlCommandSet;
+    private readonly Control _baseControl;
+
+    public ControlCommandSetTests()
+    {
+        _siteMock = new();
+        _designerHostMock = new();
+        _menuServiceMock = new();
+        _eventHandlerServiceMock = new();
+        _selectionServiceMock = new();
+        _dictionaryServiceMock = new();
+        _baseControl = new Control();
+
+        _siteMock.Setup(s => s.GetService(typeof(IDesignerHost))).Returns(_designerHostMock.Object);
+        _siteMock.Setup(s => s.GetService(typeof(IMenuCommandService))).Returns(_menuServiceMock.Object);
+        _siteMock.Setup(s => s.GetService(typeof(IEventHandlerService))).Returns(_eventHandlerServiceMock.Object);
+        _siteMock.Setup(s => s.GetService(typeof(ISelectionService))).Returns(_selectionServiceMock.Object);
+        _siteMock.Setup(s => s.GetService(typeof(IDictionaryService))).Returns(_dictionaryServiceMock.Object);
+        _designerHostMock.Setup(h => h.RootComponent).Returns(_baseControl);
+
+        _controlCommandSet = new ControlCommandSet(_siteMock.Object);
+    }
+
+    public void Dispose()
+    {
+        _controlCommandSet.Dispose();
+        _baseControl.Dispose();
+    }
+
+    [Fact]
+    public void Constructor_ShouldInitializeCommandSet()
+    {
+        _controlCommandSet.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Dispose_ShouldRemoveCommandsFromMenuService()
+    {
+        _controlCommandSet.Dispose();
+
+        _menuServiceMock.Verify(m => m.RemoveCommand(It.IsAny<MenuCommand>()), Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public void GetSnapInformation_ShouldRetrieveSnapInformation()
+    {
+        using Control component = new();
+        Mock<IContainer> containerMock = new();
+        _siteMock.Setup(s => s.Container).Returns(containerMock.Object);
+        component.Site = _siteMock.Object;
+
+        _designerHostMock.Setup(h => h.RootComponent).Returns(_baseControl);
+
+        _controlCommandSet.TestAccessor().Dynamic.GetSnapInformation(_designerHostMock.Object, component, out Size snapSize, out IComponent snapComponent, out PropertyDescriptor snapProperty);
+
+        snapComponent.Should().Be(_baseControl);
+        snapProperty.Should().BeNull();
+        snapSize.Should().Be(Size.Empty);
+    }
+
+    [Fact]
+    public void OnMenuLockControls_ShouldToggleLockControls()
+    {
+        using Control component = new();
+        Mock<IContainer> containerMock = new();
+        _siteMock.Setup(s => s.Container).Returns(containerMock.Object);
+        component.Site = _siteMock.Object;
+
+        _designerHostMock.Setup(h => h.RootComponent).Returns(_baseControl);
+        _designerHostMock.Setup(h => h.Container.Components).Returns(new ComponentCollection([component]));
+
+        CommandID commandID = new(Guid.NewGuid(), 0);
+        MenuCommand menuCommand = new(null, commandID) { Checked = false };
+
+        _controlCommandSet.TestAccessor().Dynamic.OnMenuLockControls(menuCommand, EventArgs.Empty);
+
+        menuCommand.Checked.Should().BeTrue();
+    }
+}

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ControlCommandSetTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ControlCommandSetTests.cs
@@ -133,7 +133,7 @@ public class ControlCommandSetTests : IDisposable
     }
 
     /// <summary>
-    /// Helper class to provide mock property descriptors
+    ///  Helper class to provide mock property descriptors.
     /// </summary>
     private class MockTypeDescriptionProvider : TypeDescriptionProvider
     {

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataGridViewColumnTypeEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataGridViewColumnTypeEditorTests.cs
@@ -1,0 +1,93 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.ComponentModel;
+using System.ComponentModel.Design;
+using System.Drawing.Design;
+using Moq;
+
+namespace System.Windows.Forms.Design.Tests;
+
+public class DataGridViewColumnTypeEditorTests
+{
+    private readonly DataGridViewColumnTypeEditor _editor;
+
+    public DataGridViewColumnTypeEditorTests()
+    {
+        _editor = new();
+    }
+
+    [Fact]
+    public void Constructor_ShouldInitializeCorrectly()
+    {
+        _editor.Should().NotBeNull();
+        _editor.IsDropDownResizable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsDropDownResizable_ShouldReturnTrue() =>
+        _editor.IsDropDownResizable.Should().BeTrue();
+
+    [Fact]
+    public void GetEditStyle_ShouldReturnDropDown() =>
+        _editor.GetEditStyle(null).Should().Be(UITypeEditorEditStyle.DropDown);
+
+    [Fact]
+    public void EditValue_ShouldReturnOriginalValue_WhenNoServiceProvider() =>
+        _editor.EditValue(null, null!, typeof(DataGridViewTextBoxColumn)).Should().Be(typeof(DataGridViewTextBoxColumn));
+
+    [Fact]
+    public void EditValue_ShouldReturnOriginalValue_WhenNoEditorService()
+    {
+        Mock<IServiceProvider> serviceProviderMock = new();
+        serviceProviderMock.Setup(sp => sp.GetService(typeof(IWindowsFormsEditorService))).Returns(null!);
+
+        _editor.EditValue(null, serviceProviderMock.Object, typeof(DataGridViewTextBoxColumn)).Should().Be(typeof(DataGridViewTextBoxColumn));
+    }
+
+    [Fact]
+    public void EditValue_ShouldReturnOriginalValue_WhenNoContextInstance()
+    {
+        Mock<IServiceProvider> serviceProviderMock = new();
+        Mock<IWindowsFormsEditorService> editorServiceMock = new();
+        serviceProviderMock.Setup(sp => sp.GetService(typeof(IWindowsFormsEditorService))).Returns(editorServiceMock.Object);
+
+        _editor.EditValue(null, serviceProviderMock.Object, typeof(DataGridViewTextBoxColumn)).Should().Be(typeof(DataGridViewTextBoxColumn));
+    }
+
+    [Fact]
+    public void EditValue_ShouldReturnOriginalValue_WhenSelectedTypeIsNull()
+    {
+        Mock<IServiceProvider> mockProvider = new();
+        Mock<IWindowsFormsEditorService> mockEditorService = new();
+        Mock<ITypeDescriptorContext> mockContext = new();
+        Mock<IDesignerHost> mockDesignerHost = new();
+        Mock<ITypeDiscoveryService> mockDiscoveryService = new();
+
+        mockProvider.Setup(p => p.GetService(typeof(IWindowsFormsEditorService)))
+                    .Returns(mockEditorService.Object);
+        mockProvider.Setup(p => p.GetService(typeof(IDesignerHost)))
+                    .Returns(mockDesignerHost.Object);
+        mockDesignerHost.Setup(d => d.GetService(typeof(ITypeDiscoveryService)))
+                        .Returns(mockDiscoveryService.Object);
+
+        ArrayList mockTypeCollection = [typeof(DataGridViewTextBoxColumn), typeof(DataGridViewCheckBoxColumn)];
+        mockDiscoveryService.Setup(d => d.GetTypes(typeof(DataGridViewColumn), false))
+                            .Returns(mockTypeCollection);
+
+        DataGridViewTextBoxColumn column = new();
+        SubListBoxItem listBoxItem = new(column);
+        mockContext.Setup(c => c.Instance).Returns(listBoxItem);
+
+        object? result = _editor.EditValue(mockContext.Object, mockProvider.Object, null);
+
+        mockEditorService.Verify(s => s.DropDownControl(It.IsAny<Control>()), Times.Once);
+        result.Should().Be(null);
+    }
+
+    private class SubListBoxItem : DataGridViewColumnCollectionDialog.ListBoxItem
+    {
+        public SubListBoxItem(DataGridViewColumn column) : base(column, null!, null!) { }
+    }
+}


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773

## Proposed changes

- Add unit test file: ControlCommandSetTests.cs for public methods and 2 protected methods of the ControlCommandSet.cs.




 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13130)