### PR TITLE
Add _isReleasingDataSource to prevent unnecessary operations on CurrentCell when changing or releasing DataSource (#13320)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -27462,7 +27462,8 @@ public partial class DataGridView
                 int oldCurrentCellY = _ptCurrentCell.Y;
                 if (oldCurrentCellX >= 0 &&
                     !_dataGridViewState1[State1_TemporarilyResetCurrentCell] &&
-                    !_dataGridViewOper[OperationInDispose])
+                    !_dataGridViewOper[OperationInDispose] &&
+                    !_dataGridViewOper[OperationInReleasingDataSource])
                 {
                     DataGridViewCell currentCell = CurrentCellInternal;
                     if (!EndEdit(DataGridViewDataErrorContexts.Parsing | DataGridViewDataErrorContexts.Commit | DataGridViewDataErrorContexts.CurrentCellChange,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -224,6 +224,7 @@ public partial class DataGridView : Control, ISupportInitialize
     private const int OperationInEndEdit = 0x00400000;
     private const int OperationResizingOperationAboutToStart = 0x00800000;
     private const int OperationTrackKeyboardColResize = 0x01000000;
+    private const int OperationInReleasingDataSource = 0x02000000;
     private const int OperationMouseOperationMask = OperationTrackColResize | OperationTrackRowResize |
         OperationTrackColRelocation | OperationTrackColHeadersResize | OperationTrackRowHeadersResize;
     private const int OperationKeyboardOperationMask = OperationTrackKeyboardColResize;
@@ -2044,7 +2045,17 @@ public partial class DataGridView : Control, ISupportInitialize
                     newDataSource.Disposed += OnDataSourceDisposed;
                 }
 
-                CurrentCell = null;
+                _dataGridViewOper[OperationInReleasingDataSource] = true;
+
+                try
+                {
+                    CurrentCell = null;
+                }
+                finally
+                {
+                    _dataGridViewOper[OperationInReleasingDataSource] = false;
+                }
+
                 if (DataConnection is null)
                 {
                     DataConnection = new DataGridViewDataConnection(this);


### PR DESCRIPTION
Backport of #13320 to release/8.0
Fixes #13304

## Proposed changes
- Guard against opening the cell edit dialog when the CurrentCell property is being unset because the DataSource is released.
 
## Customer Impact
- When the DataGridView is in editing mode, its dialog box can be closed normally

## Regression?
- Yes, introduced in  https://github.com/dotnet/winforms/pull/4637

## Testing
- Manual testing with the user-provided project

## Risk
- Low