### PR TITLE
Optimize icon rendering: refactor DrawIcon helper and add unit tests

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Icon.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Icon.cs
@@ -269,124 +269,44 @@ public sealed unsafe partial class Icon : MarshalByRefObject, ICloneable, IDispo
     // object, but a graphics object generally has no idea how to render a given image. So,
     // it passes the call to the actual image. This version crops the image to the given
     // dimensions and allows the user to specify a rectangle within the image to draw.
-    private void DrawIcon(HDC hdc, Rectangle imageRect, Rectangle targetRect, bool stretch)
+    private void DrawIcon(Graphics graphics, Rectangle targetRect, bool stretch)
     {
-        int imageX = 0;
-        int imageY = 0;
-        int imageWidth;
-        int imageHeight;
-        int targetX = 0;
-        int targetY = 0;
-        int targetWidth;
-        int targetHeight;
+        Size iconSize = Size;
+        if (targetRect.IsEmpty)
+            targetRect = new Rectangle(Point.Empty, iconSize);
 
-        Size cursorSize = Size;
+        // Apply the GDI+ world transform translation (without allocating a Matrix object).
+        // Truncation reproduces the historical (int)-cast behavior, consistent with Cursor.
+        Vector2 translation = graphics.TransformElements.Translation;
+        targetRect.Offset((int)translation.X, (int)translation.Y);
 
-        // Compute the dimensions of the icon if needed.
-        if (!imageRect.IsEmpty)
-        {
-            imageX = imageRect.X;
-            imageY = imageRect.Y;
-            imageWidth = imageRect.Width;
-            imageHeight = imageRect.Height;
-        }
-        else
-        {
-            imageWidth = cursorSize.Width;
-            imageHeight = cursorSize.Height;
-        }
-
-        if (!targetRect.IsEmpty)
-        {
-            targetX = targetRect.X;
-            targetY = targetRect.Y;
-            targetWidth = targetRect.Width;
-            targetHeight = targetRect.Height;
-        }
-        else
-        {
-            targetWidth = cursorSize.Width;
-            targetHeight = cursorSize.Height;
-        }
-
-        int drawWidth, drawHeight;
-        int clipWidth, clipHeight;
-
-        if (stretch)
-        {
-            drawWidth = cursorSize.Width * targetWidth / imageWidth;
-            drawHeight = cursorSize.Height * targetHeight / imageHeight;
-            clipWidth = targetWidth;
-            clipHeight = targetHeight;
-        }
-        else
-        {
-            drawWidth = cursorSize.Width;
-            drawHeight = cursorSize.Height;
-            clipWidth = targetWidth < imageWidth ? targetWidth : imageWidth;
-            clipHeight = targetHeight < imageHeight ? targetHeight : imageHeight;
-        }
-
-        // The ROP is SRCCOPY, so we can be simple here and take
-        // advantage of clipping regions. Drawing the cursor
-        // is merely a matter of offsetting and clipping.
+        // The ROP is SRCCOPY, so we can be simple here and take advantage of clipping regions.
+        // Drawing the icon is merely a matter of offsetting and clipping.
+        using DeviceContextHdcScope hdc = new(graphics, ApplyGraphicsProperties.Clipping);
         using RegionScope clippingRegion = new(hdc);
-        try
+
+        Rectangle drawRect = targetRect;
+        Rectangle clipRect = targetRect;
+
+        if (!stretch)
         {
-            PInvokeCore.IntersectClipRect(hdc, targetX, targetY, targetX + clipWidth, targetY + clipHeight);
-            PInvokeCore.DrawIconEx(
-                hdc,
-                targetX - imageX,
-                targetY - imageY,
-                this,
-                drawWidth,
-                drawHeight);
+            drawRect.Size = iconSize;
+            // Clip to the smaller of the target and the native icon size.
+            clipRect.Size = new(
+                Math.Min(targetRect.Width, iconSize.Width),
+                Math.Min(targetRect.Height, iconSize.Height));
         }
-        finally
-        {
-            // We need to delete the region handle after restoring the region as GDI+ uses a copy of the handle.
-            PInvokeCore.SelectClipRgn(hdc, clippingRegion);
-        }
+
+        PInvokeCore.IntersectClipRect(hdc, clipRect.Left, clipRect.Top, clipRect.Right, clipRect.Bottom);
+        PInvokeCore.DrawIconEx(hdc, drawRect.X, drawRect.Y, this, drawRect.Width, drawRect.Height);
+        PInvokeCore.SelectClipRgn(hdc, clippingRegion);
     }
 
-    internal void Draw(Graphics graphics, int x, int y)
-    {
-        Size size = Size;
-        Draw(graphics, new Rectangle(x, y, size.Width, size.Height));
-    }
+    internal void Draw(Graphics graphics, int x, int y) => DrawIcon(graphics, new Rectangle(x, y, Size.Width, Size.Height), stretch: true);
 
