### PR TITLE
Clean-up dependencies after first VMR sync

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -64,16 +64,7 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Internal.Runtime.WindowsDesktop.Transport" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
     <Dependency Name="System.Runtime.Serialization.Formatters" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
-    <!-- These dependencies are required by windowsdesktop for coherency. -->
-    <Dependency Name="Microsoft.Win32.Registry.AccessControl" Version="10.0.0-preview.5.25227.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
     </Dependency>
@@ -85,39 +76,7 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
     </Dependency>
-    <Dependency Name="System.ComponentModel.Composition" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
     <Dependency Name="System.Configuration.ConfigurationManager" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
-    <Dependency Name="System.Data.Odbc" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
-    <Dependency Name="System.Data.OleDb" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
-    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
-    <Dependency Name="System.DirectoryServices.AccountManagement" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
-    <Dependency Name="System.DirectoryServices.Protocols" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="10.0.0-preview.5.25227.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
     </Dependency>
@@ -126,66 +85,6 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
       <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
     </Dependency>
     <Dependency Name="System.IO.Hashing" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
-    <Dependency Name="System.IO.Packaging" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
-    <Dependency Name="System.IO.Ports" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
-    <Dependency Name="System.Management" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
-    <Dependency Name="System.Reflection.Context" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
-    <Dependency Name="System.Runtime.Caching" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
-    <Dependency Name="System.Security.Cryptography.Pkcs" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
-    <Dependency Name="System.ServiceModel.Syndication" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
-    <Dependency Name="System.ServiceProcess.ServiceController" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
-    <Dependency Name="System.Speech" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
-    <Dependency Name="System.Text.Encoding.CodePages" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
-    <Dependency Name="System.Threading.AccessControl" Version="10.0.0-preview.5.25227.101">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
-    </Dependency>
-    <Dependency Name="System.ComponentModel.Composition.Registration" Version="10.0.0-preview.5.25227.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>c71a5e287b51dabb97b7e0be5c4ba9b11f840402</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,24 +14,13 @@
   <!-- Below have corresponding entries in Versions.Details.XML because they are updated via Maestro -->
   <PropertyGroup>
     <VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion>10.0.0-preview.5.25227.101</VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion>
-    <SystemDiagnosticsEventLogPackageVersion>10.0.0-preview.5.25227.101</SystemDiagnosticsEventLogPackageVersion>
-    <SystemDirectoryServicesPackageVersion>10.0.0-preview.5.25227.101</SystemDirectoryServicesPackageVersion>
     <SystemFormatsNrbfPackageVersion>10.0.0-preview.5.25227.101</SystemFormatsNrbfPackageVersion>
-    <SystemReflectionMetadataLoadContextPackageVersion>10.0.0-preview.5.25227.101</SystemReflectionMetadataLoadContextPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>10.0.0-preview.5.25227.101</SystemSecurityCryptographyXmlPackageVersion>
     <SystemIOHashingPackageVersion>10.0.0-preview.5.25227.101</SystemIOHashingPackageVersion>
-    <SystemIOPackagingPackageVersion>10.0.0-preview.5.25227.101</SystemIOPackagingPackageVersion>
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>5.0.0-preview.7.20320.5</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <MicrosoftNETCoreILDAsmPackageVersion>10.0.0-preview.5.25227.101</MicrosoftNETCoreILDAsmPackageVersion>
-    <SystemDiagnosticsPerformanceCounterPackageVersion>10.0.0-preview.5.25227.101</SystemDiagnosticsPerformanceCounterPackageVersion>
     <SystemRuntimeCompilerServicesUnsafePackageVersion>6.1.0-preview.1.24511.1</SystemRuntimeCompilerServicesUnsafePackageVersion>
     <SystemRuntimeSerializationFormattersPackageVersion>10.0.0-preview.5.25227.101</SystemRuntimeSerializationFormattersPackageVersion>
