### PR TITLE
Update PublishCodeCoverageResults

### DIFF
--- a/eng/pipelines/build-PR.yml
+++ b/eng/pipelines/build-PR.yml
@@ -141,12 +141,11 @@ jobs:
       condition: and(succeeded(), eq(variables._Coverage, 'true'), eq('${{ parameters.targetArchitecture }}', 'x64'))
 
     #Publish code coverage results
-    - task: PublishCodeCoverageResults@1
+    - task: PublishCodeCoverageResults@2
       inputs:
-        codeCoverageTool: 'cobertura'
         summaryFileLocation: '$(Build.SourcesDirectory)\artifacts\bin\CodeCoverage\coverage\full\Cobertura.xml'
         pathToSources: '$(Build.SourcesDirectory)'
-        reportDirectory: '$(Build.SourcesDirectory)\artifacts\bin\CodeCoverage\coverage\full'
+        failIfCoverageEmpty: true
       displayName: PublishCodeCoverageResults
       condition: and(eq(variables['_BuildConfig'], 'Debug'), eq('${{ parameters.targetArchitecture }}', 'x64'))
 

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -144,12 +144,11 @@ jobs:
     condition: and(succeeded(), eq(variables._Coverage, 'true'), eq('${{ parameters.targetArchitecture }}', 'x64'))
 
   #Publish code coverage results
-  - task: PublishCodeCoverageResults@1
+  - task: PublishCodeCoverageResults@2
     inputs:
-      codeCoverageTool: 'cobertura'
       summaryFileLocation: '$(Build.SourcesDirectory)\artifacts\bin\CodeCoverage\coverage\full\Cobertura.xml'
       pathToSources: '$(Build.SourcesDirectory)'
-      reportDirectory: '$(Build.SourcesDirectory)\artifacts\bin\CodeCoverage\coverage\full'
+      failIfCoverageEmpty: true
     displayName: PublishCodeCoverageResults
     condition: and(eq(variables['_BuildConfig'], 'Debug'), eq('${{ parameters.targetArchitecture }}', 'x64'))
 


### PR DESCRIPTION
fix #12634

Upgrade PublishCodeCoverageResults@1 to PublishCodeCoverageResults@2

### Before
![image](https://github.com/user-attachments/assets/3d45bc14-e81f-4dc3-82d3-3209903e474a)
![image](https://github.com/user-attachments/assets/ec9705bc-4d00-4d06-8d17-0f371c32dea1)

### After
![image](https://github.com/user-attachments/assets/55622bf9-7cc5-497d-bbf4-fab1462364ae)
![image](https://github.com/user-attachments/assets/e67f7394-4bd9-4d8f-95fa-2d5774c5d9df)



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13131)