-    // Draws this image to a graphics object. The drawing command originates on the graphics
-    // object, but a graphics object generally has no idea how to render a given image. So,
-    // it passes the call to the actual image. This version stretches the image to the given
-    // dimensions and allows the user to specify a rectangle within the image to draw.
-    internal void Draw(Graphics graphics, Rectangle targetRect)
-    {
-        Rectangle copy = targetRect;
+    internal void Draw(Graphics graphics, Rectangle targetRect) => DrawIcon(graphics, targetRect, stretch: true);
 
-        using Matrix transform = graphics.Transform;
-        PointF offset = transform.Offset;
-        copy.X += (int)offset.X;
-        copy.Y += (int)offset.Y;
-
-        using DeviceContextHdcScope hdc = new(graphics, ApplyGraphicsProperties.Clipping);
-        DrawIcon(hdc, Rectangle.Empty, copy, true);
-    }
-
-    // Draws this image to a graphics object. The drawing command originates on the graphics
-    // object, but a graphics object generally has no idea how to render a given image. So,
-    // it passes the call to the actual image. This version crops the image to the given
-    // dimensions and allows the user to specify a rectangle within the image to draw.
-    internal void DrawUnstretched(Graphics graphics, Rectangle targetRect)
-    {
-        Rectangle copy = targetRect;
-        using Matrix transform = graphics.Transform;
-        PointF offset = transform.Offset;
-        copy.X += (int)offset.X;
-        copy.Y += (int)offset.Y;
-
-        using DeviceContextHdcScope hdc = new(graphics, ApplyGraphicsProperties.Clipping);
-        DrawIcon(hdc, Rectangle.Empty, copy, false);
-    }
+    internal void DrawUnstretched(Graphics graphics, Rectangle targetRect) => DrawIcon(graphics, targetRect, stretch: false);
 
     ~Icon() => Dispose();
 

