### PR TITLE
fix issue  #13369 Changing the position of the BindingSource triggers the ListChanged event with ListChangedType.ItemAdded

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/DataBinding/BindingSource.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/DataBinding/BindingSource.cs
@@ -733,7 +733,7 @@ public partial class BindingSource : Component,
         // when our parent updates which then causes our parent to update which
         // then causes us to update which then causes our parent to update which
         // then causes us to update which then causes our parent to update...
-        if (!_state.HasFlag(BindingSourceStates.InnerListChanging))
+        if (!_state.HasFlag(BindingSourceStates.InnerListChanging) && (CurrencyManager is null || !CurrencyManager.IsInSettingPosition))
         {
             try
             {

--- a/src/System.Windows.Forms/System/Windows/Forms/DataBinding/CurrencyManager.CurrencyManagerStates.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/DataBinding/CurrencyManager.CurrencyManagerStates.cs
@@ -13,5 +13,6 @@ public partial class CurrencyManager
         PullingData                     = 0b0000_0100,
         InChangeRecordState             = 0b0000_1000,
         SuspendPushDataInCurrentChanged = 0b0001_0000,
+        InSettingPosition               = 0b0010_0000,
     }
 }

--- a/src/System.Windows.Forms/System/Windows/Forms/DataBinding/CurrencyManager.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/DataBinding/CurrencyManager.cs
@@ -213,6 +213,8 @@ public partial class CurrencyManager : BindingManagerBase
         }
     }
 
+    internal bool IsInSettingPosition => _state.HasFlag(CurrencyManagerStates.InSettingPosition);
+
     /// <summary>
     ///  Gets or sets the position you are at within the list.
     /// </summary>
@@ -221,6 +223,7 @@ public partial class CurrencyManager : BindingManagerBase
         get => listposition;
         set
         {
+            _state.ChangeFlags(CurrencyManagerStates.InSettingPosition, true);
             if (listposition == -1)
             {
                 return;
@@ -243,6 +246,7 @@ public partial class CurrencyManager : BindingManagerBase
                 endCurrentEdit: true,
                 firePositionChange: true,
                 pullData: false);
+            _state.ChangeFlags(CurrencyManagerStates.InSettingPosition, false);
         }
     }
 


### PR DESCRIPTION

Fixes #13369


## Proposed changes

- 
- OnListChanged event is raised when Setting Position, which I think is not necessary.
- 

<!--
## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-
 -->



## Screenshots 

### Before


https://github.com/user-attachments/assets/f2d09bd5-8543-4e3d-b045-6b5838d6d73f

### After

![Issue_13369](https://github.com/user-attachments/assets/3aa7a70d-49f5-487b-a0a4-0587b2e4b774)


<!--

## Test methodology 

- 
- 
- 

## Accessibility testing  




## Test environment(s) 

I -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13392)