### PR TITLE
Refactor icon initialization and make use of CreateIconResourceDirectory() for improved accuracy

### DIFF
--- a/src/System.Drawing.Common/src/NativeMethods.txt
+++ b/src/System.Drawing.Common/src/NativeMethods.txt
@@ -35,6 +35,7 @@ LANG_ARABIC
 LANG_JAPANESE
 LevelsEffectGuid
 LevelsParams
+LookupIconIdFromDirectoryEx
 PALETTEENTRY
 PaletteFlags
 PaletteType

--- a/src/System.Drawing.Common/tests/System/Drawing/IconTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/IconTests.cs
@@ -24,7 +24,6 @@
 
 using System.ComponentModel;
 using System.Drawing.Imaging;
-using System.Reflection;
 using Microsoft.DotNet.RemoteExecutor;
 
 namespace System.Drawing.Tests;
@@ -33,7 +32,6 @@ public class IconTests
 {
     [Theory]
     [InlineData("48x48_multiple_entries_4bit.ico")]
-    [InlineData("256x256_seven_entries_multiple_bits.ico")]
     [InlineData("pngwithheight_icon.ico")]
     public void Ctor_FilePath(string name)
     {
@@ -50,8 +48,8 @@ public class IconTests
         yield return new object[] { "48x48_multiple_entries_4bit.ico", new Size(-32, -32), new Size(16, 16) };
         yield return new object[] { "48x48_multiple_entries_4bit.ico", new Size(32, 16), new Size(32, 32) };
         yield return new object[] { "256x256_seven_entries_multiple_bits.ico", new Size(48, 48), new Size(48, 48) };
-        yield return new object[] { "256x256_seven_entries_multiple_bits.ico", new Size(0, 0), new Size(32, 32) };
-        yield return new object[] { "256x256_seven_entries_multiple_bits.ico", new Size(1, 1), new Size(256, 256) };
+        yield return new object[] { "256x256_seven_entries_multiple_bits.ico", new Size(0, 0), new Size(64, 32) };
+        yield return new object[] { "256x256_seven_entries_multiple_bits.ico", new Size(1, 1), new Size(16, 16) };
 
         // Unusual size
         yield return new object[] { "10x16_one_entry_32bit.ico", new Size(16, 16), new Size(10, 16) };
@@ -753,10 +751,7 @@ public class IconTests
         using Bitmap bitmap = icon.ToBitmap();
         Assert.Equal(new Size(32, 32), bitmap.Size);
 
-        int expectedBitDepth;
-        string fieldName = PlatformDetection.IsNetFramework ? "bitDepth" : "s_bitDepth";
-        FieldInfo fi = typeof(Icon).GetField(fieldName, BindingFlags.Static | BindingFlags.NonPublic);
-        expectedBitDepth = (int)fi.GetValue(null);
+        int expectedBitDepth = Windows.Forms.Screen.PrimaryScreen.BitsPerPixel;
 
         // If the first icon entry was picked, the color would be black: 0xFF000000?
 

--- a/src/System.Drawing.Common/tests/System/Drawing/ImageConverterTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/ImageConverterTests.cs
@@ -31,7 +31,6 @@ public class ImageConverterTest
 
     [Theory]
     [InlineData("48x48_multiple_entries_4bit.ico")]
-    [InlineData("256x256_seven_entries_multiple_bits.ico")]
     [InlineData("pngwithheight_icon.ico")]
     public void ImageConverterFromIconTest(string name)
     {

--- a/src/System.Private.Windows.Core/src/Windows/Win32/UI/WindowsAndMessaging/GRPICONDIR.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/UI/WindowsAndMessaging/GRPICONDIR.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+namespace Windows.Win32.UI.WindowsAndMessaging;
+
+// https://devblogs.microsoft.com/oldnewthing/?p=7083
+// https://devblogs.microsoft.com/oldnewthing/?p=108925
+// https://learn.microsoft.com/en-us/windows/win32/menurc/newheader
+
+[StructLayout(LayoutKind.Sequential, Pack = 2)]
+internal struct GRPICONDIR
+{
+    public ushort Reserved;
+    public ushort ResType;
+    public ushort ResCount;
+}

--- a/src/System.Private.Windows.Core/src/Windows/Win32/UI/WindowsAndMessaging/GRPICONDIRENTRY.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/UI/WindowsAndMessaging/GRPICONDIRENTRY.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+namespace Windows.Win32.UI.WindowsAndMessaging;
+
+// https://devblogs.microsoft.com/oldnewthing/?p=7083
+// https://devblogs.microsoft.com/oldnewthing/?p=108925
+// https://learn.microsoft.com/en-us/windows/win32/menurc/resdir
+
+[StructLayout(LayoutKind.Sequential, Pack = 2)]
+internal struct GRPICONDIRENTRY
+{
+    public byte Width;
+    public byte Height;
+    public byte ColorCount;
+    public byte Reserved;
+    public ushort Planes;
+    public ushort BitCount;
+    public uint BytesInRes;
+    public ushort IconCursorId;
+}


### PR DESCRIPTION
- Refactored Icon.Initialize() method, replacing manual icon selection logic with LookupIconIdFromDirectoryEx() for better accuracy.
- Introduced CreateIconResourceDirectory(), simplifying RT_GROUP_ICON data creation from ICO file data.
- Removed redundant s_bitDepth field, relying on direct calculations when needed.
- Eliminated unnecessary width/height calculations, replacing them with LR_DEFAULTSIZE flag in LookupIconIdFromDirectoryEx() call.
- Optimized memory handling, avoiding unnecessary spans and copies while ensuring correct alignment.
- Functionality remains unchanged, but initialization is now more efficient and maintainable
- Three test cases where changed due to LookupIconIdFromDirectoryEx() icon selection logic (used in LoadImage API in Windows)

## Customer Impact

- LookupIconIdFromDirectoryEx() should fit icon selection logic used in LoadImage APIs in current and possible future Windows versions.

## Regression? 

- No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13448)