### PR TITLE
Remove unnecessary 'fixed' statement

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameter.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameter.cs
@@ -214,12 +214,9 @@ public sealed unsafe class EncoderParameter : IDisposable
         _parameterValue = Marshal.AllocHGlobal(checked(_numberOfValues * sizeof(int)));
 
         int* dest = (int*)_parameterValue;
-        fixed (long* source = value)
+        for (int i = 0; i < value.Length; i++)
         {
-            for (int i = 0; i < value.Length; i++)
-            {
-                dest[i] = (int)source[i];
-            }
+            dest[i] = (int)value[i];
         }
 
         GC.KeepAlive(this);


### PR DESCRIPTION
Part of the "remove unsafe" campaign. This call site was flagged by an experimental rule as being a good candidate for removing the `fixed` keyword and using standard array iteration. There's still obviously unsafe code in this method, but we're working in baby steps. :)

The experimental rule was looking only for low-hanging fruit and did not identify any other good candidates in this repo at this time.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13146)