### PR TITLE
Add code coverage for UpDownBase.UpDownBaseAccessibleObject

### DIFF
--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/UpDownBase.UpDownBaseAccessibleObjectTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/UpDownBase.UpDownBaseAccessibleObjectTests.cs
@@ -27,16 +27,16 @@ public class UpDownBase_UpDownBaseAccessibleObjectTests : IDisposable
     [InlineData(-1)]
     [InlineData(2)]
     [InlineData(100)]
-    public void GetChild_WithInvalidIndices_ReturnsNull(int index)
-        => _accObj.GetChild(index).Should().BeNull();
+    public void GetChild_WithInvalidIndices_ReturnsNull(int index) =>
+        _accObj.GetChild(index).Should().BeNull();
 
     [WinFormsFact]
-    public void GetChildCount_WithCustomParents_ReturnsTwo()
-        => _accObj.GetChildCount().Should().Be(2);
+    public void GetChildCount_WithCustomParents_ReturnsTwo() =>
+        _accObj.GetChildCount().Should().Be(2);
 
     [WinFormsFact]
-    public void Role_WithCustomParents_ReturnsSpinButton()
-        => _accObj.Role.Should().Be(AccessibleRole.SpinButton);
+    public void Role_WithCustomParents_ReturnsSpinButton() =>
+        _accObj.Role.Should().Be(AccessibleRole.SpinButton);
 
     private class TestUpDownBase : UpDownBase
     {
@@ -52,7 +52,7 @@ public class UpDownBase_UpDownBaseAccessibleObjectTests : IDisposable
         public override void DownButton() => throw new NotImplementedException();
         public override void UpButton() => throw new NotImplementedException();
         protected override void UpdateEditText() => throw new NotImplementedException();
-        protected override AccessibleObject CreateAccessibilityInstance()
-            => new UpDownBaseAccessibleObject(this);
+        protected override AccessibleObject CreateAccessibilityInstance() =>
+            new UpDownBaseAccessibleObject(this);
     }
 }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/UpDownBase.UpDownBaseAccessibleObjectTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/UpDownBase.UpDownBaseAccessibleObjectTests.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace System.Windows.Forms.AccessibleObjects;
+namespace System.Windows.Forms.Tests.AccessibleObjects;
 
 public class UpDownBase_UpDownBaseAccessibleObjectTests : IDisposable
 {

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/UpDownBase.UpDownBaseAccessibleObjectTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/UpDownBase.UpDownBaseAccessibleObjectTests.cs
@@ -28,22 +28,15 @@ public class UpDownBase_UpDownBaseAccessibleObjectTests : IDisposable
     [InlineData(2)]
     [InlineData(100)]
     public void GetChild_WithInvalidIndices_ReturnsNull(int index)
-    {
-        _accObj.GetChild(index).Should().BeNull();
-    }
+        => _accObj.GetChild(index).Should().BeNull();
 
     [WinFormsFact]
     public void GetChildCount_WithCustomParents_ReturnsTwo()
-    {
-        _accObj.GetChildCount().Should().Be(2);
-    }
+        => _accObj.GetChildCount().Should().Be(2);
 
     [WinFormsFact]
-
     public void Role_WithCustomParents_ReturnsSpinButton()
-    {
-        _accObj.Role.Should().Be(AccessibleRole.SpinButton);
-    }
+        => _accObj.Role.Should().Be(AccessibleRole.SpinButton);
 
     private class TestUpDownBase : UpDownBase
     {
@@ -58,8 +51,8 @@ public class UpDownBase_UpDownBaseAccessibleObjectTests : IDisposable
 
         public override void DownButton() => throw new NotImplementedException();
         public override void UpButton() => throw new NotImplementedException();
+        protected override void UpdateEditText() => throw new NotImplementedException();
         protected override AccessibleObject CreateAccessibilityInstance()
             => new UpDownBaseAccessibleObject(this);
-        protected override void UpdateEditText() => throw new NotImplementedException();
     }
 }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/UpDownBase.UpDownBaseAccessibleObjectTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/UpDownBase.UpDownBaseAccessibleObjectTests.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace System.Windows.Forms.Tests;
