### PR TITLE
Fix 13538: Update method Drop of DropTarget.cs

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/OLE/DropTarget.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/OLE/DropTarget.cs
@@ -212,8 +212,6 @@ internal unsafe class DropTarget : OleIDropTarget.Interface, IManagedWrapper<Ole
             }
         }
 
-        *pdwEffect = DROPEFFECT.DROPEFFECT_NONE;
-
         try
         {
             if (CreateDragEventArgs(pDataObj, grfKeyState, pt, *pdwEffect) is { } dragEvent)
@@ -226,6 +224,10 @@ internal unsafe class DropTarget : OleIDropTarget.Interface, IManagedWrapper<Ole
 
                 result = HandleOnDragDrop(dragEvent, asyncCapability, pdwEffect);
                 asyncCapability = null;
+            }
+            else
+            {
+                *pdwEffect = DROPEFFECT.DROPEFFECT_NONE;
             }
 
             _lastEffect = DragDropEffects.None;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13538


## Proposed changes

- Update method `Drop` to delete `*pdwEffect = DROPEFFECT.DROPEFFECT_NONE` before `CreateDragEventArgs` 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The component controls can be moved in design time

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Unable move component controls in DemoConsole application.

https://github.com/user-attachments/assets/fb3397cc-15c7-4565-b42a-09866a6bd404

### After
Component controls can be moved normally
![AfterChange](https://github.com/user-attachments/assets/1eb7c844-df53-4819-b710-321fb2380a74)


## Test methodology <!-- How did you ensure quality? -->

- Manually
 

## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-preview.6.25278.103

<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13542)