--- a/src/System.Drawing.Common/tests/System/Drawing/Icon_DrawTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/Icon_DrawTests.cs
@@ -1,0 +1,151 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Windows.Win32;
+using Windows.Win32.Graphics.Gdi;
+
+namespace System.Drawing.Tests;
+
+public class Icon_DrawTests
+{
+    private const string TestIcon = "48x48_multiple_entries_4bit.ico";
+
+    public static IEnumerable<object[]> Draw_TestData()
+    {
+        // Empty rectangle
+        yield return new object[] { Rectangle.Empty };
+        // Normal rectangle at origin
+        yield return new object[] { new Rectangle(0, 0, 32, 32) };
+        // Normal rectangle with offset
+        yield return new object[] { new Rectangle(10, 20, 64, 64) };
+        // Rectangle smaller than icon
+        yield return new object[] { new Rectangle(5, 5, 16, 16) };
+        // Oversized rectangle
+        yield return new object[] { new Rectangle(0, 0, 200, 200) };
+    }
+
+    [Theory]
+    [MemberData(nameof(Draw_TestData))]
+    public void Graphics_DrawIcon_Invoke_Success(Rectangle targetRect)
+    {
+        using Icon icon = new(Helpers.GetTestBitmapPath(TestIcon));
+        using Bitmap image = new(100, 100);
+        using Graphics graphics = Graphics.FromImage(image);
+        graphics.DrawIcon(icon, targetRect);
+    }
+
+    [Theory]
+    [MemberData(nameof(Draw_TestData))]
+    public void Graphics_DrawIconUnstretched_Invoke_Success(Rectangle targetRect)
+    {
+        using Icon icon = new(Helpers.GetTestBitmapPath(TestIcon));
+        using Bitmap image = new(100, 100);
+        using Graphics graphics = Graphics.FromImage(image);
+        graphics.DrawIconUnstretched(icon, targetRect);
+    }
+
+    [Fact]
+    public void Graphics_DrawIcon_IntInt_Success()
+    {
+        using Icon icon = new(Helpers.GetTestBitmapPath(TestIcon));
+        using Bitmap image = new(100, 100);
+        using Graphics graphics = Graphics.FromImage(image);
+        graphics.DrawIcon(icon, 10, 20);
+    }
+
+    [Fact]
+    public void Graphics_DrawIcon_NullIcon_ThrowsArgumentNullException()
+    {
+        using Bitmap image = new(10, 10);
+        using Graphics graphics = Graphics.FromImage(image);
+        AssertExtensions.Throws<ArgumentNullException>("icon", () => graphics.DrawIcon(null, 0, 0));
+        AssertExtensions.Throws<ArgumentNullException>("icon", () => graphics.DrawIcon(null, Rectangle.Empty));
+        AssertExtensions.Throws<ArgumentNullException>("icon", () => graphics.DrawIconUnstretched(null, Rectangle.Empty));
+    }
+
+    // --- Group B: Direct internal Icon.Draw / DrawUnstretched on screen DC (exercises the GDI helper) ---
+
+    [Theory]
+    [MemberData(nameof(Draw_TestData))]
+    public void Icon_Draw_InvokeOnScreenDC_DoesNotThrow(Rectangle targetRect)
+    {
+        using Icon icon = new(Helpers.GetTestBitmapPath(TestIcon));
+        using GetDcScope hdc = new(PInvokeCore.GetDesktopWindow());
+        using Graphics graphics = Graphics.FromHdcInternal(hdc);
+        icon.Draw(graphics, targetRect);
+    }
+
+    [Theory]
+    [MemberData(nameof(Draw_TestData))]
+    public void Icon_DrawUnstretched_InvokeOnScreenDC_DoesNotThrow(Rectangle targetRect)
+    {
+        using Icon icon = new(Helpers.GetTestBitmapPath(TestIcon));
+        using GetDcScope hdc = new(PInvokeCore.GetDesktopWindow());
+        using Graphics graphics = Graphics.FromHdcInternal(hdc);
+        icon.DrawUnstretched(graphics, targetRect);
+    }
+
+    [Fact]
+    public void Icon_Draw_InvokeOnScreenDC_NotBlank()
+    {
+        using Icon icon = new(Helpers.GetTestBitmapPath("32x32_one_entry_4bit.ico"));
+        using Bitmap bitmap = new(100, 100);
+        using Graphics graphics = Graphics.FromImage(bitmap);
+
+        // Draw the icon at an offset within the bitmap.
+        icon.Draw(graphics, new Rectangle(10, 20, 32, 32));
+
+        // Verify that drawing produced non-blank pixels.
+        Helpers.VerifyBitmapNotBlank(bitmap);
+    }
+
+    // --- Group C: Transform offset ---
+
+    [Fact]
+    public void Icon_Draw_TranslateTransform_DoesNotThrow()
+    {
+        using Icon icon = new(Helpers.GetTestBitmapPath(TestIcon));
+        using Bitmap image = new(100, 100);
+        using Graphics graphics = Graphics.FromImage(image);
+
+        // Non-integer translation to exercise the offset calculation.
+        graphics.TranslateTransform(5.4f, 7.6f);
+        icon.Draw(graphics, new Rectangle(0, 0, 32, 32));
+    }
+
+    [Fact]
+    public void Icon_DrawUnstretched_TranslateTransform_DoesNotThrow()
+    {
+        using Icon icon = new(Helpers.GetTestBitmapPath(TestIcon));
+        using Bitmap image = new(100, 100);
+        using Graphics graphics = Graphics.FromImage(image);
+
+        graphics.TranslateTransform(5.4f, 7.6f);
+        icon.DrawUnstretched(graphics, new Rectangle(0, 0, 32, 32));
+    }
+
+    // --- Group D: Empty target defaults to native icon size ---
+
+    [Fact]
+    public void Icon_Draw_EmptyTarget_UsesNativeSize()
+    {
+        using Icon icon = new(Helpers.GetTestBitmapPath(TestIcon));
+        using Bitmap image = new(100, 100);
+        using Graphics graphics = Graphics.FromImage(image);
+
+        // Empty rectangle should be treated as the native icon size (32x32).
+        icon.Draw(graphics, Rectangle.Empty);
+        Helpers.VerifyBitmapNotBlank(image);
+    }
+
+    [Fact]
+    public void Icon_DrawUnstretched_EmptyTarget_UsesNativeSize()
+    {
+        using Icon icon = new(Helpers.GetTestBitmapPath(TestIcon));
+        using Bitmap image = new(100, 100);
+        using Graphics graphics = Graphics.FromImage(image);
+
+        icon.DrawUnstretched(graphics, Rectangle.Empty);
+        Helpers.VerifyBitmapNotBlank(image);
+    }
+}


### PR DESCRIPTION
- Remove unused imageRect parameter from private DrawIcon helper
- Fix clipping regression: use correct clip calculations for stretch and
  unstretched modes matching the original behavior
- Replace graphics.Transform.Offset (allocates Matrix) with
  graphics.TransformElements.Translation (allocation-free, consistent with
  the existing pattern in GraphicsContext)
- Use Point.Truncate instead of Point.Round for transform offset to match
  the historical (int)-cast behavior and Cursor.DrawImageCore
- Collapse Draw/DrawUnstretched into single-line expression bodies

Add 27 unit tests covering:
- Public Graphics.DrawIcon/DrawIconUnstretched contract (null checks, various rects)
- Direct internal Icon.Draw/DrawUnstretched on screen DC (exercises the GDI helper)
- Non-integer transform offsets (TranslateTransform with fractional values)
- Empty target rect defaulting to native icon size

Future work (separate PRs):
- Move the drawing helper into the Graphics class
- Unify with Cursor.DrawImageCore to share the common clipping logic
- Remove Icon.Draw/DrawUnstretched wrappers after the helper moves to Graphics

