### PR TITLE
Update the run-on setting to ubuntu-22.04 in .github/workflows/backport.yml

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   backport:
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/backport to')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Extract backport target branch
       uses: actions/github-script@v3


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13332


## Root Cause

From the logs, the backport PR was not generated because the Ubuntu 20.04 LTS set in the [current workflow](https://github.com/dotnet/winforms/blob/698cfb403515150b08ca8cd1f201b5d0aacde813/.github/workflows/backport.yml#L14) was removed on 2025-04-15, and we need to set up a new runner

<img width="1016" alt="Image" src="https://github.com/user-attachments/assets/d0ac1f5a-1e70-4584-851f-f7fc799217a9" />

## Proposed changes

- Update the run-on setting to ubuntu-22.04 in .github/workflows/backport.yml


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13340)