### PR TITLE
Adds some specific serialization test cases for the `ToolStripMenuItemCodeDomSerializer` class

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripMenuItemCodeDomSerializerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripMenuItemCodeDomSerializerTests.cs
@@ -1,9 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Moq;
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
+using System.Drawing;
 
 namespace System.Windows.Forms.Design.Tests;
 
@@ -39,7 +40,7 @@ public class ToolStripMenuItemCodeDomSerializerTests
         _mockManager.Setup(m => m.GetSerializer(typeof(ImageList).BaseType, typeof(CodeDomSerializer)))
                     .Returns(_mockBaseSerializer.Object);
 
-        ToolStripMenuItem dummyItem = new();
+        using ToolStripMenuItem dummyItem = new();
         Mock<ToolStrip> mockParent = new();
         mockParent.Setup(p => p.Site).Returns((ISite?)null);
         dummyItem.TestAccessor().Dynamic.Parent = mockParent.Object;
@@ -55,8 +56,8 @@ public class ToolStripMenuItemCodeDomSerializerTests
         _mockManager.Setup(m => m.GetSerializer(typeof(ImageList).BaseType, typeof(CodeDomSerializer)))
                     .Returns(_mockBaseSerializer.Object);
 
-        ToolStripMenuItem nonDummyItem = new();
-        ToolStripDropDown dropDown = new();
+        using ToolStripMenuItem nonDummyItem = new();
+        using ToolStripDropDown dropDown = new();
         dropDown.Items.Add(nonDummyItem);
 
         Mock<ISite> mockSite = new();
@@ -72,5 +73,81 @@ public class ToolStripMenuItemCodeDomSerializerTests
 
         result.Should().NotBeNull();
         _mockBaseSerializer.Verify(s => s.Serialize(_mockManager.Object, nonDummyItem), Times.Once);