+namespace System.Windows.Forms.AccessibleObjects;
 
 public class UpDownBase_UpDownBaseAccessibleObjectTests
 {

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/UpDownBase.UpDownBaseAccessibleObjectTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/UpDownBase.UpDownBaseAccessibleObjectTests.cs
@@ -40,19 +40,10 @@ public class UpDownBase_UpDownBaseAccessibleObjectTests : IDisposable
 
     private class TestUpDownBase : UpDownBase
     {
-        public TestUpDownBase()
-        {
-            AccessibleObject textBoxParent = new();
-            AccessibleObject buttonsParent = new();
-
-            TextBox.AccessibilityObject.SetParent(textBoxParent);
-            UpDownButtonsInternal.AccessibilityObject.SetParent(buttonsParent);
-        }
+        public TestUpDownBase() : base() { }
 
         public override void DownButton() => throw new NotImplementedException();
         public override void UpButton() => throw new NotImplementedException();
         protected override void UpdateEditText() => throw new NotImplementedException();
-        protected override AccessibleObject CreateAccessibilityInstance() =>
-            new UpDownBaseAccessibleObject(this);
     }
 }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/UpDownBase.UpDownBaseAccessibleObjectTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/UpDownBase.UpDownBaseAccessibleObjectTests.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.Tests;
+
+public class UpDownBase_UpDownBaseAccessibleObjectTests
+{
+    [WinFormsFact]
+    public void GetChild_WithValidIndices_ReturnsExpectedChildren()
+    {
+        using TestUpDownBase upDown = new();
+        UpDownBase.UpDownBaseAccessibleObject accObj = new(upDown);
+
+        accObj.GetChild(0).Should().BeSameAs(upDown.TextBox.AccessibilityObject.Parent);
+        accObj.GetChild(1).Should().BeSameAs(upDown.UpDownButtonsInternal.AccessibilityObject.Parent);
+    }
+
+    [WinFormsTheory]
+    [InlineData(-1)]
+    [InlineData(2)]
+    [InlineData(100)]
+    public void GetChild_WithInvalidIndices_ReturnsNull(int index)
+    {
+        using TestUpDownBase upDown = new();
+        UpDownBase.UpDownBaseAccessibleObject accObj = new(upDown);
+
+        accObj.GetChild(index).Should().BeNull();
+    }
+
+    [WinFormsFact]
+    public void GetChildCount_Returns2()
+    {
+        using TestUpDownBase upDown = new();
+        UpDownBase.UpDownBaseAccessibleObject accObj = new(upDown);
+
+        accObj.GetChildCount().Should().Be(2);
+    }
+
+    private class TestUpDownBase : UpDownBase
+    {
+        public AccessibleObject CustomTextBoxAO { get; }
+        public AccessibleObject CustomButtonsAO { get; }
+
+        public TestUpDownBase()
+        {
+            AccessibleObject textBoxParent = new();
+            AccessibleObject buttonsParent = new();
+
+            CustomTextBoxAO = new MyAccessibleObject(textBoxParent);
+            CustomButtonsAO = new MyAccessibleObject(buttonsParent);
+
+            TextBox.AccessibilityObject.SetParent(textBoxParent);
+            UpDownButtonsInternal.AccessibilityObject.SetParent(buttonsParent);
+        }
+
+        public override void DownButton() => throw new NotImplementedException();
+        public override void UpButton() => throw new NotImplementedException();
+        protected override AccessibleObject CreateAccessibilityInstance()
+            => new UpDownBaseAccessibleObject(this);
+        protected override void UpdateEditText() => throw new NotImplementedException();
+    }
+
+    private class MyAccessibleObject : AccessibleObject
+    {
+        private readonly AccessibleObject _parent;
+
+        public MyAccessibleObject(AccessibleObject parent)
+        {
+            _parent = parent;
+        }
+
+        public override AccessibleObject? Parent => _parent;
+    }
+}


### PR DESCRIPTION
Related #13442


## Proposed changes

- Add unit test file: UpDownBase.UpDownBaseAccessibleObjectTests.cs for public methods of the UpDownBase.UpDownBaseAccessibleObject.cs.cs
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13498)