### PR TITLE
fix #13305  Baseline SnapLines do not appear in DesignSurface

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
@@ -802,7 +802,7 @@ public sealed partial class BehaviorService : IDisposable
 
             if (host.GetDesigner(comp) is ControlDesigner designer)
             {
-                foreach (SnapLine line in designer.SnapLinesInternal)
+                foreach (SnapLine line in designer.SnapLines)
                 {
                     snapLineInfo.Append($"{line}\tAssociated Control = {designer.Control.Name}:::");
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DragAssistanceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DragAssistanceManager.cs
@@ -193,7 +193,7 @@ internal sealed partial class DragAssistanceManager
     /// </summary>
     private void AddSnapLines(ControlDesigner controlDesigner, List<SnapLine> horizontalList, List<SnapLine> verticalList, bool isTarget, bool validTarget)
     {
-        IList<SnapLine> snapLines = controlDesigner.SnapLinesInternal;
+        IList snapLines = controlDesigner.SnapLines;
         // Used for padding snaplines
         Rectangle controlRect = controlDesigner.Control.ClientRectangle;
         // Used for all others


### PR DESCRIPTION
fix #13305

## The cause of this issue
This issue is caused by [PR10279](https://github.com/dotnet/winforms/pull/10279)

These are two of all changes make in [PR10279](https://github.com/dotnet/winforms/pull/10279)
![image](https://github.com/user-attachments/assets/155740a9-6e1e-4a7c-8581-9d813b1d149b)

`BehaviorService`, `DragAssistanceManager` use `SnapLines` to add some effects during design time.


`ControlDesigner` has a **_virtual_** property `SnapLines`, but most designers override the property, in other words,  _**most designers have customized `SnapLines`**_

### Code flow before [PR10279](https://github.com/dotnet/winforms/pull/10279)

when `BehaviorService` or `DragAssistanceManager` accesses  `SnapLines` , customized `SnapLines` were returned.

### Code flow after [PR10279](https://github.com/dotnet/winforms/pull/10279)

ControlDesigner.cs

![image](https://github.com/user-attachments/assets/eee26426-1322-43f2-8100-7dddd8ccfd43)

when `BehaviorService` or `DragAssistanceManager` **_accesses  `SnapLinesInternal`_** , **_customized `SnapLines` were skipped._**

## Proposed changes

- 
- Use `SnapLines`
- 


<!-- 
## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-
 -->


## Screenshots 

### Before

![Image](https://github.com/user-attachments/assets/5650c5d5-8433-4b5e-8723-806867186be2)

### After

![Image](https://github.com/user-attachments/assets/4c528e07-39a9-497b-86d8-3f450f6e634b)



## Test methodology 

- 
- manually 
- 
<!--

## Accessibility testing  
## Test environment(s) 

  -->



<!-- Mention language, UI scaling, or anything else that might be relevant -->
