### PR TITLE
Property grid entry for ShortCut keys should not be up/down scrollable

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
@@ -4643,7 +4643,7 @@ internal sealed partial class PropertyGridView :
             {
                 InPropertySet = true;
 
-                // If this propentry is enumerable, then once a value is selected from the editor,
+                // If this entry is enumerable, then once a value is selected from the editor,
                 // we'll want to close the drop down (like true/false). Otherwise, if we're
                 // working with Anchor for ex., then we should be able to select different values
                 // from the editor, without having it close every time.

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/KeysConverterTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/KeysConverterTests.cs
@@ -102,7 +102,7 @@ public partial class KeysConverterTests
 
         Keys[] expectedValues =
         [
-            Keys.None, Keys.D0, Keys.D1, Keys.D2, Keys.D3, Keys.D4, Keys.D5, Keys.D6, Keys.D7, Keys.D8, Keys.D9, Keys.Alt, Keys.Back, Keys.Control,
+            Keys.D0, Keys.D1, Keys.D2, Keys.D3, Keys.D4, Keys.D5, Keys.D6, Keys.D7, Keys.D8, Keys.D9, Keys.Alt, Keys.Back, Keys.Control,
             Keys.Delete, Keys.End, Keys.Enter, Keys.F1, Keys.F10, Keys.F11, Keys.F12, Keys.F2, Keys.F3, Keys.F4, Keys.F5, Keys.F6, Keys.F7, Keys.F8,
             Keys.F9, Keys.Home, Keys.Insert, Keys.Next, Keys.PageUp, Keys.Shift
         ];

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/PropertyGridInternal/PropertyGridView.DropDownHolderTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/PropertyGridInternal/PropertyGridView.DropDownHolderTests.cs
@@ -11,7 +11,7 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests;
 public class PropertyGridView_DropDownHolderTests
 {
     [WinFormsFact]
-    public void DropDownHolder_AccessibilityObject_Constructor_initializes_correctly()
+    public void Constructor_initializes_correctly()
     {
         using PropertyGridView propertyGridView = new(null, null);
         propertyGridView.BackColor = Color.Green;
@@ -21,7 +21,7 @@ public class PropertyGridView_DropDownHolderTests
     }
 
     [WinFormsFact]
-    public void DropDownHolder_SupportsUiaProviders_returns_true()
+    public void SupportsUiaProviders_returns_true()
     {
         using PropertyGridView propertyGridView = new(null, null);
         using DropDownHolder dropDownHolder = new(propertyGridView);
@@ -29,7 +29,7 @@ public class PropertyGridView_DropDownHolderTests
     }
 
     [WinFormsFact]
-    public void DropDownHolder_CreateAccessibilityObject_creates_DropDownHolderAccessibleObject()
+    public void CreateAccessibilityObject_creates_DropDownHolderAccessibleObject()
     {
         using PropertyGrid propertyGrid = new();
         PropertyGridView propertyGridView = propertyGrid.TestAccessor().GridView;
@@ -40,7 +40,7 @@ public class PropertyGridView_DropDownHolderTests
     }
 
     [WinFormsFact]
-    public void DropDownHolder_SetDropDownControl_control_notnull()
+    public void SetDropDownControl_control_notnull()
     {
         using PropertyGrid propertyGrid = new();
         PropertyGridView propertyGridView = propertyGrid.TestAccessor().GridView;
@@ -57,7 +57,7 @@ public class PropertyGridView_DropDownHolderTests
     }
 
     [WinFormsFact]
-    public void DropDownHolder_SetDropDownControl_control_null()
+    public void SetDropDownControl_control_null()
     {
         using PropertyGrid propertyGrid = new();
         PropertyGridView propertyGridView = propertyGrid.TestAccessor().GridView;
@@ -68,7 +68,7 @@ public class PropertyGridView_DropDownHolderTests
     }
 
     [WinFormsFact]
-    public void DropDownHolder_SetDropDownControl_Control_Height_verify()
+    public void SetDropDownControl_Control_Height_verify()
     {
         using PropertyGrid propertyGrid = new();
         PropertyGridView propertyGridView = propertyGrid.TestAccessor().GridView;
@@ -88,7 +88,7 @@ public class PropertyGridView_DropDownHolderTests
     }
 
     [WinFormsFact]
-    public void DropDownHolder_SetDropDownControl_resizable_true()
+    public void SetDropDownControl_resizable_true()
     {
         using PropertyGrid propertyGrid = new();
         PropertyGridView propertyGridView = propertyGrid.TestAccessor().GridView;


### PR DESCRIPTION
ToolStripMenuItem.ShortcutKeys property type (Keys enum) has a TypeConverter that reports that it has a set of standard values. This is not entirely accurate. Keys type has a set of standard values, but the ShortcutKeys property does not, Shortcuts are combinations or keys and modifiers that follow certain rules, it's not practical to present all combinations for user to step through with up/down keys or with mouse wheel. We need to disable scrolling through potential values in the properyt grid.

This behavior regressed when we added Keys.None value to the list of standard values - #8401. This was done to localize "None" (as "(none)") in the property grid. We should keep this value in the type converted tables for localization purposes. But we should remove it from the list of standard values. When the current value of the shortcut is not one of the standard values, property grid entry does not enter the "scroll through the standard items" functionality, which we want to block again.

Fixes #12982
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13280)