### PR TITLE
Fix 13286: Add a null check before getting SelectionService and BehaviorService

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripTemplateNode.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripTemplateNode.cs
@@ -346,7 +346,7 @@ internal class ToolStripTemplateNode : IMenuStatusHandler
     {
         get
         {
-            _selectionService ??= (ISelectionService)_component.Site.GetService(typeof(ISelectionService));
+            _selectionService ??= (ISelectionService)_component.Site?.GetService(typeof(ISelectionService));
 
             return _selectionService;
         }
@@ -356,7 +356,7 @@ internal class ToolStripTemplateNode : IMenuStatusHandler
     {
         get
         {
-            _behaviorService ??= (BehaviorService)_component.Site.GetService(typeof(BehaviorService));
+            _behaviorService ??= (BehaviorService)_component.Site?.GetService(typeof(BehaviorService));
 
             return _behaviorService;
         }
@@ -797,7 +797,7 @@ internal class ToolStripTemplateNode : IMenuStatusHandler
         FocusForm();
         CommitTextToDesigner(text, commit, enterKeyPressed, tabKeyPressed);
         // finally Invalidate the selection rect ...
-        if (SelectionService.PrimarySelection is ToolStripItem curSel)
+        if (SelectionService?.PrimarySelection is ToolStripItem curSel)
         {
             if (_designerHost is not null)
             {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13286


## Proposed changes

- Add a null check before getting `SelectionService` and `BehaviorService` in ToolStripTemplateNode.cs

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- ToolStripMenuItem can be added normally in DemoConsole project

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

https://github.com/user-attachments/assets/4bff443e-cdc2-4bc9-9ca8-aee3f7660d39

### After

![AfterChanges](https://github.com/user-attachments/assets/57928b8d-0355-4313-bd61-b14426a5daae)



## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-preview.4.25223.119


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13393)