### PR TITLE
Skip unstable ListView UI tests

### DIFF
--- a/src/test/integration/UIIntegrationTests/ListViewTests.cs
+++ b/src/test/integration/UIIntegrationTests/ListViewTests.cs
@@ -533,10 +533,7 @@ public class ListViewTests : ControlTestBase
         });
     }
 
-    [ActiveIssue("https://github.com/dotnet/winforms/issues/13288")]
     [WinFormsFact]
-    [SkipOnArchitecture(TestArchitectures.X86 | TestArchitectures.X64,
-        "Flaky tests, see: https://github.com/dotnet/winforms/issues/13288")]
     public async Task ListView_Click_On_Second_Column_Does_Not_Alter_CheckBoxesAsync()
     {
         await RunTestAsync(async (form, listView) =>

--- a/src/test/integration/UIIntegrationTests/ListViewTests.cs
+++ b/src/test/integration/UIIntegrationTests/ListViewTests.cs
@@ -11,8 +11,7 @@ namespace System.Windows.Forms.UITests;
 // NOTE: This class contains many tests which don't require user input. Although they arguably belong to the unit
 // tests project, these tests assert behaviors of ListView.View=View.Tile, which doesn't work correctly unless
 // we ran an app.
-[Collection("ListViewUITests")]
-[UISettings(MaxAttempts = 3)] // Try up to 3 times before failing.
+
 public class ListViewTests : ControlTestBase
 {
     public ListViewTests(ITestOutputHelper testOutputHelper)
@@ -40,7 +39,10 @@ public class ListViewTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/11328")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X86 | TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/11328")]
     public async Task ListView_Group_NavigateKeyboard_SucceedsAsync()
     {
         await RunTestAsync(async (form, listView) =>
@@ -109,7 +111,10 @@ public class ListViewTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/13291")]
     [WinFormsTheory]
+    [SkipOnArchitecture(TestArchitectures.X86 | TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/13291")]
     [InlineData(2, 2, 150, 150, 0, 1, (int)NavigateDirection.NavigateDirection_FirstChild)]
     [InlineData(4, 3, 150, 150, 0, 3, (int)NavigateDirection.NavigateDirection_LastChild)]
     [InlineData(4, 1, 150, 150, 0, 1, (int)NavigateDirection.NavigateDirection_LastChild)]
@@ -132,7 +137,10 @@ public class ListViewTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/13291")]
     [WinFormsTheory]
+    [SkipOnArchitecture(TestArchitectures.X86 | TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/13291")]
     [InlineData(1, 0, 150, 150, (int)NavigateDirection.NavigateDirection_FirstChild)]
     [InlineData(1, 2, 150, 150, (int)NavigateDirection.NavigateDirection_FirstChild)]
     [InlineData(2, 1, 10, 10, (int)NavigateDirection.NavigateDirection_FirstChild)]
@@ -153,7 +161,10 @@ public class ListViewTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/13291")]
     [WinFormsTheory]
+    [SkipOnArchitecture(TestArchitectures.X86 | TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/13291")]
     [InlineData(4, 1)]
     [InlineData(2, 3)]
     public async Task ListView_Tile_SubItem_FragmentNavigate_Sibling_ReturnsNullAsync(int columnCount, int subItemsCount)
@@ -173,7 +184,10 @@ public class ListViewTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/13291")]
     [WinFormsTheory]
+    [SkipOnArchitecture(TestArchitectures.X86 | TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/13291")]
     [InlineData(4, 3, 150, 150, 3)]
     [InlineData(4, 0, 150, 150, 0)]
     [InlineData(4, 1, 150, 150, 1)]
@@ -195,7 +209,10 @@ public class ListViewTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/13291")]
     [WinFormsTheory]
+    [SkipOnArchitecture(TestArchitectures.X86 | TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/13291")]
     [InlineData(4, 1)]
     [InlineData(2, 5)]
     public async Task ListView_Tile_GetChildAsync(int columnCount, int subItemsCount)
@@ -215,7 +232,10 @@ public class ListViewTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/13291")]
     [WinFormsTheory]
+    [SkipOnArchitecture(TestArchitectures.X86 | TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/13291")]
     [InlineData(4, 0, 150, 150)]
     [InlineData(1, 2, 150, 150)]
     [InlineData(2, 1, 10, 10)]
@@ -235,7 +255,10 @@ public class ListViewTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/13291")]
     [WinFormsTheory]
+    [SkipOnArchitecture(TestArchitectures.X86 | TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/13291")]
     [InlineData(4, 1, 150, 150, -1, 1)]
     [InlineData(2, 1, 10, 10, -1, -1)]
     public async Task ListView_Tile_GetChildIndex_ForDifferentSize_ReturnsExpectedAsync(int columnCount, int subItemsCount, int width, int height, int expected1, int expected2)
@@ -254,7 +277,10 @@ public class ListViewTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/13291")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X86 | TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/13291")]
     public async Task ListView_Tile_SubItem_FragmentNavigate_NextSibling_ReturnsExpectedAsync()
     {
         await RunTestAsync((form, listView) =>
@@ -275,7 +301,10 @@ public class ListViewTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/13291")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X86 | TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/13291")]
     public async Task ListView_Tile_SubItem_HitTest_ReturnExpectedAsync()
     {
         await RunTestAsync((form, listView) =>
@@ -301,7 +330,10 @@ public class ListViewTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/13291")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X86 | TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/13291")]
     public async Task ListView_Tile_SubItem_FragmentNavigate_Sibling_ReturnsNull_For_SmallSizeAsync()
     {
         await RunTestAsync((form, listView) =>
@@ -319,7 +351,10 @@ public class ListViewTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/13291")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X86 | TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/13291")]
     public async Task ListView_Tile_SubItem_FragmentNavigate_Child_ReturnsNullAsync()
     {
         await RunTestAsync((form, listView) =>
@@ -336,7 +371,10 @@ public class ListViewTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/13291")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X86 | TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/13291")]
     public async Task ListView_Tile_GetChild_ReturnsExpectedAsync()
     {
         await RunTestAsync((form, listView) =>
@@ -356,7 +394,10 @@ public class ListViewTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/13291")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X86 | TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/13291")]
     public async Task ListView_Tile_GetChild_ReturnsExpected_For_BigSizeAsync()
     {
         await RunTestAsync((form, listView) =>
@@ -378,7 +419,10 @@ public class ListViewTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/13291")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X86 | TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/13291")]
     public async Task ListView_Tile_GetChildIndex_ReturnsExpectedAsync()
     {
         await RunTestAsync((form, listView) =>
@@ -397,7 +441,10 @@ public class ListViewTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/13291")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X86 | TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/13291")]
     public async Task ListView_Tile_GetChildIndex_ReturnsExpected_SubItemsMoreThanColumnsAsync()
     {
         await RunTestAsync((form, listView) =>
@@ -417,7 +464,10 @@ public class ListViewTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/13291")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X86 | TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/13291")]
     public async Task ListView_Tile_GetChildIndex_ReturnsMinusOne_For_Single_ColumnAsync()
     {
         await RunTestAsync((form, listView) =>
@@ -434,7 +484,10 @@ public class ListViewTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/13291")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X86 | TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/13291")]
     public async Task ListView_Tile_GetChildIndex_ReturnsExpected_For_BigSizeAsync()
     {
         await RunTestAsync((form, listView) =>
@@ -460,7 +513,10 @@ public class ListViewTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/13291")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X86 | TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/13291")]
     public async Task ListView_Tile_ColumnProperty_ReturnsMinusOneAsync()
     {
         await RunTestAsync((form, listView) =>
@@ -476,7 +532,10 @@ public class ListViewTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/13288")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X86 | TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/13288")]
     public async Task ListView_Click_On_Second_Column_Does_Not_Alter_CheckBoxesAsync()
     {
         await RunTestAsync(async (form, listView) =>

--- a/src/test/integration/UIIntegrationTests/ListViewTests.cs
+++ b/src/test/integration/UIIntegrationTests/ListViewTests.cs
@@ -11,7 +11,8 @@ namespace System.Windows.Forms.UITests;
 // NOTE: This class contains many tests which don't require user input. Although they arguably belong to the unit
 // tests project, these tests assert behaviors of ListView.View=View.Tile, which doesn't work correctly unless
 // we ran an app.
-
+[Collection("ListViewUITests")]
+[UISettings(MaxAttempts = 3)] // Try up to 3 times before failing.
 public class ListViewTests : ControlTestBase
 {
     public ListViewTests(ITestOutputHelper testOutputHelper)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related #11328, #13291

Adding this test to the new synchronized collection does not resolve the instability

## Proposed changes

-  **Skip the following unstable ListView tests** 

1. System.Windows.Forms.UITests.ListViewTests.ListView_Tile_FragmentNavigate_ReturnsNullAsync(columnCount: 1, subItemsCount: 0, width: 150, height: 150, direction: 3)
2. System.Windows.Forms.UITests.ListViewTests.ListView_Tile_FragmentNavigate_WorksExpectedAsync(columnCount: 2, subItemsCount: 2, width: 150, height: 150, itemIndex: 0, subItemIndex: 1, direction: 3)
3. System.Windows.Forms.UITests.ListViewTests.ListView_Tile_GetChild_ReturnsExpected_For_BigSizeAsync
4. System.Windows.Forms.UITests.ListViewTests.ListView_Tile_GetChild_ReturnsExpectedAsync
5. System.Windows.Forms.UITests.ListViewTests.ListView_Tile_GetChild_ReturnsNullAsync(columnCount: 4, subItemsCount: 0, width: 150, height: 150)
6. System.Windows.Forms.UITests.ListViewTests.ListView_Tile_GetChildAsync(columnCount: 4, subItemsCount: 1)
7. System.Windows.Forms.UITests.ListViewTests.ListView_Tile_GetChildCount_ReturnsExpectedAsync(columnCount: 4, subItemsCount: 3, width: 150, height: 150, expected: 3)
8. System.Windows.Forms.UITests.ListViewTests.ListView_Tile_GetChildIndex_ForDifferentSize_ReturnsExpectedAsync(columnCount: 4, subItemsCount: 1, width: 150, height: 150, expected1: -1, expected2: 1)
9. System.Windows.Forms.UITests.ListViewTests.ListView_Tile_GetChildIndex_ReturnsExpected_For_BigSizeAsync
10. System.Windows.Forms.UITests.ListViewTests.ListView_Tile_GetChildIndex_ReturnsExpected_SubItemsMoreThanColumnsAsync
11. System.Windows.Forms.UITests.ListViewTests.ListView_Tile_GetChildIndex_ReturnsExpectedAsync
12. System.Windows.Forms.UITests.ListViewTests.ListView_Tile_SubItem_FragmentNavigate_Child_ReturnsNullAsync
13. System.Windows.Forms.UITests.ListViewTests.ListView_Tile_SubItem_FragmentNavigate_NextSibling_ReturnsExpectedAsync
14. System.Windows.Forms.UITests.ListViewTests.ListView_Tile_SubItem_FragmentNavigate_Sibling_ReturnsNull_For_SmallSizeAsync
15. System.Windows.Forms.UITests.ListViewTests.ListView_Tile_SubItem_FragmentNavigate_Sibling_ReturnsNullAsync(columnCount: 4, subItemsCount: 1)
16. System.Windows.Forms.UITests.ListViewTests.ListView_Tile_SubItem_HitTest_ReturnExpectedAsync
17. System.Windows.Forms.UITests.ListViewTests.ListView_Tile_ColumnProperty_ReturnsMinusOneAsync
18. System.Windows.Forms.UITests.ListViewTests.ListView_Tile_GetChildIndex_ReturnsMinusOne_For_Single_ColumnAsync
19. ListView_Group_NavigateKeyboard_SucceedsAsync
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13514)