### PR TITLE
Update test "ConvertFrom_ShouldConvertKeys_Localization" to use the SR resource name to retrieve the localized string

### DIFF
--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/KeysConverterTests.LocalizationTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/KeysConverterTests.LocalizationTests.cs
@@ -1,0 +1,76 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+
+namespace System.Windows.Forms;
+
+public partial class KeysConverterTests
+{
+    // This test modifies global culture settings (Thread.CurrentUICulture and SR.Culture).
+    // As a result, it must run sequentially to avoid conflicts with other tests that may
+    // rely on or alter these settings. Running it in a sequential collection ensures consistent results.
+    [Collection("Sequential")]
+    public class LocalizationTests
+    {
+        [Theory]
+        [InlineData("fr-FR", "toStringNone", Keys.None)]
+        [InlineData("zh-CN", "toStringNone", Keys.None)]
+        [InlineData("nb-NO", "toStringNone", Keys.None)]
+        [InlineData("de-DE", "toStringEnd", Keys.End)]
+        public void ConvertFrom_ShouldConvertKeys_Localization(string cultureName, string resourceKey, Keys expectedKey)
+        {
+            // Record original culture.
+            CultureInfo originalUICulture = Thread.CurrentThread.CurrentUICulture;
+            CultureInfo originalSRCulture = SR.Culture;
+
+            CultureInfo targetCulture = CultureInfo.GetCultureInfo(cultureName);
+
+            try
+            {
+                // Use the SR resource key to retrieve the localized string corresponding to SR.Culture.
+                SR.Culture = targetCulture;
+                string localizedString = SR.GetResourceString(resourceKey);
+
+                KeysConverter converter = new();
+                var resultFromSpecificCulture = (Keys?)converter.ConvertFrom(context: null, targetCulture, localizedString);
+
+                Assert.Equal(expectedKey, resultFromSpecificCulture);
+
+                Thread.CurrentThread.CurrentUICulture = targetCulture;
+
+                // When the culture is empty, the 'localizedString' is converted
+                // to the corresponding key value based on CurrentUICulture.
+                var resultFromUICulture = (Keys?)converter.ConvertFrom(context: null, culture: null, localizedString);
+                Assert.Equal(expectedKey, resultFromUICulture);
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentUICulture = originalUICulture;
+                SR.Culture = originalSRCulture;
+            }
+        }
+
+        [Theory]
+        [InlineData("fr-FR", Keys.None, "toStringNone")]
+        [InlineData("de-DE", Keys.End, "toStringEnd")]
+        public void ConvertToString_ShouldConvertKeys_Localization(string cultureName, Keys key, string resourceKey)
+        {
+            CultureInfo originalSRCulture = SR.Culture;
+            try
+            {
+                CultureInfo targetCulture = CultureInfo.GetCultureInfo(cultureName);
+
+                KeysConverter converter = new();
+                string? result = converter.ConvertToString(null, targetCulture, key);
+
+                SR.Culture = targetCulture;
+                Assert.Equal(SR.GetResourceString(resourceKey), result);
+            }
+            finally
+            {
+                SR.Culture = originalSRCulture;
+            }
+        }
+    }
+}

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/KeysConverterTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/KeysConverterTests.cs
@@ -38,9 +38,8 @@ public class KeysConverterTests
 
         try
         {
+            // Use the SR resource key to retrieve the localized string corresponding to SR.Culture.
             SR.Culture = culture;
-
-            // Using the SR resource name to retrieve the localized string.
             string localizedString = SR.GetResourceString(resourceKey);
 
             KeysConverter converter = new();
@@ -50,7 +49,8 @@ public class KeysConverterTests
 
             Thread.CurrentThread.CurrentUICulture = culture;
 
-            // When the culture is empty, the 'localizedString' is converted to the corresponding key value based on CurrentUICulture.
+            // When the culture is empty, the 'localizedString' is converted
+            // to the corresponding key value based on CurrentUICulture.
             var resultFromUICulture = (Keys?)converter.ConvertFrom(context: null, culture: null, localizedString);
             Assert.Equal(expectedKey, resultFromUICulture);
         }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/KeysConverterTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/KeysConverterTests.cs
@@ -32,22 +32,22 @@ public class KeysConverterTests
     [InlineData("de-DE", "toStringEnd", Keys.End)]
     public void ConvertFrom_ShouldConvertKeys_Localization(string cultureName, string resourceKey, Keys expectedKey)
     {
-        CultureInfo culture = CultureInfo.GetCultureInfo(cultureName);
-        SR.Culture = culture;
-
-        // Using the SR resource name to retrieve the localized string.
-        string localizedString = SR.GetResourceString(resourceKey);
-
-        KeysConverter converter = new();
-        var resultFromSpecificCulture = (Keys?)converter.ConvertFrom(context: null, culture, localizedString);
-
-        Assert.Equal(expectedKey, resultFromSpecificCulture);
-
         // Record original UI culture.
         CultureInfo originalUICulture = Thread.CurrentThread.CurrentUICulture;
+        CultureInfo culture = CultureInfo.GetCultureInfo(cultureName);
 
         try
         {
+            SR.Culture = culture;
+
+            // Using the SR resource name to retrieve the localized string.
+            string localizedString = SR.GetResourceString(resourceKey);
+
+            KeysConverter converter = new();
+            var resultFromSpecificCulture = (Keys?)converter.ConvertFrom(context: null, culture, localizedString);
+
+            Assert.Equal(expectedKey, resultFromSpecificCulture);
+
             Thread.CurrentThread.CurrentUICulture = culture;
 
             // When the culture is empty, the 'localizedString' is converted to the corresponding key value based on CurrentUICulture.
@@ -57,6 +57,7 @@ public class KeysConverterTests
         finally
         {
             Thread.CurrentThread.CurrentUICulture = originalUICulture;
+            SR.Culture = originalUICulture;
         }
     }
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/KeysConverterTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/KeysConverterTests.cs
@@ -26,16 +26,21 @@ public class KeysConverterTests
     }
 
     [Theory]
