### PR TITLE
Add code coverage for ImageListConverter & RelatedImageListAttribute

### DIFF
--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ImageListConverterTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ImageListConverterTests.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+
+namespace System.Windows.Forms.Controls.Tests;
+
+public class ImageListConverterTests
+{
+    internal ImageListConverter Converter { get; } = new();
+
+    [Fact]
+    public void Ctor_Default_SetsBaseType()
+    {
+        Converter.Should().BeAssignableTo<ComponentConverter>();
+    }
+
+    [Fact]
+    public void GetPropertiesSupported_ReturnsTrue()
+    {
+        Converter.GetPropertiesSupported(null).Should().BeTrue();
+    }
+}

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/RelatedImageListAttributeTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/RelatedImageListAttributeTests.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.Controls.Tests;
+
+public class RelatedImageListAttributeTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("MainImageList")]
+    public void RelatedImageList_ReturnsConstructorValue(string? value)
+    {
+        RelatedImageListAttribute attr = new(value);
+        attr.RelatedImageList.Should().Be(value);
+    }
+}


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/13442

Proposed changes
Add unit test file: ImageListConverterTests.cs  & RelatedImageListAttributeTests for public/Internal methods of the ImageListConverter.cs & RelatedImageListAttribute.cs