### PR TITLE
Introduces a `DesignerOptionsBuilder` helper that explicitly sets `UseSmartTags = false`

### DIFF
--- a/src/test/integration/DesignSurface/DesignSurfaceExt/DesignSurfaceExt.cs
+++ b/src/test/integration/DesignSurface/DesignSurfaceExt/DesignSurfaceExt.cs
@@ -30,7 +30,7 @@ public class DesignSurfaceExt : DesignSurface, IDesignSurfaceExt
             serviceProvider.RemoveService(typeof(DesignerOptionService));
         }
 
-        DesignerOptionService opsService2 = new DesignerOptionServiceExt4SnapLines();
+        DesignerOptionService opsService2 = new DesignerOptionService4SnapLinesExtension();
         serviceProvider.AddService(typeof(DesignerOptionService), opsService2);
     }
 
@@ -43,7 +43,7 @@ public class DesignSurfaceExt : DesignSurface, IDesignSurfaceExt
             serviceProvider.RemoveService(typeof(DesignerOptionService));
         }
 
-        DesignerOptionService opsService2 = new DesignerOptionServiceExt4Grid(gridSize);
+        DesignerOptionService opsService2 = new DesignerOptionService4GridExtension(gridSize);
         serviceProvider.AddService(typeof(DesignerOptionService), opsService2);
     }
 
@@ -56,7 +56,7 @@ public class DesignSurfaceExt : DesignSurface, IDesignSurfaceExt
             serviceProvider.RemoveService(typeof(DesignerOptionService));
         }
 
-        DesignerOptionService opsService2 = new DesignerOptionServiceExt4GridWithoutSnapping(gridSize);
+        DesignerOptionService opsService2 = new DesignerOptionService4GridWithoutSnappingExtension(gridSize);
         serviceProvider.AddService(typeof(DesignerOptionService), opsService2);
     }
 
@@ -69,7 +69,7 @@ public class DesignSurfaceExt : DesignSurface, IDesignSurfaceExt
             serviceProvider.RemoveService(typeof(DesignerOptionService));
         }
 
-        DesignerOptionService opsService2 = new DesignerOptionServiceExt4NoGuides();
+        DesignerOptionService opsService2 = new DesignerOptionService4NoGuidesExtension();
         serviceProvider.AddService(typeof(DesignerOptionService), opsService2);
     }
 

--- a/src/test/integration/DesignSurface/DesignSurfaceExt/DesignerOptionServiceExt.cs
+++ b/src/test/integration/DesignSurface/DesignSurfaceExt/DesignerOptionServiceExt.cs
@@ -3,109 +3,61 @@
 
 namespace DesignSurfaceExt;
 
-internal sealed class DesignerOptionsBuilder : DesignerOptionService
-{
-    private readonly DesignerOptions _options;
-
-    public DesignerOptionsBuilder(DesignerOptions baseOptions = null)
-    {
-        _options = baseOptions ?? new DesignerOptions();
-        _options.UseSmartTags = true;
-        _options.ObjectBoundSmartTagAutoShow = false;
-    }
-
-    public DesignerOptionsBuilder WithSnapLines(bool value)
-    {
-        _options.UseSnapLines = value;
-        return this;
-    }
-
-    public DesignerOptionsBuilder WithGrid(Size gridSize, bool snapToGrid, bool showGrid)
-    {
-        _options.GridSize = gridSize;
-        _options.SnapToGrid = snapToGrid;
-        _options.ShowGrid = showGrid;
-        return this;
-    }
-
-    public DesignerOptions Build() => _options;
-}
-
-internal sealed class DesignerOptionServiceExt4SnapLines : DesignerOptionService
-{
-    public DesignerOptionServiceExt4SnapLines() : base() { }
-
-    protected override void PopulateOptionCollection(DesignerOptionCollection options)
-    {
-        if (options.Parent is not null)
-            return;
-
-        DesignerOptions ops = new DesignerOptionsBuilder()
-            .WithSnapLines(true)
-            .Build();
-
-        DesignerOptionCollection wfd = CreateOptionCollection(options, "WindowsFormsDesigner", null);
-        CreateOptionCollection(wfd, "General", ops);
-    }
-}
-
-internal sealed class DesignerOptionServiceExt4Grid : DesignerOptionService
+internal abstract class DesignerOptionServiceExtBase : DesignerOptionService
 {
     private readonly Size _gridSize;
+    private readonly bool _useSnapLines;
+    private readonly bool _snapToGrid;
+    private readonly bool _showGrid;
 
-    public DesignerOptionServiceExt4Grid(Size gridSize) : base() { _gridSize = gridSize; }
+    protected DesignerOptionServiceExtBase(Size gridSize, bool useSnapLines, bool snapToGrid, bool showGrid)
+    {
+        _gridSize = gridSize;
+        _useSnapLines = useSnapLines;
+        _snapToGrid = snapToGrid;
+        _showGrid = showGrid;
+    }
 
     protected override void PopulateOptionCollection(DesignerOptionCollection options)
     {
         if (options.Parent is not null)
             return;
 
-        DesignerOptions ops = new DesignerOptionsBuilder()
-            .WithSnapLines(false)
-            .WithGrid(_gridSize, snapToGrid: true, showGrid: true)
-            .Build();
+        DesignerOptions ops = new()
+        {
+            GridSize = _gridSize,
+            UseSnapLines = _useSnapLines,
+            SnapToGrid = _snapToGrid,
+            ShowGrid = _showGrid,
+            UseSmartTags = true,
+            ObjectBoundSmartTagAutoShow = false
+        };
 
         DesignerOptionCollection wfd = CreateOptionCollection(options, "WindowsFormsDesigner", null);
         CreateOptionCollection(wfd, "General", ops);
     }
 }
 
