### PR TITLE
Fix 13288 by add Task.Delay for test ListView_Click_On_Second_Column_Does_Not_Alter_CheckBoxesAsync

### DIFF
--- a/src/test/integration/UIIntegrationTests/ListViewTests.cs
+++ b/src/test/integration/UIIntegrationTests/ListViewTests.cs
@@ -501,7 +501,7 @@ public class ListViewTests : ControlTestBase
                form,
                inputSimulator => inputSimulator.Mouse.LeftButtonClick()
                                                .Keyboard.KeyUp(VIRTUAL_KEY.VK_SHIFT));
-
+            await Task.Delay(15);
             foreach (ListViewItem item in listView.Items)
             {
                 Assert.Equal(0, item.StateImageIndex);

--- a/src/test/integration/UIIntegrationTests/ListViewTests.cs
+++ b/src/test/integration/UIIntegrationTests/ListViewTests.cs
@@ -501,7 +501,7 @@ public class ListViewTests : ControlTestBase
                form,
                inputSimulator => inputSimulator.Mouse.LeftButtonClick()
                                                .Keyboard.KeyUp(VIRTUAL_KEY.VK_SHIFT));
-            await Task.Delay(15);
+            await form.InvokeAsync(() => { });
             foreach (ListViewItem item in listView.Items)
             {
                 Assert.Equal(0, item.StateImageIndex);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13288


## Proposed changes

- Add Task.Delay for test ListView_Click_On_Second_Column_Does_Not_Alter_CheckBoxesAsync

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13534)