### PR TITLE
fix #13508 Original text box is not empty after drag and drop the value to a new text box

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/OLE/DropTarget.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/OLE/DropTarget.cs
@@ -283,7 +283,7 @@ internal unsafe class DropTarget : OleIDropTarget.Interface, IManagedWrapper<Ole
         try
         {
             _owner.OnDragDrop(e);
-            effect = (DROPEFFECT)e.Effect;
+            *pdwEffect = effect = (DROPEFFECT)e.Effect;
         }
         finally
         {


### PR DESCRIPTION
Fixes #13508 

code snippet before [PR13431](https://github.com/dotnet/winforms/pull/13431)
```
            {
                ClearDropDescription();
                DragDropHelper.Drop(dragEvent);
            }

            _owner.OnDragDrop(dragEvent);
            *pdwEffect = (DROPEFFECT)dragEvent.Effect;
        }
        else
        {
            *pdwEffect = DROPEFFECT.DROPEFFECT_NONE;
        }

        _lastEffect = DragDropEffects.None;
        _lastDataObject = null;
        return HRESULT.S_OK;
    }
```
code snippet after [PR13431](https://github.com/dotnet/winforms/pull/13431)
```
    private HRESULT HandleOnDragDrop(DragEventArgs e, IDataObjectAsyncCapability* asyncCapability, DROPEFFECT* pdwEffect)
    {
#pragma warning disable WFO5003 // Type is for evaluation purposes only
        if (asyncCapability is not null && _owner is IAsyncDropTarget asyncDropTarget)
#pragma warning restore WFO5003
        {
            // We have an implemented IAsyncDropTarget and the drag source supports async operations, push to a
            // worker thread to allow the drop to complete without blocking the UI thread.
            Task.Run(() =>
            {
                DROPEFFECT effect = DROPEFFECT.DROPEFFECT_NONE;

                try
                {
                    asyncDropTarget.OnAsyncDragDrop(e);
                    effect = (DROPEFFECT)e.Effect;
                }
                finally
                {
                    HRESULT result = asyncCapability->EndOperation(HRESULT.S_OK, null, (uint)effect);
                    asyncCapability->Release();
                }
            });

            // It isn't clear what we're supposed to do with the effect here as the actual result comes from
            // EndOperation. Perhaps DROPEFFECT_COPY would be a better default?
            *pdwEffect = DROPEFFECT.DROPEFFECT_NONE;
            return HRESULT.S_OK;
        }

        // We don't have the IAsyncDropTarget or the drag source doesn't support async operations, so just call
        // the normal OnDragDrop.

        DROPEFFECT effect = DROPEFFECT.DROPEFFECT_NONE;

        try
        {
            _owner.OnDragDrop(e);
            effect = (DROPEFFECT)e.Effect;
        }
        finally
        {
            if (asyncCapability is not null)
            {
                HRESULT result = asyncCapability->EndOperation(HRESULT.S_OK, null, (uint)effect);
                asyncCapability->Release();
            }
        }

        return HRESULT.S_OK;
    }
```

I think we forgot to update `*pdwEffect` after `_owner.OnDragDrop(dragEvent);`

## Proposed changes

- 
- update `*pdwEffect` after `_owner.OnDragDrop(dragEvent);`
- 

## Regression? 

- Yes

<!-- 
## Risk

-
 -->

## Screenshots 
### Before

![Image](https://github.com/user-attachments/assets/63ddefe1-71aa-4210-97aa-f0b7de42d29b)

### After

![pull_13526](https://github.com/user-attachments/assets/be832c36-d670-4561-a5f7-aa8d5d223cb4)



## Test methodology <!-- How did you ensure quality? -->

- 
- manually 
- 



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13526)