-internal sealed class DesignerOptionServiceExt4GridWithoutSnapping : DesignerOptionService
+internal sealed class DesignerOptionServiceExt4SnapLines : DesignerOptionServiceExtBase
 {
-    private readonly Size _gridSize;
-
-    public DesignerOptionServiceExt4GridWithoutSnapping(Size gridSize) : base() { _gridSize = gridSize; }
-
-    protected override void PopulateOptionCollection(DesignerOptionCollection options)
-    {
-        if (options.Parent is not null)
-            return;
-
-        DesignerOptions ops = new DesignerOptionsBuilder()
-            .WithSnapLines(false)
-            .WithGrid(_gridSize, snapToGrid: false, showGrid: true)
-            .Build();
-
-        DesignerOptionCollection wfd = CreateOptionCollection(options, "WindowsFormsDesigner", null);
-        CreateOptionCollection(wfd, "General", ops);
-    }
+    public DesignerOptionServiceExt4SnapLines()
+        : base(new Size(0, 0), snapToGrid: true, useSnapLines: false, showGrid: false) { }
 }
 
-internal sealed class DesignerOptionServiceExt4NoGuides : DesignerOptionService
+internal sealed class DesignerOptionServiceExt4Grid : DesignerOptionServiceExtBase
 {
-    public DesignerOptionServiceExt4NoGuides() : base() { }
+    public DesignerOptionServiceExt4Grid(Size gridSize)
+        : base(gridSize, useSnapLines: false, snapToGrid: true, showGrid: true) { }
+}
 
-    protected override void PopulateOptionCollection(DesignerOptionCollection options)
-    {
-        if (options.Parent is not null)
-            return;
+internal sealed class DesignerOptionServiceExt4GridWithoutSnapping : DesignerOptionServiceExtBase
+{
+    public DesignerOptionServiceExt4GridWithoutSnapping(Size gridSize)
+        : base(gridSize, useSnapLines: false, snapToGrid: false, showGrid: true) { }
+}
 
-        DesignerOptions ops = new DesignerOptionsBuilder()
-            .WithSnapLines(false)
-            .WithGrid(new Size(8, 8), snapToGrid: false, showGrid: false)
-            .Build();
-
-        DesignerOptionCollection wfd = CreateOptionCollection(options, "WindowsFormsDesigner", null);
-        CreateOptionCollection(wfd, "General", ops);
-    }
+internal sealed class DesignerOptionServiceExt4NoGuides : DesignerOptionServiceExtBase
+{
+    public DesignerOptionServiceExt4NoGuides()
+        : base(new Size(8, 8), useSnapLines: false, snapToGrid: false, showGrid: false) { }
 }

--- a/src/test/integration/DesignSurface/DesignSurfaceExt/DesignerOptionServiceExt.cs
+++ b/src/test/integration/DesignSurface/DesignSurfaceExt/DesignerOptionServiceExt.cs
@@ -3,14 +3,14 @@
 
 namespace DesignSurfaceExt;
 
