### PR TITLE
Throw ExternalException instead of OutOfMemory

### DIFF
--- a/src/System.Drawing.Common/src/Resources/Strings.resx
+++ b/src/System.Drawing.Common/src/Resources/Strings.resx
@@ -170,9 +170,6 @@
   <data name="GdiplusInvalidSize" xml:space="preserve">
     <value>Operation requires a transformation of the image from GDI+ to GDI. GDI does not support images with a width or height greater than 32767.</value>
   </data>
-  <data name="GdiplusOutOfMemory" xml:space="preserve">
-    <value>Out of memory.</value>
-  </data>
   <data name="GdiplusNotImplemented" xml:space="preserve">
     <value>Not implemented.</value>
   </data>

--- a/src/System.Private.Windows.Core/src/Resources/SR.resx
+++ b/src/System.Private.Windows.Core/src/Resources/SR.resx
@@ -194,7 +194,7 @@
   <data name="GdiplusInvalidParameter" xml:space="preserve">
     <value>Parameter is not valid.</value>
   </data>
-  <data name="GdiplusOutOfMemory" xml:space="preserve">
+  <data name="GdiplusInvalidOperation" xml:space="preserve">
     <value>An object could not be created, possibly due to a lack of memory, but most likely due to invalid input.</value>
   </data>
   <data name="GdiplusNotImplemented" xml:space="preserve">

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/StatusExtensions.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/StatusExtensions.cs
@@ -27,7 +27,14 @@ internal static class StatusExtensions
             case Status.InvalidParameter:
                 return new ArgumentException(SR.GdiplusInvalidParameter);
             case Status.OutOfMemory:
-                return new OutOfMemoryException(SR.GdiplusOutOfMemory);
+                // This is almost never an actual out of memory error. It usually means that GDI+
+                // was unable to create an internal object due to an invalid parameter or some other
+                // missing state. As it causes no end of confusion, we've switched both the message and
+                // the exception type to be less misleading.
+                //
+                // If we're truly running low on memory, an OutOfMemoryException is likely to be thrown
+                // in some other path soon anyway.
+                return new ExternalException(SR.GdiplusInvalidOperation, (int)HRESULT.E_UNEXPECTED);
             case Status.ObjectBusy:
                 return new InvalidOperationException(SR.GdiplusObjectBusy);
             case Status.InsufficientBuffer:


### PR DESCRIPTION
GDI+ isn't particularly good at returning errors when it is unable to create internal objects. There are many cases where object creation will fail due to invalid input and higher-level code will get a null and turn it into `Status.OutOfMemory`.

As this is a frequent cause of confusion, we're changing this to `ExternalException`, which is already thrown in other code paths. We had already changed the exception message.

Fixes #12627