### PR TITLE
Add unit test for GridEntryRecreateChildrenEventArgs.cs file

### DIFF
--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/GridEntryRecreateChildrenEventArgsTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/GridEntryRecreateChildrenEventArgsTests.cs
@@ -23,14 +23,10 @@ public class GridEntryRecreateChildrenEventArgsTests
     }
 
     [Fact]
-    public void GridEntryRecreateChildrenEventArgs_Properties_AreReadOnly()
+    public void GridEntryRecreateChildrenEventArgs_Inherits_EventArgs()
     {
-        typeof(GridEntryRecreateChildrenEventArgs)
-            .GetProperty(nameof(GridEntryRecreateChildrenEventArgs.OldChildCount))!
-            .CanWrite.Should().BeFalse();
+        GridEntryRecreateChildrenEventArgs args = new(1, 2);
 
-        typeof(GridEntryRecreateChildrenEventArgs)
-            .GetProperty(nameof(GridEntryRecreateChildrenEventArgs.NewChildCount))!
-            .CanWrite.Should().BeFalse();
+        args.Should().BeAssignableTo<EventArgs>();
     }
 }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/GridEntryRecreateChildrenEventArgsTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/GridEntryRecreateChildrenEventArgsTests.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Windows.Forms.PropertyGridInternal;
+
+namespace System.Windows.Forms.Tests;
+
+public class GridEntryRecreateChildrenEventArgsTests
+{
+    [WinFormsTheory]
+    [InlineData(0, 0)]
+    [InlineData(1, 2)]
+    [InlineData(-1, 5)]
+    [InlineData(10, -3)]
+    [InlineData(int.MaxValue, int.MinValue)]
+    [InlineData(int.MinValue, int.MaxValue)]
+    public void GridEntryRecreateChildrenEventArgs_SetsProperties(int oldCount, int newCount)
+    {
+        GridEntryRecreateChildrenEventArgs args = new(oldCount, newCount);
+
+        args.OldChildCount.Should().Be(oldCount);
+        args.NewChildCount.Should().Be(newCount);
+    }
+
+    [WinFormsFact]
+    public void GridEntryRecreateChildrenEventArgs_Inherits_EventArgs()
+    {
+        GridEntryRecreateChildrenEventArgs args = new(1, 2);
+        args.Should().BeAssignableTo<EventArgs>();
+    }
+
+    [WinFormsFact]
+    public void GridEntryRecreateChildrenEventArgs_Properties_AreReadOnly()
+    {
+        typeof(GridEntryRecreateChildrenEventArgs)
+            .GetProperty(nameof(GridEntryRecreateChildrenEventArgs.OldChildCount))!
+            .CanWrite.Should().BeFalse();
+
+        typeof(GridEntryRecreateChildrenEventArgs)
+            .GetProperty(nameof(GridEntryRecreateChildrenEventArgs.NewChildCount))!
+            .CanWrite.Should().BeFalse();
+    }
+}

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/GridEntryRecreateChildrenEventArgsTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/GridEntryRecreateChildrenEventArgsTests.cs
@@ -7,7 +7,7 @@ namespace System.Windows.Forms.Tests;
 
 public class GridEntryRecreateChildrenEventArgsTests
 {
-    [WinFormsTheory]
+    [Theory]
     [InlineData(0, 0)]
     [InlineData(1, 2)]
     [InlineData(-1, 5)]
@@ -22,14 +22,7 @@ public class GridEntryRecreateChildrenEventArgsTests
         args.NewChildCount.Should().Be(newCount);
     }
 
-    [WinFormsFact]
-    public void GridEntryRecreateChildrenEventArgs_Inherits_EventArgs()
-    {
-        GridEntryRecreateChildrenEventArgs args = new(1, 2);
-        args.Should().BeAssignableTo<EventArgs>();
-    }
-
-    [WinFormsFact]
+    [Fact]
     public void GridEntryRecreateChildrenEventArgs_Properties_AreReadOnly()
     {
         typeof(GridEntryRecreateChildrenEventArgs)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->
Related https://github.com/dotnet/winforms/issues/13442
## Proposed changes
- Add unit test file: GridEntryRecreateChildrenEventArgsTests.cs for GridEntryRecreateChildrenEventArgs.cs file.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13497)