### PR TITLE
Skip test RoundTrip_DataObject_SupportsTypedInterface on windows x64

### DIFF
--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ClipboardTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ClipboardTests.cs
@@ -1293,8 +1293,17 @@ public class ClipboardTests
 
     [WinFormsTheory]
     [BoolData]
-    public void RoundTrip_DataObject_SupportsTypedInterface(bool copy) =>
+    public void RoundTrip_DataObject_SupportsTypedInterface(bool copy)
+    {
+        // Skip verification of copy = true and in windows X64
+        // due to the active issue "https://github.com/dotnet/winforms/issues/13292"
+        if (copy && RuntimeInformation.ProcessArchitecture == Architecture.X64)
+        {
+            return;
+        }
+
         CustomDataObject_RoundTrip_SupportsTypedInterface<DataObject>(copy);
+    }
 
     [WinFormsTheory]
     [BoolData]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13292


## Proposed changes

- Skip unstable test RoundTrip_DataObject_SupportsTypedInterface on windows x64