### PR TITLE
Ignore case for DESC and ASC in BindingSource.Sort

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/DataBinding/BindingSource.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/DataBinding/BindingSource.cs
@@ -981,11 +981,11 @@ public partial class BindingSource : Component,
             // Handle ASC and DESC
             int length = current.Length;
             bool ascending = true;
-            if (current.EndsWith(" ASC", StringComparison.InvariantCulture))
+            if (current.EndsWith(" ASC", StringComparison.InvariantCultureIgnoreCase))
             {
                 current = current[..(length - 4)].Trim();
             }
-            else if (current.EndsWith(" DESC", StringComparison.InvariantCulture))
+            else if (current.EndsWith(" DESC", StringComparison.InvariantCultureIgnoreCase))
             {
                 ascending = false;
                 current = current[..(length - 5)].Trim();

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/BindingSourceTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/BindingSourceTests.cs
@@ -5,6 +5,7 @@
 
 using System.Collections;
 using System.ComponentModel;
+using FluentAssertions.Execution;
 using Moq;
 
 namespace System.Windows.Forms.Tests;
@@ -710,6 +711,40 @@ public class BindingSourceTests
         Assert.Equal(2, callCount);
     }
 
+    [WinFormsTheory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("Name asc")]
+    [InlineData("Name DESC")]
+    [InlineData("IDate ASC, Name desc")]
+    public void Sort_SetValidValue_UpdatesSortProperty(string sortValue)
+    {
+        SimpleBindingList<Journal> list = new(
+        [
+            new Journal { IDate = DateTime.Now, Name = "A" },
+            new Journal { IDate = DateTime.Now.AddDays(-2), Name = "B" }
+        ]);
+
+        using var source = new BindingSource { DataSource = list };
+        if (sortValue is not null)
+        {
+            source.Sort = sortValue;
+            Assert.Equal(sortValue, source.Sort);
+        }
+        else
+        {
+            Assert.Throws<NotImplementedException>(() => source.Sort = sortValue);
+        }
+    }
+
+    [WinFormsFact]
+    public void Sort_SetNullValue_ResetsSortProperty()
+    {
+        using BindingSource source = [];
+        source.Sort = null;
+        Assert.Null(source.Sort);
+    }
+
     private class FixedSizeList<T> : VirtualList<T>
     {
         public override bool IsFixedSize => true;
@@ -915,4 +950,22 @@ public class BindingSourceTests
             Initialized(this, null);
         }
     }
+}
+
+public class Journal
+{
+    public DateTime IDate { get; set; }
+    public string Name { get; set; }
+}
+
+public class SimpleBindingList<T> : BindingList<T>, IBindingListView
+{
+    public SimpleBindingList(List<T> list) : base(list) { }
+    public string Filter { get; set; }
+    public ListSortDescriptionCollection SortDescriptions => new ListSortDescriptionCollection();
+    public bool SupportsAdvancedSorting => true;
+    public bool SupportsFiltering => true;
+    public void ApplySort(ListSortDescriptionCollection sorts) { }
+    public void RemoveFilter() { }
+    public void RemoveSort() => throw new NotImplementedException();
 }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/BindingSourceTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/BindingSourceTests.cs
@@ -5,7 +5,6 @@
 
 using System.Collections;
 using System.ComponentModel;
-using FluentAssertions.Execution;
 using Moq;
 
 namespace System.Windows.Forms.Tests;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13061


## Proposed changes

- Using `StringComparison.InvariantCultureIgnoreCase` instead  `StringComparison.InvariantCulture`  in method `ParseSortString.
`
<!-- We are in TELL-MODE the following section must be completed -->


## Regression? 

- Yes. Introduced in https://github.com/dotnet/winforms/pull/10172/files#diff-be7f960595c89e574536157bf61838085bce49d7e8c48a7f96a58e6764b6a533L994-R997

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Debugging project, exception "Sort string contains a property that is not in the IBindingList"  throws out when setting `BindingSource.Sort = "Property desc`"(lower case `desc`)
![image](https://github.com/user-attachments/assets/32beaaf9-4b69-4b49-8771-b1a6cdd681bb)

### After
The debugging result is normal
![image](https://github.com/user-attachments/assets/5c259ce8-d210-4585-b1bf-c371b4fb5eec)


## Test methodology <!-- How did you ensure quality? -->

- Manually


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13283)