### PR TITLE
fix #13344 Disabled ToolstripMenuItems are no longer highlighted

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
@@ -578,7 +578,7 @@ public abstract partial class ToolStripItem :
     /// <remarks>
     ///  <para>Usually the same as can select, but things like the control box in an MDI window are exceptions</para>
     /// </remarks>
-    internal virtual bool CanKeyboardSelect => CanSelect;
+    internal virtual bool CanKeyboardSelect => CanSelect && Enabled;
 
     /// <summary>
     ///  Occurs when the control is clicked.

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
@@ -573,7 +573,7 @@ public abstract partial class ToolStripItem :
     ///  Determines whether or not the item can be selected.
     /// </summary>
     [Browsable(false)]
-    public virtual bool CanSelect => Enabled;
+    public virtual bool CanSelect => true;
 
     /// <remarks>
     ///  <para>Usually the same as can select, but things like the control box in an MDI window are exceptions</para>
@@ -3158,7 +3158,7 @@ public abstract partial class ToolStripItem :
             forceRaiseAccessibilityFocusChanged = true;
         }
 
-        if (forceRaiseAccessibilityFocusChanged)
+        if (forceRaiseAccessibilityFocusChanged && Enabled)
         {
             bool accessibilityIsOn = IsAccessibilityObjectCreated ||
                 // When ToolStripItem is selected automatically for the first time

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripButtonTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripButtonTests.cs
@@ -1058,7 +1058,7 @@ public partial class ToolStripButtonTests
 
     [WinFormsTheory]
     [InlineData(true, AccessibleStates.Focused | AccessibleStates.HotTracked | AccessibleStates.Focusable)]
-    [InlineData(false, AccessibleStates.None)]
+    [InlineData(false, AccessibleStates.Unavailable | AccessibleStates.Focused)]
     public void ToolStripButton_CreateAccessibilityInstance_InvokeSelected_ReturnsExpected(bool enabled, AccessibleStates expectedState)
     {
         using SubToolStripButton item = new()

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripButtonTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripButtonTests.cs
@@ -1040,8 +1040,8 @@ public partial class ToolStripButtonTests
     [WinFormsTheory]
     [InlineData(true, CheckState.Checked, AccessibleStates.Focusable | AccessibleStates.Checked)]
     [InlineData(true, CheckState.Indeterminate, AccessibleStates.Focusable | AccessibleStates.Checked)]
-    [InlineData(false, CheckState.Checked, AccessibleStates.None)]
-    [InlineData(false, CheckState.Indeterminate, AccessibleStates.None)]
+    [InlineData(false, CheckState.Checked, AccessibleStates.Unavailable)]
+    [InlineData(false, CheckState.Indeterminate, AccessibleStates.Unavailable)]
     public void ToolStripButton_CreateAccessibilityInstance_InvokeChecked_ReturnsExpected(bool enabled, CheckState checkState, AccessibleStates expectedState)
     {
         using SubToolStripButton item = new()


### PR DESCRIPTION
Fixes #13344 

## Related background 

[PR_7611](https://github.com/dotnet/winforms/pull/7611) fixed [Issue_7601](https://github.com/dotnet/winforms/issues/7601) that Narrator is reading ToolStripMenuitems even when they are disabled

## Proposed changes

- 
- Set `CanSelect` True,  when selected and disabled don't send acc event.
- 

## Affected Controls
ToolStrip, MenuStrip, StatusStrip
They all hehave the same
<!-- 

## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-
 -->

## Screenshots 

### Before


![Image](https://github.com/user-attachments/assets/b4e4aab6-f4a6-4864-8c3e-765f1b23e987)

### After

![Issue_13344_01](https://github.com/user-attachments/assets/b6c2aedd-ab98-4079-beb9-eb7580c9c35a)
<!--
![Issue_13344_02](https://github.com/user-attachments/assets/be509fb0-6f16-4f67-8500-be907e46cdc9)
 -->
![Issue_13344_07](https://github.com/user-attachments/assets/1f12bde4-1c2c-46ce-adf6-21599daff30b)


## Test methodology 

- 
- manually 
-


<!--
## Accessibility testing 
 
## Test environment(s)    
 -->

## Other menuItems
![Issue_13344_05](https://github.com/user-attachments/assets/49b03c34-5804-4fb8-8a96-e71c60c04b56)
![Issue_13344_03](https://github.com/user-attachments/assets/2c572d3c-e6cf-4854-bfcc-1b95bac3e00a)

![Issue_13344_06](https://github.com/user-attachments/assets/ef49bb34-d323-4620-bccf-a9691c0de148)
![Issue_13344_04](https://github.com/user-attachments/assets/48c8db11-c018-487d-8d6e-6a1e1308bd2a)


## Other possible solutions
1.We can add a switch like `CanSelectWhenDisabled` to let users decide 
2.We can make disabled items selectable just like Winfows Desktop Context menu, but this could be breaking change.