-internal abstract class DesignerOptionServiceExtBase : DesignerOptionService
+internal class DesignerOptionServiceBase : DesignerOptionService
 {
     private readonly Size _gridSize;
     private readonly bool _useSnapLines;
     private readonly bool _snapToGrid;
     private readonly bool _showGrid;
 
-    protected DesignerOptionServiceExtBase(Size gridSize, bool useSnapLines, bool snapToGrid, bool showGrid)
+    protected DesignerOptionServiceBase(Size gridSize, bool useSnapLines, bool snapToGrid, bool showGrid)
     {
         _gridSize = gridSize;
         _useSnapLines = useSnapLines;
@@ -38,26 +38,26 @@ internal abstract class DesignerOptionServiceExtBase : DesignerOptionService
     }
 }
 
-internal sealed class DesignerOptionServiceExt4SnapLines : DesignerOptionServiceExtBase
+internal sealed class DesignerOptionService4SnapLinesExtension : DesignerOptionServiceBase
 {
-    public DesignerOptionServiceExt4SnapLines()
+    public DesignerOptionService4SnapLinesExtension()
         : base(new Size(0, 0), snapToGrid: true, useSnapLines: false, showGrid: false) { }
 }
 
-internal sealed class DesignerOptionServiceExt4Grid : DesignerOptionServiceExtBase
+internal sealed class DesignerOptionService4GridExtension : DesignerOptionServiceBase
 {
-    public DesignerOptionServiceExt4Grid(Size gridSize)
+    public DesignerOptionService4GridExtension(Size gridSize)
         : base(gridSize, useSnapLines: false, snapToGrid: true, showGrid: true) { }
 }
 
-internal sealed class DesignerOptionServiceExt4GridWithoutSnapping : DesignerOptionServiceExtBase
+internal sealed class DesignerOptionService4GridWithoutSnappingExtension : DesignerOptionServiceBase
 {
-    public DesignerOptionServiceExt4GridWithoutSnapping(Size gridSize)
+    public DesignerOptionService4GridWithoutSnappingExtension(Size gridSize)
         : base(gridSize, useSnapLines: false, snapToGrid: false, showGrid: true) { }
 }
 
-internal sealed class DesignerOptionServiceExt4NoGuides : DesignerOptionServiceExtBase
+internal sealed class DesignerOptionService4NoGuidesExtension : DesignerOptionServiceBase
 {
-    public DesignerOptionServiceExt4NoGuides()
+    public DesignerOptionService4NoGuidesExtension ()
         : base(new Size(8, 8), useSnapLines: false, snapToGrid: false, showGrid: false) { }
 }

--- a/src/test/integration/DesignSurface/DesignSurfaceExt/DesignerOptionServiceExt.cs
+++ b/src/test/integration/DesignSurface/DesignSurfaceExt/DesignerOptionServiceExt.cs
@@ -3,6 +3,34 @@
 
 namespace DesignSurfaceExt;
 
+internal sealed class DesignerOptionsBuilder : DesignerOptionService
+{
+    private readonly DesignerOptions _options;
+
+    public DesignerOptionsBuilder(DesignerOptions baseOptions = null)
+    {
+        _options = baseOptions ?? new DesignerOptions();
+        _options.UseSmartTags = true;
+        _options.ObjectBoundSmartTagAutoShow = false;
+    }
+
+    public DesignerOptionsBuilder WithSnapLines(bool value)
+    {
+        _options.UseSnapLines = value;
+        return this;
+    }
+
+    public DesignerOptionsBuilder WithGrid(Size gridSize, bool snapToGrid, bool showGrid)
+    {
+        _options.GridSize = gridSize;
+        _options.SnapToGrid = snapToGrid;
+        _options.ShowGrid = showGrid;
+        return this;
+    }
+
+    public DesignerOptions Build() => _options;
+}
+
 internal sealed class DesignerOptionServiceExt4SnapLines : DesignerOptionService
 {
     public DesignerOptionServiceExt4SnapLines() : base() { }
@@ -12,11 +40,10 @@ internal sealed class DesignerOptionServiceExt4SnapLines : DesignerOptionService
         if (options.Parent is not null)
             return;
 
-        DesignerOptions ops = new()
-        {
-            UseSnapLines = true,
-            UseSmartTags = true
-        };
+        DesignerOptions ops = new DesignerOptionsBuilder()
+            .WithSnapLines(true)
+            .Build();
+
         DesignerOptionCollection wfd = CreateOptionCollection(options, "WindowsFormsDesigner", null);
         CreateOptionCollection(wfd, "General", ops);
     }
