### PR TITLE
Update the min cmake version to enable native code compilation with cmake shipped in VS public preview .

### DIFF
--- a/src/test/unit/interop/NativeTests/CMakeLists.txt
+++ b/src/test/unit/interop/NativeTests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.10)
 project (NativeTests)
 set(CMAKE_MACOSX_RPATH 1)
 set(CMAKE_CXX_STANDARD 11)

--- a/src/test/unit/interop/System.Windows.Forms.Interop.Tests.csproj
+++ b/src/test/unit/interop/System.Windows.Forms.Interop.Tests.csproj
@@ -6,8 +6,6 @@
     <AssemblyName>System.Windows.Forms.Interop.Tests</AssemblyName>
     <Platforms>x86;x64</Platforms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- Native tests do not build in VMR - https://github.com/dotnet/winforms/issues/13186 -->
-    <ExcludeFromBuild Condition="'$(DotNetBuild)' == 'true'">true</ExcludeFromBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/winforms/issues/13186
I chose min version that works with both the latest cmake (v4.0.1 requires min version 3.10)  and the version shipped in the public preview(v 3.30 requires min version 3.5).

This fixes error like this one
```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13314)