### PR TITLE
Fix 13227: Update SetName of DesignerExtenders.NameExtenderProvider to virtual method

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerExtenders.NameExtenderProvider.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerExtenders.NameExtenderProvider.cs
@@ -88,7 +88,7 @@ internal partial class DesignerExtenders
         ///  This is an extender property that we offer to all components
         ///  on the form. It implements the "Name" property.
         /// </summary>
-        public static void SetName(IComponent comp, string newName)
+        public virtual void SetName(IComponent comp, string newName)
         {
             ISite? site = comp.Site;
             site?.Name = newName;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13227


## Proposed changes

- Change `SetName` of `DesignerExtenders.NameExtenderProvider` from `static` to `virtual` method

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Enable Name property for all controls in DemoConsole

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

In [DemoConsole](https://github.com/dotnet/winforms/tree/main/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole) test app of WinForms repo, `Name` property for all controls is disabled
.NET 10:

![Image](https://github.com/user-attachments/assets/9299cfc1-6390-4609-be1f-0b53066a18de)

### After

 `Name` property for all controls is enabled

![image](https://github.com/user-attachments/assets/8ca9e888-18bf-4256-b6c6-4689580cd187)


## Test methodology <!-- How did you ensure quality? -->

- Manually
 

## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-preview.6.25303.102


<!-- Mention language, UI scaling, or anything else that might be relevant -->