-    [InlineData("fr-FR", "(aucune)", Keys.None)]
-    [InlineData("nb-NO", "None", Keys.None)]
-    [InlineData("de-DE", "Ende", Keys.End)]
-    public void ConvertFrom_ShouldConvertKeys_Localization(string cultureName, string localizedKeyName, Keys expectedKey)
+    [InlineData("fr-FR", "toStringNone", Keys.None)]
+    [InlineData("zh-CN", "toStringNone", Keys.None)]
+    [InlineData("nb-NO", "toStringNone", Keys.None)]
+    [InlineData("de-DE", "toStringEnd", Keys.End)]
+    public void ConvertFrom_ShouldConvertKeys_Localization(string cultureName, string resourceKey, Keys expectedKey)
     {
         CultureInfo culture = CultureInfo.GetCultureInfo(cultureName);
-        KeysConverter converter = new();
+        SR.Culture = culture;
 
-        // The 'localizedKeyName' is converted into the corresponding key value according to the specified culture.
-        var resultFromSpecificCulture = (Keys?)converter.ConvertFrom(context: null, culture, localizedKeyName);
+        // Using the SR resource name to retrieve the localized string.
+        string localizedString = SR.GetResourceString(resourceKey);
+
+        KeysConverter converter = new();
+        var resultFromSpecificCulture = (Keys?)converter.ConvertFrom(context: null, culture, localizedString);
+
         Assert.Equal(expectedKey, resultFromSpecificCulture);
 
         // Record original UI culture.
@@ -45,8 +50,8 @@ public class KeysConverterTests
         {
             Thread.CurrentThread.CurrentUICulture = culture;
 
-            // When the culture is empty, the 'localizedKeyName' is converted to the corresponding key value based on CurrentUICulture.
-            var resultFromUICulture = (Keys?)converter.ConvertFrom(context: null, culture: null, localizedKeyName);
+            // When the culture is empty, the 'localizedString' is converted to the corresponding key value based on CurrentUICulture.
+            var resultFromUICulture = (Keys?)converter.ConvertFrom(context: null, culture: null, localizedString);
             Assert.Equal(expectedKey, resultFromUICulture);
         }
         finally

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/KeysConverterTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/KeysConverterTests.cs
@@ -8,7 +8,7 @@ using System.Globalization;
 
 namespace System.Windows.Forms.Tests;
 
-public class KeysConverterTests
+public partial class KeysConverterTests
 {
     [Theory]
     [UseDefaultXunitCulture]
@@ -26,42 +26,6 @@ public class KeysConverterTests
     }
 
     [Theory]
-    [InlineData("fr-FR", "toStringNone", Keys.None)]
-    [InlineData("zh-CN", "toStringNone", Keys.None)]
-    [InlineData("nb-NO", "toStringNone", Keys.None)]
-    [InlineData("de-DE", "toStringEnd", Keys.End)]
-    public void ConvertFrom_ShouldConvertKeys_Localization(string cultureName, string resourceKey, Keys expectedKey)
-    {
-        // Record original UI culture.
-        CultureInfo originalUICulture = Thread.CurrentThread.CurrentUICulture;
-        CultureInfo culture = CultureInfo.GetCultureInfo(cultureName);
-
-        try
-        {
-            // Use the SR resource key to retrieve the localized string corresponding to SR.Culture.
-            SR.Culture = culture;
-            string localizedString = SR.GetResourceString(resourceKey);
-
-            KeysConverter converter = new();
-            var resultFromSpecificCulture = (Keys?)converter.ConvertFrom(context: null, culture, localizedString);
-
-            Assert.Equal(expectedKey, resultFromSpecificCulture);
-
-            Thread.CurrentThread.CurrentUICulture = culture;
-
-            // When the culture is empty, the 'localizedString' is converted
-            // to the corresponding key value based on CurrentUICulture.
-            var resultFromUICulture = (Keys?)converter.ConvertFrom(context: null, culture: null, localizedString);
-            Assert.Equal(expectedKey, resultFromUICulture);
-        }
-        finally
-        {
-            Thread.CurrentThread.CurrentUICulture = originalUICulture;
-            SR.Culture = originalUICulture;
-        }
-    }
-
-    [Theory]
     [InlineData(Keys.None, "(none)")]
     [InlineData(Keys.S, "S")]
     [InlineData(Keys.Control | Keys.C, "Ctrl+C")]
@@ -75,19 +39,6 @@ public class KeysConverterTests
         KeysConverter converter = new();
         string result = converter.ConvertToString(null, CultureInfo.InvariantCulture, keys);
         Assert.Equal(expectedResult, result);
-    }
-
-    [Theory]
-    [InlineData("fr-FR", Keys.None, "(aucune)")]
-    [InlineData("de-DE", Keys.End, "Ende")]
-    public void ConvertToString_ShouldConvertKeys_Localization(string cultureName, Keys key, string expectedLocalizedKeyName)
-    {
-        CultureInfo culture = CultureInfo.GetCultureInfo(cultureName);
-
-        KeysConverter converter = new();
-        string result = converter.ConvertToString(null, culture, key);
-
-        Assert.Equal(expectedLocalizedKeyName, result);
     }
 
     public static IEnumerable<object[]> ConvertToEnumArray_ShouldConvertKeys_TestData()


### PR DESCRIPTION
Update test "ConvertFrom_ShouldConvertKeys_Localization" to use the SR resource name to retrieve the localized string
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13192)