### PR TITLE
Disable validation of InputLanguage.LayoutName in non-English modes in test InputLanguage_FromCulture_SupplementalInputLanguages_Expected 

### DIFF
--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/InputLanguageTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/InputLanguageTests.cs
@@ -183,15 +183,19 @@ public class InputLanguageTests
 
     private static void VerifyInputLanguage(InputLanguage language, string languageTag, string layoutId, string layoutName)
     {
-        Assert.NotNull(language);
-        Assert.NotEqual(IntPtr.Zero, language.Handle);
-        Assert.Equal(languageTag, language.Culture.Name);
-        Assert.Equal(layoutId, language.LayoutId);
+        language.Should().NotBeNull();
+        language.Handle.Should().NotBe(IntPtr.Zero);
+        language.Culture.Name.Should().Be(languageTag);
+        language.LayoutId.Should().Be(layoutId);
 
-        CultureInfo culture = new("en-US");
-        if (CultureInfo.InstalledUICulture == culture)
+        if (CultureInfo.InstalledUICulture.Name.StartsWith("en-", StringComparison.OrdinalIgnoreCase))
         {
-            Assert.Equal(layoutName, language.LayoutName);
+            language.LayoutName.Should().Be(layoutName);
+        }
+        else
+        {
+            language.LayoutName.Should().NotBeNullOrEmpty();
+            language.LayoutName.Should().NotBeEquivalentTo(SR.UnknownInputLanguageLayout);
         }
     }
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/InputLanguageTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/InputLanguageTests.cs
@@ -187,7 +187,12 @@ public class InputLanguageTests
         Assert.NotEqual(IntPtr.Zero, language.Handle);
         Assert.Equal(languageTag, language.Culture.Name);
         Assert.Equal(layoutId, language.LayoutId);
-        Assert.Equal(layoutName, language.LayoutName);
+
+        CultureInfo culture = new("en-US");
+        if (CultureInfo.InstalledUICulture == culture)
+        {
+            Assert.Equal(layoutName, language.LayoutName);
+        }
     }
 
     private static void VerifyInputLanguage(InputLanguage language)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13226


## Proposed changes

- Disable validation of InputLanguage.LayoutName in non-English OS in test InputLanguage_FromCulture_SupplementalInputLanguages_Expected 
