### PR TITLE
fix #13539 Unable to select ToolStripMenuItem and TooStripTextBox of MenuStrip2 in DemoConsole application

### DIFF
--- a/src/test/integration/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/test/integration/DesignSurface/DemoConsole/MainForm.cs
@@ -342,8 +342,7 @@ public partial class MainForm : Form
                         richTextBox.Width = toolStripContainer.Width;
                         richTextBox.Text = "I'm a RichTextBox";
 
-                        MyUserControl userControl = surface.CreateControl<MyUserControl>(new Size(0, 0), new Point(0, 0));
-                        userControl.Dock = DockStyle.Fill;
+                        MyUserControl userControl = surface.CreateControl<MyUserControl>(new Size(350, 100), new Point(0, 0));
                         userControl.BackColor = Color.LightSkyBlue;
 
                         MyScrollableControl scrollableControl = surface.CreateControl<MyScrollableControl>(new Size(0, 0), new Point(0, 0));
@@ -363,7 +362,7 @@ public partial class MainForm : Form
                         splitter.BackColor = Color.Green;
                         splitter.Dock = DockStyle.Bottom;
 
-                        Panel panel = surface.CreateControl<Panel>(new(0, tabPage6.Height / 2), new(0, 0));
+                        Panel panel = surface.CreateControl<Panel>(new(0, tabPage6.Height / 3), new(0, 0));
                         panel.Dock = DockStyle.Bottom;
                         NumericUpDown numericUpDown = surface.CreateControl<NumericUpDown>(new(50, 10), new(10, 10));
                         panel.Controls.Add(numericUpDown);


### PR DESCRIPTION
Fixes #13539

## Root cause

There is a UserControl in the designer, which is big enough to cover the MenuStrip.

![Issue_13539_2](https://github.com/user-attachments/assets/ac558add-b29f-495c-8894-054e941790cf)

## Proposed changes

- 
- Make enough room for MenuStrip
- 


## Customer Impact

- 
- low
-





## Screenshots 

### Before

https://github.com/user-attachments/assets/af05626f-e340-48d1-ab4b-3ffeb2c4f475

### After

![Issue_13539_1](https://github.com/user-attachments/assets/fcfe6488-3211-4ad1-91c3-5c5d5c383126)



## Test methodology

- 
- manual 
- 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13546)