### PR TITLE
Fix Designer issues #6292 Overflow SplitButton/DropDownButton subitem are truncated in ToolStrip when setting ToolStrip's RightToLeft to Yes and pin the Toolbox window

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDownItem.cs
@@ -379,8 +379,7 @@ public abstract class ToolStripDropDownItem : ToolStripItem
         // fix https://github.com/microsoft/winforms-designer/issues/6292
         if (DesignMode &&
             RightToLeft == RightToLeft.Yes &&
-            dropDownDirection == ToolStripDropDownDirection.Left &&
-            (Parent is ToolStripOverflow || Parent is ToolStripDropDownMenu))
+            dropDownDirection == ToolStripDropDownDirection.Left)
         {
             dropDownDirection = ToolStripDropDownDirection.Right;
         }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDownItem.cs
@@ -374,33 +374,13 @@ public abstract class ToolStripDropDownItem : ToolStripItem
         base.Dispose(disposing);
     }
 
-    private static bool FromToolStripOverflow(ToolStripDropDownItem? toolStripDropDownItem)
-    {
-        if (toolStripDropDownItem is null)
-        {
-            return false;
-        }
-
-        if (toolStripDropDownItem.Parent is ToolStripOverflow)
-        {
-            return true;
-        }
-
-        if (toolStripDropDownItem.Parent is ToolStripDropDownMenu toolStripDropDownMenu)
-        {
-            return FromToolStripOverflow(toolStripDropDownMenu.OwnerItem as ToolStripDropDownItem);
-        }
-
-        return false;
-    }
-
     private Rectangle GetDropDownBounds(ToolStripDropDownDirection dropDownDirection)
     {
         // fix https://github.com/microsoft/winforms-designer/issues/6292
         if (DesignMode &&
             RightToLeft == RightToLeft.Yes &&
             dropDownDirection == ToolStripDropDownDirection.Left &&
-            FromToolStripOverflow(this))
+            (Parent is ToolStripOverflow || Parent is ToolStripDropDownMenu))
         {
             dropDownDirection = ToolStripDropDownDirection.Right;
         }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDownItem.cs
@@ -376,6 +376,15 @@ public abstract class ToolStripDropDownItem : ToolStripItem
 
     private Rectangle GetDropDownBounds(ToolStripDropDownDirection dropDownDirection)
     {
+        // fix https://github.com/microsoft/winforms-designer/issues/6292
+        if (DesignMode &&
+            RightToLeft == RightToLeft.Yes &&
+            dropDownDirection == ToolStripDropDownDirection.Left &&
+            (Parent is ToolStripOverflow || Parent is ToolStripDropDownMenu))
+        {
+            dropDownDirection = ToolStripDropDownDirection.Right;
+        }
+
         Rectangle dropDownBounds = new(Point.Empty, DropDown.GetSuggestedSize());
         // calculate the offset from the upper left hand corner of the item.
         dropDownBounds = DropDownDirectionToDropDownBounds(dropDownDirection, dropDownBounds);

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDownItem.cs
@@ -377,9 +377,7 @@ public abstract class ToolStripDropDownItem : ToolStripItem
     private Rectangle GetDropDownBounds(ToolStripDropDownDirection dropDownDirection)
     {
         // fix https://github.com/microsoft/winforms-designer/issues/6292
-        if (DesignMode &&
-            RightToLeft == RightToLeft.Yes &&
-            dropDownDirection == ToolStripDropDownDirection.Left)
+        if (DesignMode && RightToLeft == RightToLeft.Yes && dropDownDirection == ToolStripDropDownDirection.Left)
         {
             dropDownDirection = ToolStripDropDownDirection.Right;
         }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDownItem.cs
@@ -374,13 +374,33 @@ public abstract class ToolStripDropDownItem : ToolStripItem
         base.Dispose(disposing);
     }
 
+    private static bool FromToolStripOverflow(ToolStripDropDownItem? toolStripDropDownItem)
+    {
+        if (toolStripDropDownItem is null)
+        {
+            return false;
+        }
+
+        if (toolStripDropDownItem.Parent is ToolStripOverflow)
+        {
+            return true;
+        }
+
+        if (toolStripDropDownItem.Parent is ToolStripDropDownMenu toolStripDropDownMenu)
+        {
+            return FromToolStripOverflow(toolStripDropDownMenu.OwnerItem as ToolStripDropDownItem);
+        }
+
+        return false;
+    }
+
     private Rectangle GetDropDownBounds(ToolStripDropDownDirection dropDownDirection)
     {
         // fix https://github.com/microsoft/winforms-designer/issues/6292
         if (DesignMode &&
             RightToLeft == RightToLeft.Yes &&
             dropDownDirection == ToolStripDropDownDirection.Left &&
-            (Parent is ToolStripOverflow || Parent is ToolStripDropDownMenu))
+            FromToolStripOverflow(this))
         {
             dropDownDirection = ToolStripDropDownDirection.Right;
         }


### PR DESCRIPTION
Fixes [#microsoft/winforms-designer/issues/6292](https://github.com/microsoft/winforms-designer/issues/6292)


## Proposed changes

- 
- When the dropDown is in the Overflow , turn the direction from left to right
- 
<!-- 

## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-
 -->



## Screenshots 

### Before

![Image](https://github.com/user-attachments/assets/58781d33-ddfe-40c7-bebc-8afaa202de0f)

### After
<!-- 
![image](https://github.com/user-attachments/assets/1dd5f811-89af-4e2f-be04-807d0946fa25)

![image](https://github.com/user-attachments/assets/b40157cb-c873-4b0f-b81c-4dc855fa71f3)
 -->
![image](https://github.com/user-attachments/assets/5caf5432-9e22-4a93-9d47-d9c4474088bf)



## Test methodology 

- manual 


<!--

## Accessibility testing  



## Test environment(s) 


 -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13171)