### PR TITLE
Update build.yml and build-PR.yml to use default value to failIfCoverageEmpty for task PublishCodeCoverageResults@2

### DIFF
--- a/eng/pipelines/build-PR.yml
+++ b/eng/pipelines/build-PR.yml
@@ -142,7 +142,6 @@ jobs:
       inputs:
         summaryFileLocation: '$(Build.SourcesDirectory)\artifacts\bin\CodeCoverage\coverage\full\Cobertura.xml'
         pathToSources: '$(Build.SourcesDirectory)'
-        failIfCoverageEmpty: true
       displayName: PublishCodeCoverageResults
       condition: and(eq(variables['_BuildConfig'], 'Debug'), eq('${{ parameters.targetArchitecture }}', 'x64'))
 

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -145,7 +145,6 @@ jobs:
     inputs:
       summaryFileLocation: '$(Build.SourcesDirectory)\artifacts\bin\CodeCoverage\coverage\full\Cobertura.xml'
       pathToSources: '$(Build.SourcesDirectory)'
-      failIfCoverageEmpty: true
     displayName: PublishCodeCoverageResults
     condition: and(eq(variables['_BuildConfig'], 'Debug'), eq('${{ parameters.targetArchitecture }}', 'x64'))
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Update build.yml and build-PR.yml to use default value to failIfCoverageEmpty for task PublishCodeCoverageResults@2
-  The setting failIfCoverageEmpty caused the pipeline https://dev.azure.com/dnceng/internal/_build?definitionId=1353 failed

