### PR TITLE
fix #13071 Changing properties with RefreshProperties.All does not requery the property list in the PropertyGrid in .net 9 (worked in .net 8) 

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/GridEntry.GridEntryAccessibleObject.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/GridEntry.GridEntryAccessibleObject.cs
@@ -410,7 +410,10 @@ internal abstract partial class GridEntry
 
             base.SetFocus();
 
-            RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId);
+            if (!PropertyGridView.InPropertySet && !PropertyGridView.EditMouseDown)
+            {
+                RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId);
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.Flags.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.Flags.cs
@@ -22,6 +22,7 @@ internal sealed partial class PropertyGridView
         /// </summary>
         ButtonLaunchedEditor    = 0x0100,
         NoDefault               = 0x0200,
-        ResizableDropDown       = 0x0400
+        ResizableDropDown       = 0x0400,
+        EditMouseDown           = 0x0800
     }
 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
@@ -2566,44 +2566,59 @@ internal sealed partial class PropertyGridView :
         InvokeLostFocus(this, EventArgs.Empty);
     }
 
+    internal bool EditMouseDown
+    {
+        get => _flags.HasFlag(Flags.EditMouseDown);
+        private set => SetFlag(Flags.EditMouseDown, value);
+    }
+
     private void OnEditMouseDown(object? sender, MouseEventArgs e)
     {
-        if (!FocusInside)
+        try
         {
-            SelectGridEntry(_selectedGridEntry, pageIn: false);
-        }
+            EditMouseDown = true;
 
-        if (e.Clicks % 2 == 0)
-        {
-            DoubleClickRow(_selectedRow, toggleExpand: false, RowValue);
-            EditTextBox.SelectAll();
-        }
+            if (!FocusInside)
+            {
+                SelectGridEntry(_selectedGridEntry, pageIn: false);
+            }
 
-        if (_rowSelectTime == 0)
-        {
-            return;
-        }
-
-        // Check if the click happened within the double click time since the row was selected.
-        // This allows the edits to be selected with two clicks instead of 3 (select row, double click).
-        long timeStamp = DateTime.Now.Ticks;
-        int delta = (int)((timeStamp - _rowSelectTime) / 10000); // make it milliseconds
-
-        if (delta < SystemInformation.DoubleClickTime)
-        {
-            Point screenPoint = EditTextBox.PointToScreen(e.Location);
-
-            if (Math.Abs(screenPoint.X - _rowSelectPos.X) < SystemInformation.DoubleClickSize.Width &&
-                Math.Abs(screenPoint.Y - _rowSelectPos.Y) < SystemInformation.DoubleClickSize.Height)
+            if (e.Clicks % 2 == 0)
             {
                 DoubleClickRow(_selectedRow, toggleExpand: false, RowValue);
-                PInvokeCore.SendMessage(EditTextBox, PInvokeCore.WM_LBUTTONUP, (WPARAM)0, (LPARAM)e.Location);
                 EditTextBox.SelectAll();
             }
 
-            _rowSelectPos = Point.Empty;
+            if (_rowSelectTime == 0)
+            {
+                return;
+            }
 
-            _rowSelectTime = 0;
+            // Check if the click happened within the double click time since the row was selected.
+            // This allows the edits to be selected with two clicks instead of 3 (select row, double click).
+            long timeStamp = DateTime.Now.Ticks;
+            int delta = (int)((timeStamp - _rowSelectTime) / 10000); // make it milliseconds
+
+            if (delta < SystemInformation.DoubleClickTime)
+            {
+                Point screenPoint = EditTextBox.PointToScreen(e.Location);
+
+                if (Math.Abs(screenPoint.X - _rowSelectPos.X) < SystemInformation.DoubleClickSize.Width &&
+                    Math.Abs(screenPoint.Y - _rowSelectPos.Y) < SystemInformation.DoubleClickSize.Height)
+                {
+                    DoubleClickRow(_selectedRow, toggleExpand: false, RowValue);
+                    PInvokeCore.SendMessage(EditTextBox, PInvokeCore.WM_LBUTTONUP, (WPARAM)0, (LPARAM)e.Location);
+                    EditTextBox.SelectAll();
+                }
+
+                _rowSelectPos = Point.Empty;
+
+                _rowSelectTime = 0;
+            }
+        }
+        finally
+        {
+            EditMouseDown = false;
         }
     }
 
@@ -3992,7 +4007,7 @@ internal sealed partial class PropertyGridView :
             startRow = 0;
         }
 
-        if (OwnerGrid.HavePropertyEntriesChanged())
+        if (fullRefresh || OwnerGrid.HavePropertyEntriesChanged())
         {
             if (HasEntries && !InPropertySet && !CommitEditTextBox())
             {


### PR DESCRIPTION
Fixes #13071 


## Proposed changes

- 
- revert [PR#12431](https://github.com/dotnet/winforms/pull/12431) , use another approach to fix [Issue#12440](https://github.com/dotnet/winforms/issues/12440)
- Introduce  `EditMouseDown` flag in PropertyGridView.flag. This flag is on when the TextBox in the PropertyGrid.GridEntry is focused and is off when editing is done.
- The cause of   [Issue#12440](https://github.com/dotnet/winforms/issues/12440) is that after editing is done, GridEntryAccessibleObject will raise AutomationFocusChangedEvent

GridEntry.GridEntryAccessibleObject.cs
``` c#
        ...
        internal override void SetFocus()
        {
            if (PropertyGridView is null || !PropertyGridView.IsHandleCreated)
            {
                return;
            }

            base.SetFocus();

            RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId);
        }
```

So in order to not let TextBox loose rectangle, add conditions to that event to exclude two cases:
1. when InPropertySet is on
2. when EditMouseDown is on


## Regression? 

- Yes

<!-- 
## Customer Impact

- 
- 

## Risk
-

 -->



## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

GetProperties method didn't get invoked  described in [#13071](https://github.com/dotnet/winforms/issues/13071)

### After


https://github.com/user-attachments/assets/4d013d27-8ebc-4020-a977-d2f825280bfc


https://github.com/user-attachments/assets/7885c561-f37f-45fd-971c-6af9686db030



## Test methodology <!-- How did you ensure quality? -->

- 
- manually 
- 
<!-- 
## Accessibility testing  
   -->
## Test environment(s) 

10.0.0-preview.3.25165.3