+    }
+
+    [Fact]
+    public void Serialize_SerializesDropDownItemsCorrectly()
+    {
+        _mockManager.Setup(m => m.GetSerializer(typeof(ToolStripMenuItem), typeof(CodeDomSerializer)))
+                    .Returns(_mockBaseSerializer.Object);
+
+        using ToolStripMenuItem parentItem = new() { Text = "Edit" };
+        using ToolStripMenuItem childItem = new() { Text = "Undo" };
+        parentItem.DropDownItems.Add(childItem);
+
+        _mockBaseSerializer.Setup(s => s.Serialize(_mockManager.Object, parentItem))
+                           .Returns(new { parentItem.Text, DropDownItems = new[] { new { childItem.Text } } });
+
+        object? result = _serializer.Serialize(_mockManager.Object, parentItem);
+
+        result.Should().NotBeNull();
+        result.Should().BeEquivalentTo(new { Text = "Edit", DropDownItems = new[] { new { Text = "Undo" } } });
+        _mockBaseSerializer.Verify(s => s.Serialize(_mockManager.Object, parentItem), Times.Once);
+    }
+
+    [Fact]
+    public void Serialize_SerializesEnabledPropertyCorrectly()
+    {
+        _mockManager.Setup(m => m.GetSerializer(typeof(ToolStripMenuItem), typeof(CodeDomSerializer)))
+                    .Returns(_mockBaseSerializer.Object);
+
+        using ToolStripMenuItem item = new() { Enabled = false };
+        _mockBaseSerializer.Setup(s => s.Serialize(_mockManager.Object, item))
+                           .Returns(new { item.Enabled });
+
+        object? result = _serializer.Serialize(_mockManager.Object, item);
+
+        result.Should().NotBeNull();
+        result.Should().BeEquivalentTo(new { Enabled = false });
+        _mockBaseSerializer.Verify(s => s.Serialize(_mockManager.Object, item), Times.Once);
+    }
+
+    [Fact]
+    public void Serialize_SerializesCheckedAndTextCorrectly()
+    {
+        _mockManager.Setup(m => m.GetSerializer(typeof(ToolStripMenuItem), typeof(CodeDomSerializer)))
+                    .Returns(_mockBaseSerializer.Object);
+
+        using ToolStripMenuItem parentItem = new() { Text = "File", Checked = true };
+        using ToolStripMenuItem childItem = new() { Text = "New", Checked = false };
+        parentItem.DropDownItems.Add(childItem);
+
+        _mockBaseSerializer.Setup(s => s.Serialize(_mockManager.Object, parentItem))
+                           .Returns(new { parentItem.Text, parentItem.Checked, DropDownItems = new[] { new { childItem.Text, childItem.Checked } } });
+
+        object? result = _serializer.Serialize(_mockManager.Object, parentItem);
+
+        result.Should().NotBeNull();
+        result.Should().BeEquivalentTo(new { Text = "File", Checked = true, DropDownItems = new[] { new { Text = "New", Checked = false } } });
+        _mockBaseSerializer.Verify(s => s.Serialize(_mockManager.Object, parentItem), Times.Once);
+    }
+
+    [Fact]
+    public void Serialize_SerializesImagePropertyCorrectly()
+    {
+        _mockManager.Setup(m => m.GetSerializer(typeof(ToolStripMenuItem), typeof(CodeDomSerializer)))
+                    .Returns(_mockBaseSerializer.Object);
+
+        Image testImage = new Bitmap(1, 1);
+        using ToolStripMenuItem item = new() { Image = testImage };
+
+        _mockBaseSerializer.Setup(s => s.Serialize(_mockManager.Object, item))
+                           .Returns(new { item.Image });
+
+        object? result = _serializer.Serialize(_mockManager.Object, item);
+
+        result.Should().NotBeNull();
+        result.Should().BeEquivalentTo(new { Image = testImage });
+        _mockBaseSerializer.Verify(s => s.Serialize(_mockManager.Object, item), Times.Once);
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripMenuItemCodeDomSerializerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripMenuItemCodeDomSerializerTests.cs
@@ -78,8 +78,9 @@ public class ToolStripMenuItemCodeDomSerializerTests
     [Fact]
     public void Serialize_SerializesDropDownItemsCorrectly()
     {
-        _mockManager.Setup(m => m.GetSerializer(typeof(ToolStripMenuItem), typeof(CodeDomSerializer)))
-                    .Returns(_mockBaseSerializer.Object);
+        _mockManager
+            .Setup(m => m.GetSerializer(typeof(ToolStripMenuItem), typeof(CodeDomSerializer)))
+            .Returns(_mockBaseSerializer.Object);
 
         using ToolStripMenuItem parentItem = new() { Text = "Edit" };
         using ToolStripMenuItem childItem = new() { Text = "Undo" };
@@ -138,7 +139,7 @@ public class ToolStripMenuItemCodeDomSerializerTests
         _mockManager.Setup(m => m.GetSerializer(typeof(ToolStripMenuItem), typeof(CodeDomSerializer)))
                     .Returns(_mockBaseSerializer.Object);
 
-        Image testImage = new Bitmap(1, 1);
+        using Image testImage = new Bitmap(1, 1);
         using ToolStripMenuItem item = new() { Image = testImage };
 
         _mockBaseSerializer.Setup(s => s.Serialize(_mockManager.Object, item))


### PR DESCRIPTION
Related #10773
Related #12883

## Root Cause

- After the merging of #12883, there was a [request for some specific serialization test cases of the `ToolStripMenuItemCodeDomSerializer` class](https://github.com/dotnet/winforms/pull/12883#issuecomment-2644222449).

## Proposed changes

- Adds some specific serialization test cases for the `ToolStripMenuItemCodeDomSerializer` class.

## Customer Impact

- None

## Risk

- Minimal

## Test methodology

- Unit tests

## Test environment(s)

- 10.0.100-preview.3.25167.3

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13200)