### PR TITLE
Add _isReleasingDataSource to prevent unnecessary operations on CurrentCell when changing or releasing DataSource

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
@@ -27017,7 +27017,8 @@ public partial class DataGridView
                 int oldCurrentCellY = _ptCurrentCell.Y;
                 if (oldCurrentCellX >= 0
                     && !_dataGridViewState1[State1_TemporarilyResetCurrentCell]
-                    && !_dataGridViewOper[OperationInDispose])
+                    && !_dataGridViewOper[OperationInDispose]
+                    && !_isReleasingDataSource)
                 {
                     DataGridViewCell currentCell = CurrentCellInternal;
                     if (!EndEdit(

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
@@ -27018,7 +27018,7 @@ public partial class DataGridView
                 if (oldCurrentCellX >= 0
                     && !_dataGridViewState1[State1_TemporarilyResetCurrentCell]
                     && !_dataGridViewOper[OperationInDispose]
-                    && !_isReleasingDataSource)
+                    && !_dataGridViewOper[OperationInReleasingDataSource])
                 {
                     DataGridViewCell currentCell = CurrentCellInternal;
                     if (!EndEdit(

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
@@ -222,6 +222,7 @@ public partial class DataGridView : Control, ISupportInitialize
     private const int OperationInEndEdit = 0x00400000;
     private const int OperationResizingOperationAboutToStart = 0x00800000;
     private const int OperationTrackKeyboardColResize = 0x01000000;
+    private const int OperationInReleasingDataSource = 0x02000000;
     private const int OperationMouseOperationMask = OperationTrackColResize | OperationTrackRowResize |
         OperationTrackColRelocation | OperationTrackColHeadersResize | OperationTrackRowHeadersResize;
     private const int OperationKeyboardOperationMask = OperationTrackKeyboardColResize;
@@ -1922,7 +1923,7 @@ public partial class DataGridView : Control, ISupportInitialize
                     newDataSource.Disposed += OnDataSourceDisposed;
                 }
 
-                _isReleasingDataSource = true;
+                _dataGridViewOper[OperationInReleasingDataSource] = true;
 
                 try
                 {
@@ -1930,7 +1931,7 @@ public partial class DataGridView : Control, ISupportInitialize
                 }
                 finally
                 {
-                    _isReleasingDataSource = false;
+                    _dataGridViewOper[OperationInReleasingDataSource] = false;
                 }
 
                 if (DataConnection is null)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
@@ -345,6 +345,7 @@ public partial class DataGridView : Control, ISupportInitialize
     private int _inBulkPaintCount;
     private int _inBulkLayoutCount;
     private int _inPerformLayoutCount;
+    private bool _isReleasingDataSource;
 
     private int _keyboardResizeStep;
     private Rectangle _resizeClipRectangle;
@@ -1921,7 +1922,17 @@ public partial class DataGridView : Control, ISupportInitialize
                     newDataSource.Disposed += OnDataSourceDisposed;
                 }
 
-                CurrentCell = null;
+                _isReleasingDataSource = true;
+
+                try
+                {
+                    CurrentCell = null;
+                }
+                finally
+                {
+                    _isReleasingDataSource = false;
+                }
+
                 if (DataConnection is null)
                 {
                     DataConnection = new DataGridViewDataConnection(this);

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
@@ -346,7 +346,6 @@ public partial class DataGridView : Control, ISupportInitialize
     private int _inBulkPaintCount;
     private int _inBulkLayoutCount;
     private int _inPerformLayoutCount;
-    private bool _isReleasingDataSource;
 
     private int _keyboardResizeStep;
     private Rectangle _resizeClipRectangle;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13304

## Root cause

Regression introduced in PR #4637

When closing the dialog in edit mode, `DataSource` is set to null, and then `CurrentCell = null` is set. Then unnecessary method `EndEdit` of the `SetCurrentCellAddressCore` is called.

## Proposed changes

- Add `_isReleasingDataSource` in DataGridView and set it to null in property `DataSource` before setting `CurrentCell = null` to prevent the `EndEdit` method of the SetCurrentCellAddressCore from being called

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- When the DataGridView is in editing mode, its dialog box can be closed normally

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
When a dialog with a DataGridView that has focus is closed, an `System.InvalidOperationException: Operation is not valid because it results in a reentrant call to the SetCurrentCellAddressCore function.` is thrown

https://github.com/user-attachments/assets/58be58da-987e-4402-834a-1ec2bf036dc5

### After
The DataGridView dialog with focus can be closed successfully

![AfterFix](https://github.com/user-attachments/assets/4b1b56b9-a69c-4435-8092-6facc6b6420c)

## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-preview.4.25216.9


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13320)