### PR TITLE
fix #13400 Cannot enter characters when adding ToolStripMenuItem1 and then adding ToolStripMenuItem2 after pressing enter in DemoConsole application 

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
@@ -4579,7 +4579,11 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
             SnapFocus((HWND)(nint)m.WParamInternal);
 
             // For fix https://github.com/dotnet/winforms/issues/12916
-            ToolStripManager.ModalMenuFilter.SetActiveToolStrip(this);
+            // Narrow down the range, because ToolStripDropDown is ToolStrip too. we only need to set outer ToolStrip active.
+            if (IsOuterToolStrip(this))
+            {
+                ToolStripManager.ModalMenuFilter.SetActiveToolStrip(this);
+            }
         }
 
         if (!AllowClickThrough && m.MsgInternal == PInvokeCore.WM_MOUSEACTIVATE)
@@ -4645,6 +4649,21 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
             // destroying our parent actually causes a recursive
             // WM_DESTROY.
             _dropDownOwnerWindow?.DestroyHandle();
+        }
+
+        static bool IsOuterToolStrip(ToolStrip toolStrip)
+        {
+            static ToolStrip getParentToolStrip(ToolStrip toolStrip)
+            {
+                if (toolStrip.Parent is ToolStrip parent)
+                {
+                    return getParentToolStrip(parent);
+                }
+
+                return toolStrip;
+            }
+
+            return toolStrip == getParentToolStrip(toolStrip);
         }
     }
 


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13400 


## Proposed changes

- 
- 
- 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

![Issue_13400_02](https://github.com/user-attachments/assets/117567cd-d391-4e6a-8095-d8a8346aca0e)
![Issue_13400_03](https://github.com/user-attachments/assets/1938f757-0b6a-48eb-b2f7-af3b2e2995ba)



## Test methodology <!-- How did you ensure quality? -->

- 
- 
- 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- <!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->
