### PR TITLE
Elide async lambda and use WrappedCallbackAsync directly

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control_InvokeAsync.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control_InvokeAsync.cs
@@ -171,7 +171,7 @@ public partial class Control
 
         using (cancellationToken.Register(completion.SetCanceled, useSynchronizationContext: false))
         {
-            BeginInvoke(async () => await WrappedCallbackAsync().ConfigureAwait(false));
+            BeginInvoke(WrappedCallbackAsync);
             await completion.Task.ConfigureAwait(false);
         }
 
@@ -235,7 +235,7 @@ public partial class Control
 
         using (cancellationToken.Register(completion.SetCanceled, useSynchronizationContext: false))
         {
-            BeginInvoke(async () => await WrappedCallbackAsync().ConfigureAwait(false));
+            BeginInvoke(WrappedCallbackAsync);
             return await completion.Task.ConfigureAwait(false);
         }
 


### PR DESCRIPTION
Fixes #12697

## Proposed changes

- Elides the async lambda in two locations and uses the method group directly

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Depending on the rate `InvokeAsync` is called to update the UI, it can result in a performance improvement
- Due to avoiding creating a new delegate each time and creating a state machine, memory can be saved and the GC pressure be reduced

## Regression? 

- No

## Risk

- Propagation of exceptions from within `callback`. But since `WrappedCallbackAsync` wraps `callback` in a try-catch block this should be save and not change the current behavior.

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

- Code review of related code
- Existing tests should still pass



