### PR TITLE
Suppress IDE0031

### DIFF
--- a/src/System.Private.Windows.Core/src/System.Private.Windows.Core.csproj
+++ b/src/System.Private.Windows.Core/src/System.Private.Windows.Core.csproj
@@ -21,6 +21,8 @@
       SYSLIB5005: System.Formats.Nrbf is experimental
     -->
     <NoWarn>$(NoWarn);CS3016;SYSLIB5005</NoWarn>
+    <!-- Reenable when fixes are made for IDE0031 warnings that VMR treats as errors. -->
+    <NoWarn Condition="'$(DotNetBuild)' == 'true'">$(NoWarn);IDE0031</NoWarn>
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <UsePublicApiAnalyzers>false</UsePublicApiAnalyzers>

--- a/src/System.Private.Windows.Core/src/System.Private.Windows.Core.csproj
+++ b/src/System.Private.Windows.Core/src/System.Private.Windows.Core.csproj
@@ -21,7 +21,8 @@
       SYSLIB5005: System.Formats.Nrbf is experimental
     -->
     <NoWarn>$(NoWarn);CS3016;SYSLIB5005</NoWarn>
-    <!-- Reenable when fixes are made for IDE0031 warnings that VMR treats as errors. -->
+    <!-- Reenable when SDK and dotnet Preview 4 versions flow into this repo and we are in sync with VMR. -->
+    <!-- tracking https://github.com/dotnet/winforms/issues/13261 -->
     <NoWarn Condition="'$(DotNetBuild)' == 'true'">$(NoWarn);IDE0031</NoWarn>
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/src/System.Windows.Forms/System.Windows.Forms.csproj
+++ b/src/System.Windows.Forms/System.Windows.Forms.csproj
@@ -15,6 +15,8 @@
       SYSLIB5005: System.Formats.Nrbf is experimental
     -->
     <NoWarn>$(NoWarn);SYSLIB5005</NoWarn>
+    <!-- Reenable when fixes are made for IDE0031 warnings that VMR treats as errors. -->
+    <NoWarn Condition="'$(DotNetBuild)' == 'true'">$(NoWarn);IDE0031</NoWarn>
     <Win32Manifest>Resources\System\Windows\Forms\XPThemes.manifest</Win32Manifest>
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>


### PR DESCRIPTION
IDE0031 warnings were turned into errors in VMR build, with the latest SDK and compiler - https://github.com/dotnet/sdk/pull/48226

```
D:\a\_work\1\vmr\src\winforms\src\System.Private.Windows.Core\src\System\Private\Windows\Ole\FormatEnumerator.cs(59,13): error IDE0031: Null check can be simplified (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0031) [D:\a\_work\1\vmr\src\winforms\src\System.Private.Windows.Core\src\System.Private.Windows.Core.csproj::TargetFramework=net8.0]
D:\a\_work\1\vmr\src\winforms\src\System.Private.Windows.Core\src\System\Private\Windows\Ole\FormatEnumerator.cs(77,9): error IDE0031: Null check can be simplified (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0031) [D:\a\_work\1\vmr\src\winforms\src\System.Private.Windows.Core\src\System.Private.Windows.Core.csproj::TargetFramework=net8.0]
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13260)