### PR TITLE
Unify namespaces and class names under DemoConsole

### DIFF
--- a/src/test/integration/DesignSurface/DemoConsole/GlobalUsings.cs
+++ b/src/test/integration/DesignSurface/DemoConsole/GlobalUsings.cs
@@ -7,5 +7,5 @@ global using System.Diagnostics;
 global using System.ComponentModel;
 global using System.ComponentModel.Design;
 global using System.Windows.Forms.Design;
-global using DesignSurfaceExt;
+global using DemoConsole;
 global using Timer = System.Windows.Forms.Timer;

--- a/src/test/integration/DesignSurface/DemoConsole/MainForm.Designer.cs
+++ b/src/test/integration/DesignSurface/DemoConsole/MainForm.Designer.cs
@@ -37,7 +37,7 @@ partial class MainForm
         this.tabPage4 = new System.Windows.Forms.TabPage();
         this.tabPage5 = new System.Windows.Forms.TabPage();
         this.tabPage6 = new System.Windows.Forms.TabPage();
-        this.propertyGrid = new PropertyGridExt();
+        this.propertyGrid = new PropertyGridExtended();
         this.menuStrip1 = new System.Windows.Forms.MenuStrip();
         this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
         this.ToolStripMenuItemUnDo = new System.Windows.Forms.ToolStripMenuItem();
@@ -314,7 +314,7 @@ partial class MainForm
     #endregion
 
     private System.Windows.Forms.SplitContainer splitContainer;
-    private PropertyGridExt propertyGrid;
+    private PropertyGridExtended propertyGrid;
     private System.Windows.Forms.MenuStrip menuStrip1;
     private System.Windows.Forms.ToolStripMenuItem editToolStripMenuItem;
     private System.Windows.Forms.ToolStripMenuItem ToolStripMenuItemUnDo;

--- a/src/test/integration/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/test/integration/DesignSurface/DemoConsole/MainForm.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
 namespace TestConsole;
 
 [DesignerCategory("Default")]
