### PR TITLE
[Release/9.0] Fix false-positive WinForms Analyzer diagnostics.

### DIFF
--- a/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/CSharp/Analyzers/MissingPropertySerializationConfiguration/MissingPropertySerializationConfigurationAnalyzer.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/CSharp/Analyzers/MissingPropertySerializationConfiguration/MissingPropertySerializationConfigurationAnalyzer.cs
@@ -12,8 +12,8 @@ namespace System.Windows.Forms.CSharp.Analyzers.MissingPropertySerializationConf
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class MissingPropertySerializationConfigurationAnalyzer : DiagnosticAnalyzer
 {
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        => [CSharpDiagnosticDescriptors.s_missingPropertySerializationConfiguration];
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        [CSharpDiagnosticDescriptors.s_missingPropertySerializationConfiguration];
 
     public override void Initialize(AnalysisContext context)
     {
@@ -24,22 +24,48 @@ public class MissingPropertySerializationConfigurationAnalyzer : DiagnosticAnaly
 
     private static void AnalyzeSymbol(SymbolAnalysisContext context)
     {
-        // We analyze only properties.
-        var propertySymbol = (IPropertySymbol)context.Symbol;
-
-        // Does the property belong to a class which derives from Component?
-        if (propertySymbol.ContainingType is null
-            || !propertySymbol
-                .ContainingType
-                .AllInterfaces
-                .Any(i => i.Name == nameof(IComponent)))
+        // We only care about properties, and don't care about static properties.
+        if (context.Symbol is not IPropertySymbol propertySymbol
+            || propertySymbol.IsStatic)
         {
             return;
         }
 
-        // Is the property read/write and at least internal?
-        if (propertySymbol.SetMethod is null
+        // A property of System.ComponentModel.ISite we never flag.
+        if (propertySymbol.Type.Name == nameof(ISite)
+            && propertySymbol.Type.ContainingNamespace.ToString() == "System.ComponentModel")
+        {
+            return;
+        }
+
+        // If the property is part of any interface named IComponent, we're out.
+        if (propertySymbol.ContainingType.Name == nameof(IComponent))
+        {
+            return;
+        }
+
+        // Does the property belong to a class which implements the System.ComponentModel.IComponent interface?
+        if (propertySymbol.ContainingType is null
+            || !propertySymbol
+                .ContainingType
+                .AllInterfaces
+                .Any(i => i.Name == nameof(IComponent) &&
+                          i.ContainingNamespace is not null &&
+                          i.ContainingNamespace.ToString() == "System.ComponentModel"))
+        {
+            return;
+        }
+
+        // Is the property read/write and at least internal and doesn't have a private setter?
+        if (propertySymbol.SetMethod is not IMethodSymbol propertySetter
+            || propertySetter.DeclaredAccessibility == Accessibility.Private
             || propertySymbol.DeclaredAccessibility < Accessibility.Internal)
+        {
+            return;
+        }
+
+        // Skip overridden properties since the base property should already have the appropriate serialization configuration
+        if (propertySymbol.IsOverride)
         {
             return;
         }

--- a/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/CSharp/Analyzers/MissingPropertySerializationConfiguration/MissingPropertySerializationConfigurationAnalyzer.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/CSharp/Analyzers/MissingPropertySerializationConfiguration/MissingPropertySerializationConfigurationAnalyzer.cs
@@ -40,6 +40,21 @@ public class MissingPropertySerializationConfigurationAnalyzer : DiagnosticAnaly
             return;
         }
 
+        // Is the property read/write and at least internal and doesn't have a private setter?
+        if (propertySymbol.SetMethod is not IMethodSymbol propertySetter
+            || propertySetter.DeclaredAccessibility == Accessibility.Private
+            || propertySymbol.DeclaredAccessibility < Accessibility.Internal)
+        {
+            return;
+        }
+
+        // Skip overridden properties since the base property should already
+        // have the appropriate serialization configuration
+        if (propertySymbol.IsOverride)
+        {
+            return;
+        }
+
         // If the property is part of any interface named IComponent, we're out.
         if (propertySymbol.ContainingType.Name == nameof(IComponent))
         {
@@ -54,21 +69,6 @@ public class MissingPropertySerializationConfigurationAnalyzer : DiagnosticAnaly
                 .Any(i => i.Name == nameof(IComponent) &&
                           i.ContainingNamespace is not null &&
                           i.ContainingNamespace.ToString() == SystemComponentModelName))
-        {
-            return;
-        }
-
-        // Is the property read/write and at least internal and doesn't have a private setter?
-        if (propertySymbol.SetMethod is not IMethodSymbol propertySetter
-            || propertySetter.DeclaredAccessibility == Accessibility.Private
-            || propertySymbol.DeclaredAccessibility < Accessibility.Internal)
-        {
-            return;
-        }
-
-        // Skip overridden properties since the base property should already
-        // have the appropriate serialization configuration
-        if (propertySymbol.IsOverride)
         {
             return;
         }

--- a/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/CSharp/Analyzers/MissingPropertySerializationConfiguration/MissingPropertySerializationConfigurationAnalyzer.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/CSharp/Analyzers/MissingPropertySerializationConfiguration/MissingPropertySerializationConfigurationAnalyzer.cs
@@ -12,6 +12,8 @@ namespace System.Windows.Forms.CSharp.Analyzers.MissingPropertySerializationConf
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class MissingPropertySerializationConfigurationAnalyzer : DiagnosticAnalyzer
 {
+    private const string SystemComponentModelName = "System.ComponentModel";
+
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         [CSharpDiagnosticDescriptors.s_missingPropertySerializationConfiguration];
 
@@ -24,7 +26,7 @@ public class MissingPropertySerializationConfigurationAnalyzer : DiagnosticAnaly
 
     private static void AnalyzeSymbol(SymbolAnalysisContext context)
     {
-        // We only care about properties, and don't care about static properties.
+        // We never flag a property named Site of type of ISite
         if (context.Symbol is not IPropertySymbol propertySymbol
             || propertySymbol.IsStatic)
         {
@@ -33,7 +35,7 @@ public class MissingPropertySerializationConfigurationAnalyzer : DiagnosticAnaly
 
         // A property of System.ComponentModel.ISite we never flag.
         if (propertySymbol.Type.Name == nameof(ISite)
-            && propertySymbol.Type.ContainingNamespace.ToString() == "System.ComponentModel")
+            && propertySymbol.Type.ContainingNamespace.ToString() == SystemComponentModelName)
         {
             return;
         }
@@ -51,7 +53,7 @@ public class MissingPropertySerializationConfigurationAnalyzer : DiagnosticAnaly
                 .AllInterfaces
                 .Any(i => i.Name == nameof(IComponent) &&
                           i.ContainingNamespace is not null &&
-                          i.ContainingNamespace.ToString() == "System.ComponentModel"))
+                          i.ContainingNamespace.ToString() == SystemComponentModelName))
         {
             return;
         }
@@ -64,7 +66,8 @@ public class MissingPropertySerializationConfigurationAnalyzer : DiagnosticAnaly
             return;
         }
 
-        // Skip overridden properties since the base property should already have the appropriate serialization configuration
+        // Skip overridden properties since the base property should already
+        // have the appropriate serialization configuration
         if (propertySymbol.IsOverride)
         {
             return;

--- a/src/System.Windows.Forms.Analyzers.VisualBasic/src/Analyzers/MissingPropertySerializationConfiguration/MissingPropertySerializationConfigurationDiagnosticAnalyzer.vb
+++ b/src/System.Windows.Forms.Analyzers.VisualBasic/src/Analyzers/MissingPropertySerializationConfiguration/MissingPropertySerializationConfigurationDiagnosticAnalyzer.vb
@@ -12,6 +12,8 @@ Namespace Global.System.Windows.Forms.VisualBasic.Analyzers.MissingPropertySeria
     Public Class MissingPropertySerializationConfigurationAnalyzer
         Inherits DiagnosticAnalyzer
 
+        Private Const SystemComponentModelName As String = "System.ComponentModel"
+
         Public Overrides ReadOnly Property SupportedDiagnostics As ImmutableArray(Of DiagnosticDescriptor)
             Get
                 Return ImmutableArray.Create(s_missingPropertySerializationConfiguration)
@@ -28,13 +30,14 @@ Namespace Global.System.Windows.Forms.VisualBasic.Analyzers.MissingPropertySeria
 
             ' We analyze only properties.
             Dim propertySymbol As IPropertySymbol = TryCast(context.Symbol, IPropertySymbol)
+
             If propertySymbol Is Nothing Then
                 Return
             End If
 
             ' A property of System.ComponentModel.ISite we never flag.
             If propertySymbol.Type.Name = NameOf(ISite) AndAlso
-               propertySymbol.Type.ContainingNamespace.ToString() = "System.ComponentModel" Then
+               propertySymbol.Type.ContainingNamespace.ToString() = SystemComponentModelName Then
                 Return
             End If
 
@@ -48,7 +51,7 @@ Namespace Global.System.Windows.Forms.VisualBasic.Analyzers.MissingPropertySeria
                Not propertySymbol.ContainingType.AllInterfaces.Any(
                 Function(i) i.Name = NameOf(IComponent) AndAlso
                           i.ContainingNamespace IsNot Nothing AndAlso
-                          i.ContainingNamespace.ToString() = "System.ComponentModel") Then
+                          i.ContainingNamespace.ToString() = SystemComponentModelName) Then
                 Return
             End If
 
@@ -64,7 +67,8 @@ Namespace Global.System.Windows.Forms.VisualBasic.Analyzers.MissingPropertySeria
                 Return
             End If
 
-            ' Skip overridden properties since the base property should already have the appropriate serialization configuration
+            ' Skip overridden properties since the base property should already
+            ' have the appropriate serialization configuration
             If propertySymbol.IsOverride Then
                 Return
             End If

--- a/src/System.Windows.Forms.Analyzers.VisualBasic/src/Analyzers/MissingPropertySerializationConfiguration/MissingPropertySerializationConfigurationDiagnosticAnalyzer.vb
+++ b/src/System.Windows.Forms.Analyzers.VisualBasic/src/Analyzers/MissingPropertySerializationConfiguration/MissingPropertySerializationConfigurationDiagnosticAnalyzer.vb
@@ -46,15 +46,6 @@ Namespace Global.System.Windows.Forms.VisualBasic.Analyzers.MissingPropertySeria
                 Return
             End If
 
-            ' Does the property belong to a class which implements the System.ComponentModel.IComponent interface?
-            If propertySymbol.ContainingType Is Nothing OrElse
-               Not propertySymbol.ContainingType.AllInterfaces.Any(
-                Function(i) i.Name = NameOf(IComponent) AndAlso
-                          i.ContainingNamespace IsNot Nothing AndAlso
-                          i.ContainingNamespace.ToString() = SystemComponentModelName) Then
-                Return
-            End If
-
             ' Skip static properties since they are not serialized by the designer
             If propertySymbol.IsStatic Then
                 Return
@@ -70,6 +61,15 @@ Namespace Global.System.Windows.Forms.VisualBasic.Analyzers.MissingPropertySeria
             ' Skip overridden properties since the base property should already
             ' have the appropriate serialization configuration
             If propertySymbol.IsOverride Then
+                Return
+            End If
+
+            ' Does the property belong to a class which implements the System.ComponentModel.IComponent interface?
+            If propertySymbol.ContainingType Is Nothing OrElse
+               Not propertySymbol.ContainingType.AllInterfaces.Any(
+                Function(i) i.Name = NameOf(IComponent) AndAlso
+                          i.ContainingNamespace IsNot Nothing AndAlso
+                          i.ContainingNamespace.ToString() = SystemComponentModelName) Then
                 Return
             End If
 

--- a/src/System.Windows.Forms.Analyzers.VisualBasic/src/Analyzers/MissingPropertySerializationConfiguration/MissingPropertySerializationConfigurationDiagnosticAnalyzer.vb
+++ b/src/System.Windows.Forms.Analyzers.VisualBasic/src/Analyzers/MissingPropertySerializationConfiguration/MissingPropertySerializationConfigurationDiagnosticAnalyzer.vb
@@ -32,18 +32,40 @@ Namespace Global.System.Windows.Forms.VisualBasic.Analyzers.MissingPropertySeria
                 Return
             End If
 
-            ' Does the property belong to a class which derives from Component?
-            If propertySymbol.ContainingType Is Nothing OrElse
-               Not propertySymbol.ContainingType.AllInterfaces.Any(
-                Function(i) i.Name = NameOf(IComponent)) Then
-
+            ' A property of System.ComponentModel.ISite we never flag.
+            If propertySymbol.Type.Name = NameOf(ISite) AndAlso
+               propertySymbol.Type.ContainingNamespace.ToString() = "System.ComponentModel" Then
                 Return
             End If
 
-            ' Is the property read/write and at least internal?
-            If propertySymbol.SetMethod Is Nothing OrElse
-               propertySymbol.DeclaredAccessibility < Accessibility.Internal Then
+            ' If the property is part of any interface named IComponent, we're out.
+            If propertySymbol.ContainingType.Name = NameOf(IComponent) Then
+                Return
+            End If
 
+            ' Does the property belong to a class which implements the System.ComponentModel.IComponent interface?
+            If propertySymbol.ContainingType Is Nothing OrElse
+               Not propertySymbol.ContainingType.AllInterfaces.Any(
+                Function(i) i.Name = NameOf(IComponent) AndAlso
+                          i.ContainingNamespace IsNot Nothing AndAlso
+                          i.ContainingNamespace.ToString() = "System.ComponentModel") Then
+                Return
+            End If
+
+            ' Skip static properties since they are not serialized by the designer
+            If propertySymbol.IsStatic Then
+                Return
+            End If
+
+            ' Is the property read/write, at least internal, and doesn't have a private setter?
+            If propertySymbol.SetMethod Is Nothing OrElse
+               propertySymbol.SetMethod.DeclaredAccessibility = Accessibility.Private OrElse
+               propertySymbol.DeclaredAccessibility < Accessibility.Internal Then
+                Return
+            End If
+
+            ' Skip overridden properties since the base property should already have the appropriate serialization configuration
+            If propertySymbol.IsOverride Then
                 Return
             End If
 


### PR DESCRIPTION
Fixes #13160.
We're servicing only the false-positive WinForms Analyzers edge cases for low-risk servicing.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13411)