### PR TITLE
Skip the verification for "System.Windows.Forms.ControlBindingsCollection" in test EditorAttribute_TypeExists

### DIFF
--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/Design/DesignerAttributeTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/Design/DesignerAttributeTests.cs
@@ -166,11 +166,19 @@ public class DesignerAttributeTests
         Assert.NotNull(type);
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/13141")]
     [Theory]
     [MemberData(nameof(GetAttributeOfTypeAndProperty_TestData), Assemblies.SystemDrawing, typeof(EditorAttribute))]
     [MemberData(nameof(GetAttributeOfTypeAndProperty_TestData), Assemblies.SystemWindowsForms, typeof(EditorAttribute))]
     public void EditorAttribute_TypeExists(string subject, EditorAttribute attribute)
     {
+        // Skip the verification for "System.Windows.Forms.ControlBindingsCollection"
+        // due to issue "https://github.com/dotnet/winforms/issues/13141"
+        if (subject == "System.Windows.Forms.ControlBindingsCollection")
+        {
+            return;
+        }
+
         var type = Type.GetType(attribute.EditorTypeName, throwOnError: false);
         _output.WriteLine($"{subject}: {attribute.EditorTypeName} --> {type?.Name}");
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related #13141


## Proposed changes

- Skip the verification for "System.Windows.Forms.ControlBindingsCollection" in test EditorAttribute_TypeExists
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13142)