### PR TITLE
Enable localization testing since all resources are translated

### DIFF
--- a/src/System.Windows.Forms/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.fr.xlf
@@ -11506,7 +11506,7 @@ Cette opération non conforme s'est produite sur la trace de la pile :
       </trans-unit>
       <trans-unit id="toStringNone">
         <source>(none)</source>
-        <target state="translated">(aucune)</target>
+        <target state="translated">(aucun)</target>
         <note />
       </trans-unit>
       <trans-unit id="toStringPageDown">

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/KeysConverterTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/KeysConverterTests.cs
@@ -25,8 +25,7 @@ public class KeysConverterTests
         Assert.Equal(keys, result);
     }
 
-    [ActiveIssue("https://github.com/dotnet/winforms/issues/13117")]
-    [Theory(Skip = "Localization tests, see: https://github.com/dotnet/winforms/issues/13117")]
+    [Theory]
     [InlineData("fr-FR", "(aucun)", Keys.None)]
     [InlineData("nb-NO", "None", Keys.None)]
     [InlineData("de-DE", "Ende", Keys.End)]
@@ -72,8 +71,7 @@ public class KeysConverterTests
         Assert.Equal(expectedResult, result);
     }
 
-    [ActiveIssue("https://github.com/dotnet/winforms/issues/13117")]
-    [Theory(Skip = "Localization tests, see: https://github.com/dotnet/winforms/issues/13117")]
+    [Theory]
     [InlineData("fr-FR", Keys.None, "(aucun)")]
     [InlineData("de-DE", Keys.End, "Ende")]
     public void ConvertToString_ShouldConvertKeys_Localization(string cultureName, Keys key, string expectedLocalizedKeyName)

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripMenuItemTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripMenuItemTests.cs
@@ -143,8 +143,7 @@ public class ToolStripMenuItemTests
         Assert.Throws<InvalidEnumArgumentException>(() => item.ShortcutKeys = keys);
     }
 
-    [ActiveIssue("https://github.com/dotnet/winforms/issues/13117")]
-    [WinFormsTheory(Skip = "Localization tests, see: https://github.com/dotnet/winforms/issues/13117")]
+    [WinFormsTheory]
     [MemberData(nameof(CultureInfo_Shortcut_TestData))]
     public void ToolStripMenuItem_SetShortcutKeys_ReturnExpectedShortcutText(CultureInfo threadCulture, CultureInfo threadUICulture, string expectedShortcutText)
     {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13117 


## Proposed changes

- Enable following localization tests since all resources are translated
   -   System.Windows.Forms.Tests.KeysConverterTests.ConvertFrom_ShouldConvertKeys_Localization
   -   System.Windows.Forms.Tests.ToolStripMenuItemTests.ToolStripMenuItem_SetShortcutKeys_ReturnExpectedShortcutText
   -   System.Windows.Forms.Tests.KeysConverterTests.ConvertToString_ShouldConvertKeys_Localization
- Correct the translation for `(none)` in French from `(aucune)` to `(aucun)`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13162)