### PR TITLE
Move `DataGridViewChooseDataSourceActionList` into a separate file

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewDesigner.DataGridViewChooseDataSourceActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewDesigner.DataGridViewChooseDataSourceActionList.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+using System.ComponentModel.Design;
+using System.Drawing.Design;
+
+namespace System.Windows.Forms.Design;
+
+internal partial class DataGridViewDesigner
+{
+    [ComplexBindingProperties("DataSource", "DataMember")]
+    private class DataGridViewChooseDataSourceActionList : DesignerActionList
+    {
+        private readonly DataGridViewDesigner _owner;
+
+        public DataGridViewChooseDataSourceActionList(DataGridViewDesigner owner) : base(owner.Component)
+        {
+            _owner = owner;
+        }
+
+        // The choose data source designer action item is missing
+        public override DesignerActionItemCollection GetSortedActionItems()
+        {
+            DesignerActionItemCollection items = [];
+            DesignerActionPropertyItem chooseDataSource = new(
+                nameof(DataSource),
+                SR.DataGridViewChooseDataSource)
+            {
+                RelatedComponent = _owner.Component
+            };
+
+            items.Add(chooseDataSource);
+            return items;
+        }
+
+        [AttributeProvider(typeof(IListSource))]
+        [Editor($"System.Windows.Forms.Design.DataSourceListEditor, {AssemblyRef.SystemDesign}", typeof(UITypeEditor))]
+        public object? DataSource
+        {
+            // Use the shadow property which is defined on the designer.
+            get => _owner.DataSource;
+            set
+            {
+                // left to do: transaction stuff
+                DataGridView dataGridView = _owner.Control;
+                IDesignerHost? host = dataGridView.Site?.GetService<IDesignerHost>();
+                PropertyDescriptor? dataSourceProp = TypeDescriptor.GetProperties(dataGridView)["DataSource"];
+                IComponentChangeService? changeService = dataGridView.Site?.GetService<IComponentChangeService>();
+                DesignerTransaction? transaction = host?.CreateTransaction(string.Format(SR.DataGridViewChooseDataSourceTransactionString, dataGridView.Name));
+                try
+                {
+                    changeService?.OnComponentChanging(_owner.Component, dataSourceProp);
+                    // Use the shadow property which is defined on the designer.
+                    _owner.DataSource = value;
+                    changeService?.OnComponentChanged(_owner.Component, dataSourceProp, null, null);
+                    transaction?.Commit();
+                    transaction = null;
+                }
+                finally
+                {
+                    transaction?.Cancel();
+                }
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewDesigner.cs
@@ -5,11 +5,10 @@ using System.ComponentModel;
 using System.Collections;
 using System.ComponentModel.Design;
 using System.Drawing;
-using System.Drawing.Design;
 
 namespace System.Windows.Forms.Design;
 
-internal class DataGridViewDesigner : ControlDesigner
+internal partial class DataGridViewDesigner : ControlDesigner
 {
     protected DesignerVerbCollection? designerVerbs;
 
@@ -802,61 +801,6 @@ internal class DataGridViewDesigner : ControlDesigner
         else
         {
             return dialog.ShowDialog(Control);
-        }
-    }
-
-    [ComplexBindingProperties("DataSource", "DataMember")]
-    private class DataGridViewChooseDataSourceActionList : DesignerActionList
-    {
-        private readonly DataGridViewDesigner _owner;
-
-        public DataGridViewChooseDataSourceActionList(DataGridViewDesigner owner) : base(owner.Component)
-        {
-            _owner = owner;
-        }
-
-        public override DesignerActionItemCollection GetSortedActionItems()
-        {
-            DesignerActionItemCollection items = [];
-            DesignerActionPropertyItem chooseDataSource = new(
-                nameof(DataSource),
-                SR.DataGridViewChooseDataSource)
-            {
-                RelatedComponent = _owner.Component
-            };
-
-            items.Add(chooseDataSource);
-            return items;
-        }
-
-        [AttributeProvider(typeof(IListSource))]
-        [Editor($"System.Windows.Forms.Design.DataSourceListEditor, {AssemblyRef.SystemDesign}", typeof(UITypeEditor))]
-        public object? DataSource
-        {
-            // Use the shadow property which is defined on the designer.
-            get => _owner.DataSource;
-            set
-            {
-                // left to do: transaction stuff
-                DataGridView dataGridView = _owner.Control;
-                IDesignerHost? host = dataGridView.Site?.GetService<IDesignerHost>();
-                PropertyDescriptor? dataSourceProp = TypeDescriptor.GetProperties(dataGridView)["DataSource"];
-                IComponentChangeService? changeService = dataGridView.Site?.GetService<IComponentChangeService>();
-                DesignerTransaction? transaction = host?.CreateTransaction(string.Format(SR.DataGridViewChooseDataSourceTransactionString, dataGridView.Name));
-                try
-                {
-                    changeService?.OnComponentChanging(_owner.Component, dataSourceProp);
-                    // Use the shadow property which is defined on the designer.
-                    _owner.DataSource = value;
-                    changeService?.OnComponentChanged(_owner.Component, dataSourceProp, null, null);
-                    transaction?.Commit();
-                    transaction = null;
-                }
-                finally
-                {
-                    transaction?.Cancel();
-                }
-            }
         }
     }
 


### PR DESCRIPTION
Related #13231

## Root Cause

- Missing structure for choosing data source designer action item.

## Proposed changes

- Move `DataGridViewChooseDataSourceActionList` into a separate file
- Add comment about missing structure for choosing data source designer action item.

## Customer Impact

- None

## Regression?

- No

## Risk

- Minimal

## Test environment(s)

- 10.0.100-preview.3.25201.16

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13397)