### PR TITLE
Avoid serialization with in-process Clipboard use

### DIFF
--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/DataFormatNames.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/DataFormatNames.cs
@@ -116,6 +116,26 @@ internal static partial class DataFormatNames
             case BinaryFormatMetafile:
                 formats.Add(Emf);
                 break;
+            default:
+                // The formats aren't case sensitive, notably when they are looked up via the OLE IDataObject
+                // proxy. We're most likely to see "TEXT", so we'll handle text cases.
+                if (string.Equals(format, Text, StringComparison.OrdinalIgnoreCase))
+                {
+                    formats.Add(String);
+                    formats.Add(UnicodeText);
+                }
+                else if (string.Equals(format, UnicodeText, StringComparison.OrdinalIgnoreCase))
+                {
+                    formats.Add(String);
+                    formats.Add(Text);
+                }
+                else if (string.Equals(format, String, StringComparison.OrdinalIgnoreCase))
+                {
+                    formats.Add(Text);
+                    formats.Add(UnicodeText);
+                }
+
+                break;
         }
     }
 

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/DataStore.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/DataStore.cs
@@ -130,7 +130,7 @@ internal sealed partial class DataStore<TOleServices> : IDataObjectInternal wher
 
         for (int i = 0; i < formats.Length; i++)
         {
-            if (format.Equals(formats[i]))
+            if (format.Equals(formats[i], StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }

--- a/src/System.Windows.Forms/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+static System.Windows.Forms.Clipboard.TryGetData<T>(out T data) -> bool

--- a/src/System.Windows.Forms/System/Windows/Forms/OLE/Clipboard.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/OLE/Clipboard.cs
@@ -436,7 +436,7 @@ public static class Clipboard
         ArgumentNullException.ThrowIfNull(data);
 
         // Note: We delegate argument checking to IDataObject.SetData, if it wants to do so.
-        SetDataObject(new WrappingDataObject(format, data), copy: true);
+        SetDataObject(new DataObject(format, data), copy: true);
     }
 
     /// <inheritdoc cref="DataObject.SetDataAsJson{T}(string, T)"/>

--- a/src/System.Windows.Forms/System/Windows/Forms/OLE/Clipboard.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/OLE/Clipboard.cs
@@ -352,6 +352,10 @@ public static class Clipboard
         return dataObject.TryGetData(format, out data);
     }
 
+    /// <inheritdoc cref="TryGetData{T}(string, out T)"/>
+    public static bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+        [NotNullWhen(true), MaybeNullWhen(false)] out T data) => TryGetData(typeof(T).FullName!, out data);
+
     /// <summary>
     ///  Retrieves a collection of file names from the <see cref="Clipboard"/>.
     /// </summary>
@@ -432,7 +436,7 @@ public static class Clipboard
         ArgumentNullException.ThrowIfNull(data);
 
         // Note: We delegate argument checking to IDataObject.SetData, if it wants to do so.
-        SetDataObject(new DataObject(format, data), copy: true);
+        SetDataObject(new WrappingDataObject(format, data), copy: true);
     }
 
     /// <inheritdoc cref="DataObject.SetDataAsJson{T}(string, T)"/>

--- a/src/System.Windows.Forms/System/Windows/Forms/OLE/WrappingDataObject.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/OLE/WrappingDataObject.cs
@@ -14,7 +14,13 @@ internal sealed class WrappingDataObject : DataObject
     {
         // Don't wrap existing DataObject instances.
         Debug.Assert(data is not DataObject);
+        _originalIsIDataObject = data is IDataObject;
+    }
 
+    public WrappingDataObject(string format, object data) : base(format, data)
+    {
+        // Don't wrap existing DataObject instances.
+        Debug.Assert(data is not DataObject);
         _originalIsIDataObject = data is IDataObject;
     }
 
@@ -26,7 +32,25 @@ internal sealed class WrappingDataObject : DataObject
             return base.TryUnwrapUserDataObject(out dataObject);
         }
 
-        dataObject = null;
-        return false;
+        // When we hand back our wrapper we're emulating what would happen through via the native IDataObject
+        // proxy. As the native interface has no concept of "autoConvert", we need to always consider it "true"
+        // as out native IDataObject implementation would.
+        dataObject = this;
+        return true;
     }
