### PR TITLE
Fix 13247 by removing unnecessary judgment from method Serialize of DemoConsole.DesignerSerializationService

### DIFF
--- a/src/test/integration/DesignSurface/DesignSurfaceExt/DesignerSerializationServiceImpl.cs
+++ b/src/test/integration/DesignSurface/DesignSurfaceExt/DesignerSerializationServiceImpl.cs
@@ -33,8 +33,7 @@ internal sealed class DesignerSerializationService : IDesignerSerializationServi
         {
             foreach (object obj in objects)
             {
-                if (obj is Control)
-                    componentSerializationService.Serialize(serializationStore, obj);
+                componentSerializationService.Serialize(serializationStore, obj);
             }
 
             returnObject = serializationStore;


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13247


## Proposed changes

- Removing unnecessary judgment  `if (obj is Control)` from method `Serialize` of `DemoConsole.DesignerSerializationService`

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The ToolStrip can be copy and paste normally 

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

The subitem of the ToolStrip cannot be copied
![BeforeChangs](https://github.com/user-attachments/assets/4fc11858-d0f2-4387-8339-073fee242200)

### After
All of the content can be copied normally
![AfterChanges](https://github.com/user-attachments/assets/59efae48-52a3-48a3-b890-723e12f5e084)

## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.100-preview.5.25265.106


<!-- Mention language, UI scaling, or anything else that might be relevant -->
