### PR TITLE
Fix a series of Analyzer issues (backport from release/net9).

### DIFF
--- a/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/CSharp/Analyzers/MissingPropertySerializationConfiguration/MissingPropertySerializationConfigurationAnalyzer.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/CSharp/Analyzers/MissingPropertySerializationConfiguration/MissingPropertySerializationConfigurationAnalyzer.cs
@@ -25,21 +25,56 @@ public class MissingPropertySerializationConfigurationAnalyzer : DiagnosticAnaly
     private static void AnalyzeSymbol(SymbolAnalysisContext context)
     {
         // We analyze only properties.
-        var propertySymbol = (IPropertySymbol)context.Symbol;
+        IPropertySymbol? propertySymbol = (IPropertySymbol)context.Symbol;
 
-        // Does the property belong to a class which derives from Component?
-        if (propertySymbol.ContainingType is null
-            || !propertySymbol
-                .ContainingType
-                .AllInterfaces
-                .Any(i => i.Name == nameof(IComponent)))
+        // We never flag a property named Site of type of ISite
+        if (propertySymbol is null)
         {
             return;
         }
 
-        // Is the property read/write and at least internal?
-        if (propertySymbol.SetMethod is null
+        // A property of System.ComponentModel.ISite we never flag.
+        if (propertySymbol.Type.Name == nameof(ISite)
+            && propertySymbol.Type.ContainingNamespace.ToString() == "System.ComponentModel")
+        {
+            return;
+        }
+
+        // If the property is part of any interface named IComponent, we're out.
+        if (propertySymbol.ContainingType.Name == nameof(IComponent))
+        {
+            return;
+        }
+
+        // Does the property belong to a class which implements the System.ComponentModel.IComponent interface?
+        if (propertySymbol.ContainingType is null
+            || !propertySymbol
+                .ContainingType
+                .AllInterfaces
+                .Any(i => i.Name == nameof(IComponent) &&
+                          i.ContainingNamespace is not null &&
+                          i.ContainingNamespace.ToString() == "System.ComponentModel"))
+        {
+            return;
+        }
+
+        // Skip static properties since they are not serialized by the designer
+        if (propertySymbol.IsStatic)
+        {
+            return;
+        }
+
+        // Is the property read/write and at least internal and doesn't have a private setter?
+        if (propertySymbol.SetMethod is not IMethodSymbol propertySetter
+            || propertySetter.DeclaredAccessibility == Accessibility.Private
             || propertySymbol.DeclaredAccessibility < Accessibility.Internal)
+        {
+            return;
+        }
+
+        // Skip overridden properties since the base property should already have the appropriate serialization configuration
+        // TODO: Does just this cover all the cases, particularly for legacy code where the dev doesn't own the source?
+        if (propertySymbol.IsOverride)
         {
             return;
         }

--- a/src/System.Windows.Forms.Analyzers.VisualBasic/src/Analyzers/MissingPropertySerializationConfiguration/MissingPropertySerializationConfigurationDiagnosticAnalyzer.vb
+++ b/src/System.Windows.Forms.Analyzers.VisualBasic/src/Analyzers/MissingPropertySerializationConfiguration/MissingPropertySerializationConfigurationDiagnosticAnalyzer.vb
@@ -32,18 +32,40 @@ Namespace Global.System.Windows.Forms.VisualBasic.Analyzers.MissingPropertySeria
                 Return
             End If
 
-            ' Does the property belong to a class which derives from Component?
-            If propertySymbol.ContainingType Is Nothing OrElse
-               Not propertySymbol.ContainingType.AllInterfaces.Any(
-                Function(i) i.Name = NameOf(IComponent)) Then
-
+            ' A property of System.ComponentModel.ISite we never flag.
+            If propertySymbol.Type.Name = NameOf(ISite) AndAlso
+               propertySymbol.Type.ContainingNamespace.ToString() = "System.ComponentModel" Then
                 Return
             End If
 
-            ' Is the property read/write and at least internal?
-            If propertySymbol.SetMethod Is Nothing OrElse
-               propertySymbol.DeclaredAccessibility < Accessibility.Internal Then
+            ' If the property is part of any interface named IComponent, we're out.
+            If propertySymbol.ContainingType.Name = NameOf(IComponent) Then
+                Return
+            End If
 
+            ' Does the property belong to a class which implements the System.ComponentModel.IComponent interface?
+            If propertySymbol.ContainingType Is Nothing OrElse
+               Not propertySymbol.ContainingType.AllInterfaces.Any(
+                Function(i) i.Name = NameOf(IComponent) AndAlso
+                          i.ContainingNamespace IsNot Nothing AndAlso
+                          i.ContainingNamespace.ToString() = "System.ComponentModel") Then
+                Return
+            End If
+
+            ' Skip static properties since they are not serialized by the designer
+            If propertySymbol.IsStatic Then
+                Return
+            End If
+
+            ' Is the property read/write, at least internal, and doesn't have a private setter?
+            If propertySymbol.SetMethod Is Nothing OrElse
+               propertySymbol.SetMethod.DeclaredAccessibility = Accessibility.Private OrElse
+               propertySymbol.DeclaredAccessibility < Accessibility.Internal Then
+                Return
+            End If
+
+            ' Skip overridden properties since the base property should already have the appropriate serialization configuration
+            If propertySymbol.IsOverride Then
                 Return
             End If
 


### PR DESCRIPTION
## Forward port of .NET 9 Analyzer Fixes.

Note: This PR bring over the fixes, NOT the test infrastructure at this point.
We want the fixes of the following issues have in as early as possible for more time to test with real bits out.

Note also, that this PR will NOT close these issues. 
They remain open until we're services release/net9.

- [x] #13205
- [x] #13206
- [x] #13207
- [x] #13208
- [x] #13237 