@@ -8,7 +7,7 @@ public partial class MainForm : Form
 {
     private ISelectionService _selectionService;
 
-    private readonly List<IDesignSurfaceExt> _listOfDesignSurface = [];
+    private readonly List<IDesignSurfaceExtended> _listOfDesignSurface = [];
 
     public MainForm()
     {
@@ -38,7 +37,7 @@ public partial class MainForm : Form
         // - enable the UndoEngines
         for (int i = 0; i < tabControl1.TabCount; i++)
         {
-            IDesignSurfaceExt isurf = _listOfDesignSurface[i];
+            IDesignSurfaceExtended isurf = _listOfDesignSurface[i];
             isurf.GetUndoEngineExt().Enabled = true;
         }
 
@@ -47,7 +46,7 @@ public partial class MainForm : Form
         // - if we obtain it then hook the SelectionChanged event
         for (int i = 0; i < tabControl1.TabCount; i++)
         {
-            IDesignSurfaceExt isurf = _listOfDesignSurface[i];
+            IDesignSurfaceExtended isurf = _listOfDesignSurface[i];
             _selectionService = (ISelectionService)(isurf.GetIDesignerHost().GetService(typeof(ISelectionService)));
             if (_selectionService is not null)
                 _selectionService.SelectionChanged += OnSelectionChanged;
@@ -60,7 +59,7 @@ public partial class MainForm : Form
         if (_selectionService is null)
             return;
 
-        IDesignSurfaceExt isurf = _listOfDesignSurface[tabControl1.SelectedIndex];
+        IDesignSurfaceExtended isurf = _listOfDesignSurface[tabControl1.SelectedIndex];
         if (isurf is not null)
         {
             ISelectionService selectionService = isurf.GetIDesignerHost().GetService(typeof(ISelectionService)) as ISelectionService;
@@ -72,7 +71,7 @@ public partial class MainForm : Form
     {
         // - step.0
         // - create a DesignSurface and put it inside a Form in DesignTime
-        DesignSurfaceExt.DesignSurfaceExt surface = new();
+        DesignSurfaceExtended surface = new();
         // -
         // -
         // - store for later use
@@ -442,7 +441,7 @@ public partial class MainForm : Form
     private void SelectRootComponent()
     {
         // - find out the DesignSurfaceExt control hosted by the TabPage
-        IDesignSurfaceExt isurf = _listOfDesignSurface[tabControl1.SelectedIndex];
+        IDesignSurfaceExtended isurf = _listOfDesignSurface[tabControl1.SelectedIndex];
         if (isurf is not null)
         {
             splitContainer.Panel2.Controls.Remove(propertyGrid);
@@ -465,13 +464,13 @@ public partial class MainForm : Form
 
     private void undoToolStripMenuItem_Click(object sender, EventArgs e)
     {
-        IDesignSurfaceExt isurf = _listOfDesignSurface[tabControl1.SelectedIndex];
+        IDesignSurfaceExtended isurf = _listOfDesignSurface[tabControl1.SelectedIndex];
         isurf?.GetUndoEngineExt().Undo();
     }
 
     private void redoToolStripMenuItem_Click(object sender, EventArgs e)
     {
-        IDesignSurfaceExt isurf = _listOfDesignSurface[tabControl1.SelectedIndex];
+        IDesignSurfaceExtended isurf = _listOfDesignSurface[tabControl1.SelectedIndex];
         isurf?.GetUndoEngineExt().Redo();
     }
 
@@ -483,7 +482,7 @@ public partial class MainForm : Form
     private void toolStripMenuItemTabOrder_Click(object sender, EventArgs e)
     {
         // - find out the DesignSurfaceExt control hosted by the TabPage
-        IDesignSurfaceExt isurf = _listOfDesignSurface[tabControl1.SelectedIndex];
+        IDesignSurfaceExtended isurf = _listOfDesignSurface[tabControl1.SelectedIndex];
         isurf?.SwitchTabOrder();
     }
 
@@ -504,7 +503,7 @@ public partial class MainForm : Form
 
     private void OnMenuClick(object sender, EventArgs e)
     {
-        IDesignSurfaceExt isurf = _listOfDesignSurface[tabControl1.SelectedIndex];
+        IDesignSurfaceExtended isurf = _listOfDesignSurface[tabControl1.SelectedIndex];
         isurf?.DoAction((sender as ToolStripMenuItem).Text);
     }
 }

--- a/src/test/integration/DesignSurface/DesignSurfaceExt/DesignSurfaceExt.cs
+++ b/src/test/integration/DesignSurface/DesignSurfaceExt/DesignSurfaceExt.cs
@@ -1,9 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace DesignSurfaceExt;
+namespace DemoConsole;
 
-public class DesignSurfaceExt : DesignSurface, IDesignSurfaceExt
+public class DesignSurfaceExtended : DesignSurface, IDesignSurfaceExtended
 {
     private const string Name = "DesignSurfaceExt";
 
@@ -73,7 +73,7 @@ public class DesignSurfaceExt : DesignSurface, IDesignSurfaceExt
         serviceProvider.AddService(typeof(DesignerOptionService), opsService2);
     }
 
-    public UndoEngineExt GetUndoEngineExt()
+    public UndoEngineExtended GetUndoEngineExt()
     {
         return _undoEngine;
     }
@@ -270,15 +270,15 @@ public class DesignSurfaceExt : DesignSurface, IDesignSurfaceExt
 
     #region  UndoEngine
 
-    private UndoEngineExt _undoEngine;
-    private NameCreationServiceImp _nameCreationService;
-    private DesignerSerializationServiceImpl _designerSerializationService;
+    private UndoEngineExtended _undoEngine;
+    private NameCreationService _nameCreationService;
+    private DesignerSerializationService _designerSerializationService;
     private CodeDomComponentSerializationService _codeDomComponentSerializationService;
 
     #endregion
 
     // - ctor
-    public DesignSurfaceExt()
+    public DesignSurfaceExtended()
     {
         InitServices();
     }
@@ -300,7 +300,7 @@ public class DesignSurfaceExt : DesignSurface, IDesignSurfaceExt
         // - otherwise the root component did not have a name and this caused
         // - troubles when we try to use the UndoEngine
         // - 1. NameCreationService
-        _nameCreationService = new NameCreationServiceImp();
+        _nameCreationService = new NameCreationService();
         ServiceContainer.RemoveService(typeof(INameCreationService), false);
         ServiceContainer.AddService(typeof(INameCreationService), _nameCreationService);
 
@@ -310,12 +310,12 @@ public class DesignSurfaceExt : DesignSurface, IDesignSurfaceExt
         ServiceContainer.AddService(typeof(ComponentSerializationService), _codeDomComponentSerializationService);
 
         // - 3. IDesignerSerializationService
-        _designerSerializationService = new DesignerSerializationServiceImpl(ServiceContainer);
+        _designerSerializationService = new DesignerSerializationService(ServiceContainer);
         ServiceContainer.RemoveService(typeof(IDesignerSerializationService), false);
         ServiceContainer.AddService(typeof(IDesignerSerializationService), _designerSerializationService);
 
         // - 4. UndoEngine
-        _undoEngine = new UndoEngineExt(ServiceContainer)
+        _undoEngine = new UndoEngineExtended(ServiceContainer)
         {
             // Disable the UndoEngine
             Enabled = false

--- a/src/test/integration/DesignSurface/DesignSurfaceExt/DesignerOptionServiceExt.cs
+++ b/src/test/integration/DesignSurface/DesignSurfaceExt/DesignerOptionServiceExt.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace DesignSurfaceExt;
+namespace DemoConsole;
 
 internal class DesignerOptionServiceBase : DesignerOptionService
 {

--- a/src/test/integration/DesignSurface/DesignSurfaceExt/DesignerSerializationServiceImpl.cs
+++ b/src/test/integration/DesignSurface/DesignSurfaceExt/DesignerSerializationServiceImpl.cs
@@ -1,13 +1,13 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace DesignSurfaceExt;
+namespace DemoConsole;
 
-internal sealed class DesignerSerializationServiceImpl : IDesignerSerializationService
+internal sealed class DesignerSerializationService : IDesignerSerializationService
 {
     private readonly IServiceProvider _serviceProvider;
 
-    public DesignerSerializationServiceImpl(IServiceProvider serviceProvider)
+    public DesignerSerializationService(IServiceProvider serviceProvider)
     {
         _serviceProvider = serviceProvider;
     }

--- a/src/test/integration/DesignSurface/DesignSurfaceExt/IDesignSurfaceExt.cs
+++ b/src/test/integration/DesignSurface/DesignSurfaceExt/IDesignSurfaceExt.cs
@@ -1,9 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace DesignSurfaceExt;
+namespace DemoConsole;
 
-public interface IDesignSurfaceExt
+public interface IDesignSurfaceExtended
 {
     // - perform Cut/Copy/Paste/Delete commands
     void DoAction(string command);
@@ -25,7 +25,7 @@ public interface IDesignSurfaceExt
         where TControl : Control;
 
     // - Get the UndoEngineExtended object
-    UndoEngineExt GetUndoEngineExt();
+    UndoEngineExtended GetUndoEngineExt();
 
     // - Get the IDesignerHost of the .NET 2.0 DesignSurface
     IDesignerHost GetIDesignerHost();

--- a/src/test/integration/DesignSurface/DesignSurfaceExt/NameCreationServiceImp.cs
+++ b/src/test/integration/DesignSurface/DesignSurfaceExt/NameCreationServiceImp.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace DesignSurfaceExt;
+namespace DemoConsole;
 
 /// <summary>
 /// Implements <see cref="INameCreationService"/> to provide names for newly created controls.
@@ -13,7 +13,7 @@ namespace DesignSurfaceExt;
 ///   it increments an integer counter until it finds a unique name that is not already in use.
 ///  </para>
 /// </remarks>
-internal sealed class NameCreationServiceImp : INameCreationService
+internal sealed class NameCreationService : INameCreationService
 {
     public string CreateName(IContainer container, Type type)
     {

--- a/src/test/integration/DesignSurface/DesignSurfaceExt/PropertyGridExt.cs
+++ b/src/test/integration/DesignSurface/DesignSurfaceExt/PropertyGridExt.cs
@@ -1,10 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace DesignSurfaceExt;
+namespace DemoConsole;
 
 [DesignerCategory("Default")]
-public class PropertyGridExt : PropertyGrid
+public class PropertyGridExtended : PropertyGrid
 {
     private IDesignerHost _host;
     private IComponentChangeService _componentChangeService;

--- a/src/test/integration/DesignSurface/DesignSurfaceExt/TabOrderHooker.cs
+++ b/src/test/integration/DesignSurface/DesignSurfaceExt/TabOrderHooker.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace DesignSurfaceExt;
+namespace DemoConsole;
 
 public class TabOrderHooker
 {

--- a/src/test/integration/DesignSurface/DesignSurfaceExt/UndoEngineExt.cs
+++ b/src/test/integration/DesignSurface/DesignSurfaceExt/UndoEngineExt.cs
@@ -1,14 +1,14 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace DesignSurfaceExt;
+namespace DemoConsole;
 
-public class UndoEngineExt : UndoEngine
+public class UndoEngineExtended : UndoEngine
 {
     private readonly Stack<UndoUnit> _undoStack = new();
     private readonly Stack<UndoUnit> _redoStack = new();
 
-    public UndoEngineExt(IServiceProvider provider) : base(provider) { }
+    public UndoEngineExtended(IServiceProvider provider) : base(provider) { }
 
     public bool EnableUndo
     {


### PR DESCRIPTION
Related #13388

## Proposed changes

- Unifies `DesignSurfaceExt` and `DemoConsole` namespaces under the latter.
- Renames class names where appropriate to reflect the shared project identity, in preparation for relocating all files into the `DemoConsole` folder in a follow-up PR.

## Customer Impact

- None

## Regression?

- No

## Risk

- Minimal

## Test environment(s)

- 10.0.100-preview.3.25201.16
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13433)