### PR TITLE
Disable IDE0082 in the VMR build

### DIFF
--- a/src/System.Private.Windows.Core/src/System.Private.Windows.Core.csproj
+++ b/src/System.Private.Windows.Core/src/System.Private.Windows.Core.csproj
@@ -14,8 +14,9 @@
       cross that bridge when we hit it (if ever).
     -->
     <NoWarn>$(NoWarn);CS8981</NoWarn>
-    <!-- Reenable when VRM SDK version contains fis for "reference-like" types -->
-    <NoWarn Condition="'$(DotNetBuild)' == 'true'">$(NoWarn);IDE0059</NoWarn>
+    <!-- Reenable IDE0059 when VRM SDK version contains the fix for "reference-like" types -->
+    <!-- Reenable IDE0082 when VRM SDK version contains the fix for typeof/nameof support for generics -->
+    <NoWarn Condition="'$(DotNetBuild)' == 'true'">$(NoWarn);IDE0059;IDE0082</NoWarn>
     <!--
       CS3016: We don't care about CLS compliance since everything here is internal and we want to match native types.
       SYSLIB5005: System.Formats.Nrbf is experimental


### PR DESCRIPTION
re-introduce https://github.com/dotnet/winforms/issues/12881 to support the VMR build which uses an older version of Roslyn is https://github.com/dotnet/sdk/pull/47167 is not fixed before Preview3.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13143)