### PR TITLE
Issue 10773 Adds code coverage for public members of `ChangeToolStripParentVerb`.

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/Mocks/MockSite.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/Mocks/MockSite.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable

--- a/src/System.Windows.Forms.Design/tests/UnitTests/Mocks/MockSite.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/Mocks/MockSite.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -11,9 +11,9 @@ namespace System.Windows.Forms.Design.Tests.Mocks
 {
     public class MockSite
     {
-        public static Mock<ISite> CreateMockSiteWithDesignerHost(object designerHost)
+        public static Mock<ISite> CreateMockSiteWithDesignerHost(object designerHost, MockBehavior mockBehavior = MockBehavior.Strict)
         {
-            Mock<ISite> mockSite = new(MockBehavior.Strict);
+            Mock<ISite> mockSite = new(mockBehavior);
             mockSite
                 .Setup(s => s.GetService(typeof(IDesignerHost)))
                 .Returns(designerHost);
@@ -51,7 +51,7 @@ namespace System.Windows.Forms.Design.Tests.Mocks
                 .Setup(s => s.GetService(typeof(ToolStripMenuItem)))
                 .Returns(null);
 
-            Mock<IServiceProvider> mockServiceProvider = new(MockBehavior.Strict);
+            Mock<IServiceProvider> mockServiceProvider = new(mockBehavior);
 
             mockSite
                 .Setup(s => s.GetService(typeof(IServiceProvider)))

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ChangeToolStripParentVerbTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ChangeToolStripParentVerbTests.cs
@@ -3,63 +3,115 @@
 
 using System.ComponentModel;
 using System.ComponentModel.Design;
+using System.Windows.Forms.Design.Behavior;
+using System.Windows.Forms.Design.Tests.Mocks;
 using Moq;
 
 namespace System.Windows.Forms.Design.Tests;
 
 public class ChangeToolStripParentVerbTests : IDisposable
 {
+    private DesignerActionService? _designerActionService;
+    private DesignerActionUIService? _designerActionUIService;
+    private BehaviorService? _behaviorService;
     private readonly Mock<IDesignerHost> _designerHostMock = new();
     private readonly Mock<IServiceProvider> _serviceProviderMock = new();
-    private readonly Mock<ISite> _siteMock = new();
+    private readonly Mock<ISelectionService> _mockSelectionService = new();
+    private Mock<ISite>? _siteMock;
     private readonly Mock<IComponentChangeService> _componentChangeServiceMock = new()  ;
+    private readonly Mock<DesignerTransaction> _mockTransaction = new(MockBehavior.Loose);
+    private readonly ParentControlDesigner _parentControlDesigner = new();
     private readonly ToolStripDesigner _designer = new();
     private ToolStrip _toolStrip = new();
 
     public void Dispose()
     {
         _toolStrip?.Dispose();
+        _parentControlDesigner.Dispose();
+        _designerActionService?.Dispose();
+        _designerActionUIService?.Dispose();
+        _behaviorService.Dispose();
         _designer.Dispose();
     }
 
     private ToolStrip MockMinimalControl()
     {
-        Mock<ISelectionService> mockSelectionService = new();
-        _siteMock
-            .Setup(s => s.GetService(typeof(ISelectionService)))
-            .Returns(mockSelectionService.Object);
-        _siteMock
-            .Setup(s => s.GetService(typeof(IDesignerHost)))
-            .Returns(_designerHostMock.Object);
-        _serviceProviderMock
-            .Setup(s => s.GetService(typeof(IDesignerHost)))
-            .Returns(_designerHostMock.Object);
-        _serviceProviderMock
-            .Setup(s => s.GetService(typeof(IComponentChangeService)))
-            .Returns(new Mock<IComponentChangeService>().Object);
-        _designerHostMock
-            .Setup(dh => dh.GetService(typeof(IComponentChangeService)))
-            .Returns(_componentChangeServiceMock.Object);
-        _designerHostMock
-            .Setup(dh => dh.GetDesigner(It.IsAny<IComponent>()))
-            .Returns(new Mock<ParentControlDesigner>().Object);
+        _mockSelectionService.Setup(s => s.GetComponentSelected(_toolStrip)).Returns(true);
+        _siteMock = MockSite.CreateMockSiteWithDesignerHost(_designerHostMock.Object, MockBehavior.Loose);
+        _siteMock.Setup(s => s.GetService(typeof(ISelectionService))).Returns(_mockSelectionService.Object);
+        _siteMock.Setup(s => s.GetService(typeof(IDesignerHost))).Returns(_designerHostMock.Object);
+        _siteMock.Setup(s => s.GetService(typeof(IComponentChangeService))).Returns(_componentChangeServiceMock.Object);
+        _behaviorService = new (_serviceProviderMock.Object, new DesignerFrame(_siteMock.Object));
+        _siteMock.Setup(s => s.GetService(typeof(BehaviorService))).Returns(_behaviorService);
+        _siteMock.Setup(s => s.GetService(typeof(ToolStripAdornerWindowService))).Returns(null!);
+        _designerActionService = new (_siteMock.Object);
+        _siteMock.Setup(s => s.GetService(typeof(DesignerActionService))).Returns(_designerActionService);
 
-        ToolStrip toolStrip = new() { Site = _siteMock.Object };
+        _siteMock.Setup(s => s.GetService(typeof(IDesignerHost))).Returns(_designerHostMock.Object);
+        _designerActionUIService = new(_siteMock.Object);
+        _siteMock.Setup(s => s.GetService(typeof(DesignerActionUIService))).Returns(_designerActionUIService);
 
-        return toolStrip;
+        _serviceProviderMock.Setup(s => s.GetService(typeof(IDesignerHost))).Returns(_designerHostMock.Object);
+        _serviceProviderMock.Setup(s => s.GetService(typeof(IComponentChangeService))).Returns(new Mock<IComponentChangeService>().Object);
+        _designerHostMock.Setup(h => h.RootComponent).Returns(_toolStrip);
+        _designerHostMock.Setup(h => h.RootComponent).Returns(_toolStrip);
+        _designerHostMock.Setup(h => h.CreateTransaction(It.IsAny<string>())).Returns(_mockTransaction.Object);
+        _designerHostMock.Setup(h => h.GetService(typeof(IComponentChangeService))).Returns(_componentChangeServiceMock.Object);
+        _designerHostMock.Setup(h => h.AddService(typeof(ToolStripKeyboardHandlingService), It.IsAny<object>()));
+        _designerHostMock.Setup(h => h.AddService(typeof(ISupportInSituService), It.IsAny<object>()));
+        _designerHostMock.Setup(h => h.AddService(typeof(DesignerActionService), It.IsAny<object>()));
+        _designerHostMock.Setup(h => h.GetDesigner(_toolStrip)).Returns(_parentControlDesigner);
+        _designerHostMock.Setup(h => h.AddService(typeof(DesignerActionUIService), It.IsAny<object>()));
+
+        _toolStrip.Site = _siteMock.Object;
+        return _toolStrip;
     }
 
     [Fact]
-    public void ChangeParent_WithoutDesignerActionUIService_DoesNotChangeParent()
+    public void ChangeParent_WithNullParent_ChangesParentToToolStripPanel()
     {
-        Control? oldParent = _toolStrip.Parent;
         _toolStrip = MockMinimalControl();
+        Control? oldParent = _toolStrip.Parent;
+        _parentControlDesigner.Initialize(_toolStrip);
         _designer.Initialize(_toolStrip);
-
         ChangeToolStripParentVerb changeToolStripParentVerb = new(_designer);
 
         changeToolStripParentVerb.ChangeParent();
-        Control? newParent = _toolStrip.Parent;
-        newParent.Should().Be(oldParent);
+
+        _toolStrip.Parent.Should().NotBe(oldParent);
+        _toolStrip.Parent.Should().BeOfType<ToolStripPanel>();
+    }
+
+    [Fact]
+    public void ChangeParent_WithParent_ChangesParentToToolStripContentPanel()
+    {
+        _toolStrip = MockMinimalControl();
+        _toolStrip.Parent = new ToolStripPanel();
+        Control oldParent = _toolStrip.Parent;
+        _parentControlDesigner.Initialize(_toolStrip);
+        _designer.Initialize(_toolStrip);
+        ChangeToolStripParentVerb changeToolStripParentVerb = new(_designer);
+
+        changeToolStripParentVerb.ChangeParent();
+        _toolStrip.Parent.Should().NotBe(oldParent);
+        _toolStrip.Parent.Should().BeOfType<ToolStripContentPanel>();
+    }
+
+    [Fact]
+    public void ChangeParent_WhenDesignerActionUIServiceIsNull_DoesNotChangeParent()
+    {
+        _toolStrip = MockMinimalControl();
+        _toolStrip.Parent = new ToolStripPanel();
+        _parentControlDesigner.Initialize(_toolStrip);
+        _designer.Initialize(_toolStrip);
+
+        _siteMock.Setup(s => s.GetService(typeof(DesignerActionUIService))).Returns(null);
+
+        Control oldParent = _toolStrip.Parent;
+        var changeToolStripParentVerb = new ChangeToolStripParentVerb(_designer);
+
+        changeToolStripParentVerb.ChangeParent();
+
+        _toolStrip.Parent.Should().Be(oldParent);
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ChangeToolStripParentVerbTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ChangeToolStripParentVerbTests.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+using System.ComponentModel.Design;
+using Moq;
+
+namespace System.Windows.Forms.Design.Tests;
+
+public class ChangeToolStripParentVerbTests : IDisposable
+{
+    private readonly ToolStripDesigner _designer = new();
+    private readonly ToolStrip _toolStrip;
+
+    public ChangeToolStripParentVerbTests()
+    {
+        _toolStrip = MockToolStrip();
+        _designer.Initialize(_toolStrip);
+    }
+
+    public void Dispose()
+    {
+        _toolStrip?.Dispose();
+        _designer.Dispose();
+    }
+
+    private ToolStrip MockToolStrip()
+    {
+        Mock<ISite> mockSite = new();
+        Mock<ISelectionService> mockSelectionService = new();
+        mockSite.Setup(s => s.GetService(typeof(ISelectionService))).Returns(mockSelectionService.Object);
+
+        Mock<IDesignerHost> mockDesignerHost = new();
+        mockSite.Setup(s => s.GetService(typeof(IDesignerHost))).Returns(mockDesignerHost.Object);
+
+        Mock<IComponentChangeService> mockComponentChangeService = new();
+        mockDesignerHost
+            .Setup(dh => dh.GetService(typeof(IComponentChangeService)))
+            .Returns(mockComponentChangeService.Object);
+
+        ToolStrip toolStrip = new() { Site = mockSite.Object };
+
+        return toolStrip;
+    }
+
+    [Fact]
+    public void Constructor_WithNullDesigner_Throws()
+    {
+        Action action = () => new ChangeToolStripParentVerb(null);
+
+        action.Should().Throw<Exception>();
+    }
+
+    [Fact]
+    public void ChangeParent_DeepestPossibleTest()
+    {
+        var changeToolStripParentVerb = new ChangeToolStripParentVerb(_designer);
+
+        changeToolStripParentVerb.ChangeParent();
+
+        throw new NotImplementedException();
+    }
+
+    [Fact]
+    public void ChangeParent_WithNullRootDesigner_DoesNotChangesParent()
+    {
+        var changeToolStripParentVerb = new ChangeToolStripParentVerb(_designer);
+
+        changeToolStripParentVerb.ChangeParent();
+
+        throw new NotImplementedException();
+    }
+}

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ChangeToolStripParentVerbTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ChangeToolStripParentVerbTests.cs
@@ -30,7 +30,7 @@ public class ChangeToolStripParentVerbTests : IDisposable
         _parentControlDesigner.Dispose();
         _designerActionService?.Dispose();
         _designerActionUIService?.Dispose();
-        _behaviorService.Dispose();
+        _behaviorService!.Dispose();
         _designer.Dispose();
     }
 
@@ -41,10 +41,10 @@ public class ChangeToolStripParentVerbTests : IDisposable
         _siteMock.Setup(s => s.GetService(typeof(ISelectionService))).Returns(_mockSelectionService.Object);
         _siteMock.Setup(s => s.GetService(typeof(IDesignerHost))).Returns(_designerHostMock.Object);
         _siteMock.Setup(s => s.GetService(typeof(IComponentChangeService))).Returns(_componentChangeServiceMock.Object);
-        _behaviorService = new (_serviceProviderMock.Object, new DesignerFrame(_siteMock.Object));
+        _behaviorService = new(_serviceProviderMock.Object, new DesignerFrame(_siteMock.Object));
         _siteMock.Setup(s => s.GetService(typeof(BehaviorService))).Returns(_behaviorService);
         _siteMock.Setup(s => s.GetService(typeof(ToolStripAdornerWindowService))).Returns(null!);
-        _designerActionService = new (_siteMock.Object);
+        _designerActionService = new(_siteMock.Object);
         _siteMock.Setup(s => s.GetService(typeof(DesignerActionService))).Returns(_designerActionService);
 
         _siteMock.Setup(s => s.GetService(typeof(IDesignerHost))).Returns(_designerHostMock.Object);
@@ -105,7 +105,7 @@ public class ChangeToolStripParentVerbTests : IDisposable
         _parentControlDesigner.Initialize(_toolStrip);
         _designer.Initialize(_toolStrip);
 
-        _siteMock.Setup(s => s.GetService(typeof(DesignerActionUIService))).Returns(null);
+        _siteMock!.Setup(s => s.GetService(typeof(DesignerActionUIService))).Returns(null!);
 
         Control oldParent = _toolStrip.Parent;
         var changeToolStripParentVerb = new ChangeToolStripParentVerb(_designer);

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ChangeToolStripParentVerbTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ChangeToolStripParentVerbTests.cs
@@ -62,12 +62,4 @@ public class ChangeToolStripParentVerbTests : IDisposable
         Control? newParent = _toolStrip.Parent;
         newParent.Should().Be(oldParent);
     }
-
-    [Fact]
-    public void Constructor_WithNullDesigner_Throws()
-    {
-        Action action = () => new ChangeToolStripParentVerb(null);
-
-        action.Should().Throw<Exception>();
-    }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related #10773

## Proposed changes

- Adds code coverage for public members of `ChangeToolStripParentVerb`.

## Customer Impact

- None

## Regression?

- No

## Risk

- Minimal

## Test methodology

- Unit tests

## Test environment(s)

- 10.0.100-preview.3.25201.16

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13445)