-    <SystemSecurityCryptographyPkcsPackageVersion>10.0.0-preview.5.25227.101</SystemSecurityCryptographyPkcsPackageVersion>
-    <SystemSecurityCryptographyProtectedDataPackageVersion>10.0.0-preview.5.25227.101</SystemSecurityCryptographyProtectedDataPackageVersion>
-    <SystemTextEncodingsWebPackageVersion>10.0.0-preview.5.25227.101</SystemTextEncodingsWebPackageVersion>
     <SystemTextJsonPackageVersion>10.0.0-preview.5.25227.101</SystemTextJsonPackageVersion>
-    <SystemThreadingAccessControlPackageVersion>10.0.0-preview.5.25227.101</SystemThreadingAccessControlPackageVersion>
-    <MicrosoftWin32RegistryAccessControlPackageVersion>10.0.0-preview.5.25227.101</MicrosoftWin32RegistryAccessControlPackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>10.0.0-preview.5.25227.101</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>10.0.0-preview.5.25227.101</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <MicrosoftNETCorePlatformsPackageVersion>10.0.0-preview.5.25227.101</MicrosoftNETCorePlatformsPackageVersion>
@@ -44,21 +33,6 @@
     <MicrosoftNETCoreILAsmPackageVersion>10.0.0-preview.5.25227.101</MicrosoftNETCoreILAsmPackageVersion>
     <runtimewinx64MicrosoftNETCoreILAsmPackageVersion>10.0.0-preview.5.25227.101</runtimewinx64MicrosoftNETCoreILAsmPackageVersion>
     <runtimewinx86MicrosoftNETCoreILAsmPackageVersion>10.0.0-preview.5.25227.101</runtimewinx86MicrosoftNETCoreILAsmPackageVersion>
-    <MicrosoftInternalRuntimeWindowsDesktopTransportVersion>10.0.0-preview.5.25227.101</MicrosoftInternalRuntimeWindowsDesktopTransportVersion>
-    <SystemComponentModelCompositionVersion>10.0.0-preview.5.25227.101</SystemComponentModelCompositionVersion>
-    <SystemDataOdbcVersion>10.0.0-preview.5.25227.101</SystemDataOdbcVersion>
-    <SystemDataOleDbVersion>10.0.0-preview.5.25227.101</SystemDataOleDbVersion>
-    <SystemDirectoryServicesAccountManagementVersion>10.0.0-preview.5.25227.101</SystemDirectoryServicesAccountManagementVersion>
-    <SystemDirectoryServicesProtocolsVersion>10.0.0-preview.5.25227.101</SystemDirectoryServicesProtocolsVersion>
-    <SystemIOPortsVersion>10.0.0-preview.5.25227.101</SystemIOPortsVersion>
-    <SystemManagementVersion>10.0.0-preview.5.25227.101</SystemManagementVersion>
-    <SystemReflectionContextVersion>10.0.0-preview.5.25227.101</SystemReflectionContextVersion>
-    <SystemRuntimeCachingVersion>10.0.0-preview.5.25227.101</SystemRuntimeCachingVersion>
-    <SystemServiceModelSyndicationVersion>10.0.0-preview.5.25227.101</SystemServiceModelSyndicationVersion>
-    <SystemServiceProcessServiceControllerVersion>10.0.0-preview.5.25227.101</SystemServiceProcessServiceControllerVersion>
-    <SystemSpeechVersion>10.0.0-preview.5.25227.101</SystemSpeechVersion>
-    <SystemTextEncodingCodePagesVersion>10.0.0-preview.5.25227.101</SystemTextEncodingCodePagesVersion>
-    <SystemComponentModelCompositionRegistrationVersion>10.0.0-preview.5.25227.101</SystemComponentModelCompositionRegistrationVersion>
     <MicrosoftNETSdkILVersion>10.0.0-preview.5.25227.101</MicrosoftNETSdkILVersion>
     <!-- 
       Microsoft.NET.Sdk.IL.targets requires definition of MicrosoftNETCoreILAsmVersion


### PR DESCRIPTION
Follow-up on https://github.com/dotnet/winforms/pull/13370

All of the removed dependencies and properties in this PR aren't necessary. They were needed previously for coherency but that isn't necessary anymore now that winforms flows directly into the VMR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13383)