### PR TITLE
fix #13344 Disabled ToolstripMenuItems are no longer highlighted

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
@@ -573,7 +573,15 @@ public abstract partial class ToolStripItem :
     ///  Determines whether or not the item can be selected.
     /// </summary>
     [Browsable(false)]
-    public virtual bool CanSelect => Enabled;
+    public virtual bool CanSelect
+    {
+        get
+        {
+            File.AppendAllText($"E:/myLog.txt", $"{DateTime.Now}  {new StackTrace(true)} \n");
+
+            return true;
+        }
+    }
 
     /// <remarks>
     ///  <para>Usually the same as can select, but things like the control box in an MDI window are exceptions</para>
@@ -3158,7 +3166,7 @@ public abstract partial class ToolStripItem :
             forceRaiseAccessibilityFocusChanged = true;
         }
 
-        if (forceRaiseAccessibilityFocusChanged)
+        if (forceRaiseAccessibilityFocusChanged && Enabled)
         {
             bool accessibilityIsOn = IsAccessibilityObjectCreated ||
                 // When ToolStripItem is selected automatically for the first time


### PR DESCRIPTION

Fixes #13344 


## Proposed changes

- 
- Set `CanSelect` True,  when selected and disabled don't send acc event.
- 

<!-- 

## Customer Impact

- 
- 

## Regression? 

- Yes / No
 -->
## Risk

-


## Screenshots 

### Before


![Image](https://github.com/user-attachments/assets/b4e4aab6-f4a6-4864-8c3e-765f1b23e987)

### After

![Issue_13344_01](https://github.com/user-attachments/assets/b6c2aedd-ab98-4079-beb9-eb7580c9c35a)

![Issue_13344_02](https://github.com/user-attachments/assets/be509fb0-6f16-4f67-8500-be907e46cdc9)


## Test methodology 

- 
- manually 
-


<!--
## Accessibility testing 
 

## Test environment(s)    
 -->