+
+    public override string[] GetFormats(bool autoConvert)
+        // Always auto convert to emulate native IDataObject behavior.
+        => base.GetFormats(autoConvert: true);
+
+    public override bool GetDataPresent(string format, bool autoConvert)
+        // Always auto convert to emulate native IDataObject behavior.
+        => base.GetDataPresent(format, autoConvert: true);
+
+#pragma warning disable WFDEV005 // Type or member is obsolete
+    [Obsolete]
+    public override object? GetData(string format, bool autoConvert)
+        // Always auto convert to emulate native IDataObject behavior.
+        => base.GetData(format, autoConvert: true);
+#pragma warning restore WFDEV005 // Type or member is obsolete
 }

--- a/src/System.Windows.Forms/System/Windows/Forms/OLE/WrappingDataObject.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/OLE/WrappingDataObject.cs
@@ -17,13 +17,6 @@ internal sealed class WrappingDataObject : DataObject
         _originalIsIDataObject = data is IDataObject;
     }
 
-    public WrappingDataObject(string format, object data) : base(format, data)
-    {
-        // Don't wrap existing DataObject instances.
-        Debug.Assert(data is not DataObject);
-        _originalIsIDataObject = data is IDataObject;
-    }
-
     internal override bool TryUnwrapUserDataObject([NotNullWhen(true)] out IDataObject? dataObject)
     {
         // We only want to unwrap IDataObject instances from users.
@@ -32,9 +25,9 @@ internal sealed class WrappingDataObject : DataObject
             return base.TryUnwrapUserDataObject(out dataObject);
         }
 
-        // When we hand back our wrapper we're emulating what would happen through via the native IDataObject
-        // proxy. As the native interface has no concept of "autoConvert", we need to always consider it "true"
-        // as out native IDataObject implementation would.
+        // When we hand back our wrapper we're emulating what would happen via the native IDataObject proxy.
+        // As the native interface has no concept of "autoConvert", we need to always consider it "true"
+        // as our native IDataObject implementation would.
         dataObject = this;
         return true;
     }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ClipboardTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ClipboardTests.cs
@@ -1322,11 +1322,11 @@ public class ClipboardTests
         string format = typeof(SerializableTestData).FullName!;
 
         // Opt-in into access to the binary formatted stream.
-        using BinaryFormatterInClipboardDragDropScope clipboardScope = new(enable: true);
+        using BinaryFormatterInClipboardDragDropScope clipboardScope = new(enable: copy);
 
         // We need the BinaryFormatter to flush the data from the managed object to the HGLOBAL
         // and to write data to HGLOBAL as a binary formatted stream now if it hadn't been flushed.
-        using BinaryFormatterScope scope = new(enable: true);
+        using BinaryFormatterScope scope = new(enable: copy);
 
         Clipboard.SetDataObject(data, copy);
 
@@ -1334,7 +1334,7 @@ public class ClipboardTests
 
         received.TryGetData(
             format,
-            (TypeName name) => name.FullName == typeof(SerializableTestData).FullName ? typeof(SerializableTestData) : null,
+            name => name.FullName == typeof(SerializableTestData).FullName ? typeof(SerializableTestData) : null,
             autoConvert: false,
             out SerializableTestData? result).Should().BeTrue();
 


### PR DESCRIPTION
When copy is not set to true, the original object is still available and we can get data directly without serializing through NRBF.

- Updated `DataFormatNames` for case-insensitive format lookups.
- Changed format equality checks in `DataStore` to be case-insensitive.
- Renamed a test method in `ClipboardCoreTests` for clarity and added a new test for `SerializableObject` to ensure it does not use `BinaryFormatter`.
- Introduced a generic `TryGetData<T>(out T data)` method in `Clipboard`.
- Modified `SetDataObject` to use `WrappingDataObject` for improved data wrapping.
- Enhanced `WrappingDataObject` to always consider `autoConvert` as true, aligning with native `IDataObject` behavior.
- Updated assertions in `ClipboardTests` for more flexible type checking.
- Added tests to verify the handling of serializable objects without using `BinaryFormatter`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13287)