### PR TITLE
Condition out the native tests in VMR

### DIFF
--- a/src/test/unit/interop/System.Windows.Forms.Interop.Tests.csproj
+++ b/src/test/unit/interop/System.Windows.Forms.Interop.Tests.csproj
@@ -6,6 +6,8 @@
     <AssemblyName>System.Windows.Forms.Interop.Tests</AssemblyName>
     <Platforms>x86;x64</Platforms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Native tests do not build in VMR - https://github.com/dotnet/winforms/issues/13186 -->
+    <ExcludeFromBuild Condition="'$(DotNetBuild)' == 'true'">true</ExcludeFromBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/winforms/issues/13188

`System.Windows.Forms` interop tests depend on NativeTests project, which doesn't build in VMR.

This PR just conditions the test project to not build in VMR. Additional work would be needed to enable these tests in VMR. The remaining work is likely best suited for someone with domain knowledge.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13187)