### PR TITLE
Update the method GetParentAutoScaleFactor to use container.AutoScaleFactor to get the latest value

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Layout/Containers/ContainerControl.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Layout/Containers/ContainerControl.cs
@@ -668,7 +668,7 @@ public class ContainerControl : ScrollableControl, IContainerControl
             parentControl = parentControl.Parent;
         }
 
-        return parentControl is ContainerControl container ? container._currentAutoScaleFactor : new SizeF(1F, 1F);
+        return parentControl is ContainerControl container ? container.AutoScaleFactor : new SizeF(1F, 1F);
     }
 
     internal override Size GetPreferredSizeCore(Size proposedSize)


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12851

## Proposed changes

- Update the method `GetParentAutoScaleFactor` to use `container.AutoScaleFactor` instead of `container._currentAutoScaleFactor `to get the latest value

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- ContainerControl can be scaled correctly when moved from one ControlCollection to another ControlCollection

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![Image](https://github.com/user-attachments/assets/515b40bc-e392-4ce8-9d0f-170ba2088306)


### After

![AfterChanges](https://github.com/user-attachments/assets/54a86f51-9628-4ec7-9d26-ca2709e9fb41)


## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-preview.5.25252.107


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13426)