### PR TITLE
Moving OS Condition to SupplementalInputLanguages_TestData for test InputLanguage_FromCulture_SupplementalInputLanguages_Expected

### DIFF
--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/InputLanguageTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/InputLanguageTests.cs
@@ -132,19 +132,14 @@ public class InputLanguageTests
 
     public static IEnumerable<object[]> SupplementalInputLanguages_TestData()
     {
+        yield return new object[] { "got-Goth", "000C0C00", "Gothic" };
+        yield return new object[] { "jv-Java", "00110C00", "Javanese" };
+        yield return new object[] { "zgh-Tfng", "0000105F", "Tifinagh (Basic)" };
+
         // N’Ko input test failed in Windows 11 version 21H2.
         if (OsVersion.IsWindows11_22H2OrGreater())
         {
-            yield return new object[] { "got-Goth", "000C0C00", "Gothic" };
-            yield return new object[] { "jv-Java", "00110C00", "Javanese" };
             yield return new object[] { "nqo", "00090C00", "N’Ko" };
-            yield return new object[] { "zgh-Tfng", "0000105F", "Tifinagh (Basic)" };
-        }
-        else
-        {
-            yield return new object[] { "got-Goth", "000C0C00", "Gothic" };
-            yield return new object[] { "jv-Java", "00110C00", "Javanese" };
-            yield return new object[] { "zgh-Tfng", "0000105F", "Tifinagh (Basic)" };
         }
     }
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/InputLanguageTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/InputLanguageTests.cs
@@ -132,22 +132,27 @@ public class InputLanguageTests
 
     public static IEnumerable<object[]> SupplementalInputLanguages_TestData()
     {
-        yield return new object[] { "got-Goth", "000C0C00", "Gothic" };
-        yield return new object[] { "jv-Java", "00110C00", "Javanese" };
-        yield return new object[] { "nqo", "00090C00", "N’Ko" };
-        yield return new object[] { "zgh-Tfng", "0000105F", "Tifinagh (Basic)" };
+        // N’Ko input test failed in Windows 11 version 21H2.
+        // This condition should be removed once https://github.com/dotnet/winforms/issues/10150 is resolved.
+        if (OsVersion.IsWindows11_22H2OrGreater())
+        {
+            yield return new object[] { "got-Goth", "000C0C00", "Gothic" };
+            yield return new object[] { "jv-Java", "00110C00", "Javanese" };
+            yield return new object[] { "nqo", "00090C00", "N’Ko" };
+            yield return new object[] { "zgh-Tfng", "0000105F", "Tifinagh (Basic)" };
+        }
+        else
+        {
+            yield return new object[] { "got-Goth", "000C0C00", "Gothic" };
+            yield return new object[] { "jv-Java", "00110C00", "Javanese" };
+            yield return new object[] { "zgh-Tfng", "0000105F", "Tifinagh (Basic)" };
+        }
     }
 
     [Theory]
     [MemberData(nameof(SupplementalInputLanguages_TestData))]
     public void InputLanguage_FromCulture_SupplementalInputLanguages_Expected(string languageTag, string layoutId, string layoutName)
     {
-        // This condition should be removed once https://github.com/dotnet/winforms/issues/10150 is resolved.
-        if (languageTag == "nqo" && !OsVersion.IsWindows11_22H2OrGreater())
-        {
-            return;
-        }
-
         // Also installs default keyboard layout for this language
         // https://learn.microsoft.com/windows-hardware/manufacture/desktop/default-input-locales-for-windows-language-packs
         InstallUserLanguage(languageTag);

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/InputLanguageTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/InputLanguageTests.cs
@@ -133,7 +133,6 @@ public class InputLanguageTests
     public static IEnumerable<object[]> SupplementalInputLanguages_TestData()
     {
         // N’Ko input test failed in Windows 11 version 21H2.
-        // This condition should be removed once https://github.com/dotnet/winforms/issues/10150 is resolved.
         if (OsVersion.IsWindows11_22H2OrGreater())
         {
             yield return new object[] { "got-Goth", "000C0C00", "Gothic" };


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixed #10150


## Proposed changes

- Moved the OS condition to SupplementalInputLanguages_TestData of the test InputLanguage_FromCulture_SupplementalInputLanguages_Expected. 
In this way, the current OS version can be known by checking the number of running scenarios in the CI pipeline running results

Currently, this scenario is always in the pass state
![image](https://github.com/user-attachments/assets/7cac45dc-7df3-4060-b702-1f17319aab99)

- Keep this condition to avoid failures if someone runs the test on W11 21H2