@@ -24,23 +51,20 @@ internal sealed class DesignerOptionServiceExt4SnapLines : DesignerOptionService
 
 internal sealed class DesignerOptionServiceExt4Grid : DesignerOptionService
 {
-    private System.Drawing.Size _gridSize;
+    private readonly Size _gridSize;
 
-    public DesignerOptionServiceExt4Grid(System.Drawing.Size gridSize) : base() { _gridSize = gridSize; }
+    public DesignerOptionServiceExt4Grid(Size gridSize) : base() { _gridSize = gridSize; }
 
     protected override void PopulateOptionCollection(DesignerOptionCollection options)
     {
         if (options.Parent is not null)
             return;
 
-        DesignerOptions ops = new()
-        {
-            GridSize = _gridSize,
-            SnapToGrid = true,
-            ShowGrid = true,
-            UseSnapLines = false,
-            UseSmartTags = true
-        };
+        DesignerOptions ops = new DesignerOptionsBuilder()
+            .WithSnapLines(false)
+            .WithGrid(_gridSize, snapToGrid: true, showGrid: true)
+            .Build();
+
         DesignerOptionCollection wfd = CreateOptionCollection(options, "WindowsFormsDesigner", null);
         CreateOptionCollection(wfd, "General", ops);
     }
@@ -48,23 +72,20 @@ internal sealed class DesignerOptionServiceExt4Grid : DesignerOptionService
 
 internal sealed class DesignerOptionServiceExt4GridWithoutSnapping : DesignerOptionService
 {
-    private System.Drawing.Size _gridSize;
+    private readonly Size _gridSize;
 
-    public DesignerOptionServiceExt4GridWithoutSnapping(System.Drawing.Size gridSize) : base() { _gridSize = gridSize; }
+    public DesignerOptionServiceExt4GridWithoutSnapping(Size gridSize) : base() { _gridSize = gridSize; }
 
     protected override void PopulateOptionCollection(DesignerOptionCollection options)
     {
         if (options.Parent is not null)
             return;
 
-        DesignerOptions ops = new()
-        {
-            GridSize = _gridSize,
-            SnapToGrid = false,
-            ShowGrid = true,
-            UseSnapLines = false,
-            UseSmartTags = true
-        };
+        DesignerOptions ops = new DesignerOptionsBuilder()
+            .WithSnapLines(false)
+            .WithGrid(_gridSize, snapToGrid: false, showGrid: true)
+            .Build();
+
         DesignerOptionCollection wfd = CreateOptionCollection(options, "WindowsFormsDesigner", null);
         CreateOptionCollection(wfd, "General", ops);
     }
@@ -79,14 +100,11 @@ internal sealed class DesignerOptionServiceExt4NoGuides : DesignerOptionService
         if (options.Parent is not null)
             return;
 
-        DesignerOptions ops = new()
-        {
-            GridSize = new System.Drawing.Size(8, 8),
-            SnapToGrid = false,
-            ShowGrid = false,
-            UseSnapLines = false,
-            UseSmartTags = true
-        };
+        DesignerOptions ops = new DesignerOptionsBuilder()
+            .WithSnapLines(false)
+            .WithGrid(new Size(8, 8), snapToGrid: false, showGrid: false)
+            .Build();
+
         DesignerOptionCollection wfd = CreateOptionCollection(options, "WindowsFormsDesigner", null);
         CreateOptionCollection(wfd, "General", ops);
     }


### PR DESCRIPTION
Fixes #13234

## Root Cause

- In .NET Framework, the `ComponentDesigner.InitializeNewComponent` method calls `ShowUI` during component initialization if `ShouldAutoShow` returns true.
- In .NET (Core+), this issue doesn't occur because the `ShowUI` logic was removed when porting `ComponentDesigner` (see [PR #552](https://github.com/dotnet/winforms/pull/552)).

## Proposed changes

- Introduces a `DesignerOptionsBuilder` helper that explicitly sets `ObjectBoundSmartTagAutoShow = false`
- Adapts classes inheriting `DesignerOptionsService` to use this builder.

## Customer Impact

- None

## Regression?

- No

## Risk

- Minimal

## Screenshots

### Before

![before](https://github.com/user-attachments/assets/59a1bf47-f783-48f0-be22-e6b6b38033a5)

### After

![after](https://github.com/user-attachments/assets/a0412734-9ea9-4e45-b004-38676675f4d7)

## Test methodology

- Manual

## Test environment(s)

- 10.0.100-preview.3.25167.3
