### PR TITLE
Moving tag OperationInReleasingDataSource to function "OnDataSourceDisposed"

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
@@ -14914,9 +14914,12 @@ public partial class DataGridView
     {
         try
         {
+            // 1. Modify the state of the current operation to avoid unnecessary operations
+            // when setting DataSource and CurrentCell.
+            // 2. Setting CurrentCell to null then release DataSource.
             _dataGridViewOper[OperationInReleasingDataSource] = true;
-            DataSource = null;
             CurrentCell = null;
+            DataSource = null;
         }
         finally
         {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
@@ -14910,7 +14910,19 @@ public partial class DataGridView
     /// <summary>
     ///  Refresh items when the DataSource is disposed.
     /// </summary>
-    private void OnDataSourceDisposed(object? sender, EventArgs e) => DataSource = null;
+    private void OnDataSourceDisposed(object? sender, EventArgs e)
+    {
+        try
+        {
+            _dataGridViewOper[OperationInReleasingDataSource] = true;
+            DataSource = null;
+            CurrentCell = null;
+        }
+        finally
+        {
+            _dataGridViewOper[OperationInReleasingDataSource] = false;
+        }
+    }
 
     protected virtual void OnDefaultCellStyleChanged(EventArgs e)
     {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
@@ -14910,22 +14910,7 @@ public partial class DataGridView
     /// <summary>
     ///  Refresh items when the DataSource is disposed.
     /// </summary>
-    private void OnDataSourceDisposed(object? sender, EventArgs e)
-    {
-        try
-        {
-            // 1. Modify the state of the current operation to avoid unnecessary operations
-            // when setting DataSource and CurrentCell.
-            // 2. Setting CurrentCell to null then release DataSource.
-            _dataGridViewOper[OperationInReleasingDataSource] = true;
-            CurrentCell = null;
-            DataSource = null;
-        }
-        finally
-        {
-            _dataGridViewOper[OperationInReleasingDataSource] = false;
-        }
-    }
+    private void OnDataSourceDisposed(object? sender, EventArgs e) => DataSource = null;
 
     protected virtual void OnDefaultCellStyleChanged(EventArgs e)
     {
@@ -27032,11 +27017,10 @@ public partial class DataGridView
                 int oldCurrentCellY = _ptCurrentCell.Y;
                 if (oldCurrentCellX >= 0
                     && !_dataGridViewState1[State1_TemporarilyResetCurrentCell]
-                    && !_dataGridViewOper[OperationInDispose]
-                    && !_dataGridViewOper[OperationInReleasingDataSource])
+                    && !_dataGridViewOper[OperationInDispose])
                 {
                     DataGridViewCell currentCell = CurrentCellInternal;
-                    if (!EndEdit(
+                    if (IsHandleCreated && !EndEdit(
                         DataGridViewDataErrorContexts.Parsing | DataGridViewDataErrorContexts.Commit | DataGridViewDataErrorContexts.CurrentCellChange,
                         validateCurrentCell ? DataGridViewValidateCellInternal.Always : DataGridViewValidateCellInternal.Never,
                         fireCellLeave: validateCurrentCell,

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
@@ -27015,12 +27015,13 @@ public partial class DataGridView
             {
                 int oldCurrentCellX = _ptCurrentCell.X;
                 int oldCurrentCellY = _ptCurrentCell.Y;
-                if (oldCurrentCellX >= 0
+                if (IsHandleCreated
+                    && oldCurrentCellX >= 0
                     && !_dataGridViewState1[State1_TemporarilyResetCurrentCell]
                     && !_dataGridViewOper[OperationInDispose])
                 {
                     DataGridViewCell currentCell = CurrentCellInternal;
-                    if (IsHandleCreated && !EndEdit(
+                    if (!EndEdit(
                         DataGridViewDataErrorContexts.Parsing | DataGridViewDataErrorContexts.Commit | DataGridViewDataErrorContexts.CurrentCellChange,
                         validateCurrentCell ? DataGridViewValidateCellInternal.Always : DataGridViewValidateCellInternal.Never,
                         fireCellLeave: validateCurrentCell,

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
@@ -1922,6 +1922,11 @@ public partial class DataGridView : Control, ISupportInitialize
                     newDataSource.Disposed += OnDataSourceDisposed;
                 }
 
+                if (CurrentCell is not null)
+                {
+                    CurrentCell = null;
+                }
+
                 if (DataConnection is null)
                 {
                     DataConnection = new DataGridViewDataConnection(this);

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
@@ -1922,17 +1922,6 @@ public partial class DataGridView : Control, ISupportInitialize
                     newDataSource.Disposed += OnDataSourceDisposed;
                 }
 
-                _dataGridViewOper[OperationInReleasingDataSource] = true;
-
-                try
-                {
-                    CurrentCell = null;
-                }
-                finally
-                {
-                    _dataGridViewOper[OperationInReleasingDataSource] = false;
-                }
-
                 if (DataConnection is null)
                 {
                     DataConnection = new DataGridViewDataConnection(this);

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
@@ -222,7 +222,6 @@ public partial class DataGridView : Control, ISupportInitialize
     private const int OperationInEndEdit = 0x00400000;
     private const int OperationResizingOperationAboutToStart = 0x00800000;
     private const int OperationTrackKeyboardColResize = 0x01000000;
-    private const int OperationInReleasingDataSource = 0x02000000;
     private const int OperationMouseOperationMask = OperationTrackColResize | OperationTrackRowResize |
         OperationTrackColRelocation | OperationTrackColHeadersResize | OperationTrackRowHeadersResize;
     private const int OperationKeyboardOperationMask = OperationTrackKeyboardColResize;
@@ -1922,10 +1921,7 @@ public partial class DataGridView : Control, ISupportInitialize
                     newDataSource.Disposed += OnDataSourceDisposed;
                 }
 
-                if (CurrentCell is not null)
-                {
-                    CurrentCell = null;
-                }
+                CurrentCell = null;
 
                 if (DataConnection is null)
                 {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13304

## Proposed changes

- This is a supplemental fix to PR #13320
- Add judgment `IsHandleCreated` before invoking `EndEdit` to avoid the exception

- #### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13362)