### PR TITLE
Fix Color value in PageSettings

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PageSettings.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PageSettings.cs
@@ -53,7 +53,7 @@ public unsafe class PageSettings : ICloneable
     public bool Color
     {
         get => _color.IsDefault
-            ? _printerSettings.GetModeField(ModeField.Color, (short)DEVMODE_COLOR.DMCOLOR_MONOCHROME) == (short)DEVMODE_COLOR.DMCOLOR_MONOCHROME
+            ? _printerSettings.GetModeField(ModeField.Color, (short)DEVMODE_COLOR.DMCOLOR_MONOCHROME) == (short)DEVMODE_COLOR.DMCOLOR_COLOR
             : (bool)_color;
         set => _color = value;
     }

--- a/src/System.Drawing.Common/tests/Helpers.cs
+++ b/src/System.Drawing.Common/tests/Helpers.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Drawing.Printing;
 using System.Text;
 using Windows.Win32;
@@ -20,6 +21,47 @@ public static unsafe class Helpers
     public const string AnyInstalledPrinters = $"{nameof(Helpers)}.{nameof(AreAnyPrintersInstalled)}";
 
     public static bool AreAnyPrintersInstalled() => s_anyInstalledPrinters;
+
+    private const string PrintToPdfPrinterName = "Microsoft Print to PDF";
+
+    /// <summary>
+    ///  Checks if PDF printing is supported by verifying installed printers.
+    /// </summary>
+    /// <returns><see langword="true"/> if a PDF printer is installed; otherwise, <see langword="false"/>.</returns>
+    public static bool CanPrintToPdf()
+    {
+        foreach (string name in InstalledPrinters)
+        {
+            if (name.StartsWith(PrintToPdfPrinterName, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///  Attempts to get the name of the PDF printer installed on the system.
+    /// </summary>
+    /// <param name="printerName">
+    ///  When this method returns, contains the name of the PDF printer if found; otherwise, <see langword="null"/>.
+    /// </param>
+    /// <returns><see langword="true"/> if a PDF printer is found; otherwise, <see langword="false"/>.</returns>
+    public static bool TryGetPdfPrinterName([NotNullWhen(true)] out string? printerName)
+    {
+        foreach (string name in InstalledPrinters)
+        {
+            if (name.StartsWith(PrintToPdfPrinterName, StringComparison.Ordinal))
+            {
+                printerName = name;
+                return true;
+            }
+        }
+
+        printerName = null;
+        return false;
+    }
 
     public static string GetTestBitmapPath(string fileName) => GetTestPath("bitmaps", fileName);
     public static string GetTestFontPath(string fileName) => GetTestPath("fonts", fileName);

--- a/src/System.Drawing.Common/tests/System/Drawing/Printing/PageSettingsTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/Printing/PageSettingsTests.cs
@@ -63,4 +63,21 @@ public class PageSettingsTests
         Assert.Equal(ps.PaperSource.Kind, clone.PaperSource.Kind);
         Assert.Equal(ps.PaperSource.SourceName, clone.PaperSource.SourceName);
     }
+
+    [ConditionalFact(Helpers.AnyInstalledPrinters)]
+    public void PrintToPDF_DefaultPageSettings_IsColor()
+    {
+        // Regression test for https://github.com/dotnet/winforms/issues/13367
+        if (!Helpers.TryGetPdfPrinterName(out string? printerName))
+        {
+            return;
+        }
+
+        PrinterSettings printerSettings = new()
+        {
+            PrinterName = printerName
+        };
+
+        printerSettings.DefaultPageSettings.Color.Should().BeTrue("PDF printer should support color printing.");
+    }
 }

--- a/src/System.Drawing.Common/tests/System/Drawing/Printing/PrintDocumentTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/Printing/PrintDocumentTests.cs
@@ -160,7 +160,7 @@ public class PrintDocumentTests : FileCleanupTestBase
         Assert.False(flag);
     }
 
-    [ConditionalFact(nameof(Helpers.CanPrintToPdf))]
+    [ConditionalFact(typeof(Helpers), nameof(Helpers.CanPrintToPdf))]
     public void Print_DefaultPrintController_Success()
     {
         if (!Helpers.TryGetPdfPrinterName(out string? printerName))

--- a/src/System.Drawing.Common/tests/System/Drawing/Printing/PrintDocumentTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/Printing/PrintDocumentTests.cs
@@ -160,10 +160,10 @@ public class PrintDocumentTests : FileCleanupTestBase
         Assert.False(flag);
     }
 
-    [ConditionalFact(nameof(CanPrintToPdf))]
+    [ConditionalFact(nameof(Helpers.CanPrintToPdf))]
     public void Print_DefaultPrintController_Success()
     {
-        if (!CanPrintToPdf())
+        if (!Helpers.TryGetPdfPrinterName(out string? printerName))
         {
             return;
         }
@@ -172,7 +172,7 @@ public class PrintDocumentTests : FileCleanupTestBase
         PrintEventHandler endPrintHandler = new((sender, e) => endPrintCalled = true);
         using (PrintDocument document = new())
         {
-            document.PrinterSettings.PrinterName = GetPdfPrinterName();
+            document.PrinterSettings.PrinterName = printerName;
             document.PrinterSettings.PrintFileName = GetTestFilePath();
             document.PrinterSettings.PrintToFile = true;
             document.EndPrint += endPrintHandler;
@@ -245,33 +245,6 @@ public class PrintDocumentTests : FileCleanupTestBase
 
         Assert.True(Enum.IsDefined(typeof(PrinterResolutionKind), pageSettings.PrinterResolution.Kind));
         Assert.True(pageSettings.PrinterSettings.IsDefaultPrinter);
-    }
-
-    private const string PrintToPdfPrinterName = "Microsoft Print to PDF";
-    private static bool CanPrintToPdf()
-    {
-        foreach (string name in Helpers.InstalledPrinters)
-        {
-            if (name.StartsWith(PrintToPdfPrinterName, StringComparison.Ordinal))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static string GetPdfPrinterName()
-    {
-        foreach (string name in Helpers.InstalledPrinters)
-        {
-            if (name.StartsWith(PrintToPdfPrinterName, StringComparison.Ordinal))
-            {
-                return name;
-            }
-        }
-
-        throw new InvalidOperationException("No PDF printer installed");
     }
 
     private class TestPrintController : PrintController


### PR DESCRIPTION
This was inadvertently flipped when changing to CsWin32. Moves helper code for using the PDF printer to write a regression test.

There is no practical workaround for this. If you're looking for whether a printer supports color, however, you can check `PrinterSettings.SupportsColor` instead. 

Fixes #13367
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13385)