### PR TITLE
Introduce FormScreenCaptureMode property on Form

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
+++ b/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
@@ -221,6 +221,7 @@ GetUpdateRgn
 GetUserObjectInformation
 GetViewportExtEx
 GetWindow
+GetWindowDisplayAffinity
 GetWindowDpiAwarenessContext
 GetWindowPlacement
 GetWorldTransform
@@ -559,6 +560,7 @@ SetThreadDpiHostingBehavior
 SetTimer
 SetViewportExtEx
 SetViewportOrgEx
+SetWindowDisplayAffinity
 SetWindowExtEx
 SetWindowOrgEx
 SetWindowPlacement

--- a/src/System.Windows.Forms/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/PublicAPI.Unshipped.txt
@@ -1,0 +1,6 @@
+System.Windows.Forms.Form.FormScreenCaptureMode.get -> System.Windows.Forms.ScreenCaptureMode
+System.Windows.Forms.Form.FormScreenCaptureMode.set -> void
+System.Windows.Forms.ScreenCaptureMode
+System.Windows.Forms.ScreenCaptureMode.Allow = 0 -> System.Windows.Forms.ScreenCaptureMode
+System.Windows.Forms.ScreenCaptureMode.HideContent = 1 -> System.Windows.Forms.ScreenCaptureMode
+System.Windows.Forms.ScreenCaptureMode.HideWindow = 2 -> System.Windows.Forms.ScreenCaptureMode

--- a/src/System.Windows.Forms/Resources/SR.resx
+++ b/src/System.Windows.Forms/Resources/SR.resx
@@ -7033,10 +7033,13 @@ Stack trace where the illegal operation occurred was:
   <data name="ClipboardOrDragDrop_InvalidFormatTypeCombination" xml:space="preserve">
     <value>The specified type '{0}' is not compatible with the specified format '{1}'.</value>
   </data>
-  <data name="ClipboardOrDragDrop_CannotJsonSerializeDataObject">
+  <data name="ClipboardOrDragDrop_CannotJsonSerializeDataObject" xml:space="preserve">
     <value>An object of type 'DataObject' will serialize as empty. Use 'DataObject.SetDataAsJson' APIs on your object to JSON-serialize the data within your object, then use the '{0}' API with your object.</value>
   </data>
-  <data name="NotSupportedExceptionOnClipboard">
+  <data name="NotSupportedExceptionOnClipboard" xml:space="preserve">
     <value>Clipboard contains a 'NotSupportedException' that indicates that write operation failed. '{0}'.</value>
+  </data>
+  <data name="FormScreenCaptureModeDescr" xml:space="preserve">
+    <value>Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</value>
   </data>
 </root>

--- a/src/System.Windows.Forms/Resources/SR.resx
+++ b/src/System.Windows.Forms/Resources/SR.resx
@@ -7042,4 +7042,7 @@ Stack trace where the illegal operation occurred was:
   <data name="FormScreenCaptureModeDescr" xml:space="preserve">
     <value>Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</value>
   </data>
+  <data name="FormScreenCaptureModeRequiresTopLevel" xml:space="preserve">
+    <value>The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.cs.xlf
@@ -5620,6 +5620,11 @@ Chcete ho nahradit?</target>
         <target state="translated">Vlastník tohoto formuláře.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeDescr">
+        <source>Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</source>
+        <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">Označuje, zda je v záhlaví okna formuláře zobrazena ikona.</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.cs.xlf
@@ -5625,6 +5625,11 @@ Chcete ho nahradit?</target>
         <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeRequiresTopLevel">
+        <source>The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</source>
+        <target state="new">The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">Označuje, zda je v záhlaví okna formuláře zobrazena ikona.</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.de.xlf
@@ -5625,6 +5625,11 @@ Möchten Sie den Pfad ersetzen?</target>
         <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeRequiresTopLevel">
+        <source>The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</source>
+        <target state="new">The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">Gibt an, ob ein Symbol in der Titelleiste des Formulars angezeigt wird.</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.de.xlf
@@ -5620,6 +5620,11 @@ Möchten Sie den Pfad ersetzen?</target>
         <target state="translated">Der Besitzer dieses Formulars.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeDescr">
+        <source>Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</source>
+        <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">Gibt an, ob ein Symbol in der Titelleiste des Formulars angezeigt wird.</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.es.xlf
@@ -5620,6 +5620,11 @@ Do you want to replace it?</source>
         <target state="translated">Propietario de este formulario.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeDescr">
+        <source>Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</source>
+        <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">Indica si un icono se muestra en la barra de título del formulario.</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.es.xlf
@@ -5625,6 +5625,11 @@ Do you want to replace it?</source>
         <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeRequiresTopLevel">
+        <source>The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</source>
+        <target state="new">The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">Indica si un icono se muestra en la barra de título del formulario.</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.fr.xlf
@@ -5620,6 +5620,11 @@ Voulez-vous le remplacer ?</target>
         <target state="translated">Le propriétaire de ce formulaire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeDescr">
+        <source>Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</source>
+        <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">Indique si une icône est affichée dans la barre de titre du formulaire.</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.fr.xlf
@@ -5625,6 +5625,11 @@ Voulez-vous le remplacer ?</target>
         <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeRequiresTopLevel">
+        <source>The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</source>
+        <target state="new">The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">Indique si une icône est affichée dans la barre de titre du formulaire.</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.it.xlf
@@ -5625,6 +5625,11 @@ Sostituirlo?</target>
         <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeRequiresTopLevel">
+        <source>The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</source>
+        <target state="new">The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">Indica se nella barra del titolo del form viene visualizzata un'icona.</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.it.xlf
@@ -5620,6 +5620,11 @@ Sostituirlo?</target>
         <target state="translated">Il proprietario di questo form.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeDescr">
+        <source>Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</source>
+        <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">Indica se nella barra del titolo del form viene visualizzata un'icona.</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.ja.xlf
@@ -5625,6 +5625,11 @@ Do you want to replace it?</source>
         <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeRequiresTopLevel">
+        <source>The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</source>
+        <target state="new">The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">アイコンがフォームのタイトル バーに表示されるかどうかを示します。</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.ja.xlf
@@ -5620,6 +5620,11 @@ Do you want to replace it?</source>
         <target state="translated">このフォームのオーナーです。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeDescr">
+        <source>Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</source>
+        <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">アイコンがフォームのタイトル バーに表示されるかどうかを示します。</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.ko.xlf
@@ -5620,6 +5620,11 @@ Do you want to replace it?</source>
         <target state="translated">이 폼의 소유자입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeDescr">
+        <source>Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</source>
+        <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">아이콘이 폼의 제목 표시줄에 표시되는지 여부를 나타냅니다.</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.ko.xlf
@@ -5625,6 +5625,11 @@ Do you want to replace it?</source>
         <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeRequiresTopLevel">
+        <source>The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</source>
+        <target state="new">The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">아이콘이 폼의 제목 표시줄에 표시되는지 여부를 나타냅니다.</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.pl.xlf
@@ -5620,6 +5620,11 @@ Czy chcesz zastąpić?</target>
         <target state="translated">Właściciel formularza.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeDescr">
+        <source>Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</source>
+        <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">Wskazuje, czy ikona jest wyświetlana na pasku tytułu formularza.</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.pl.xlf
@@ -5625,6 +5625,11 @@ Czy chcesz zastąpić?</target>
         <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeRequiresTopLevel">
+        <source>The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</source>
+        <target state="new">The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">Wskazuje, czy ikona jest wyświetlana na pasku tytułu formularza.</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.pt-BR.xlf
@@ -5625,6 +5625,11 @@ Deseja substituí-lo?</target>
         <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeRequiresTopLevel">
+        <source>The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</source>
+        <target state="new">The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">Indica se um ícone é exibido na barra de título do formulário.</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.pt-BR.xlf
@@ -5620,6 +5620,11 @@ Deseja substituí-lo?</target>
         <target state="translated">O proprietário deste formulário.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeDescr">
+        <source>Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</source>
+        <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">Indica se um ícone é exibido na barra de título do formulário.</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.ru.xlf
@@ -5625,6 +5625,11 @@ Do you want to replace it?</source>
         <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeRequiresTopLevel">
+        <source>The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</source>
+        <target state="new">The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">Указывает, отображается ли значок в строке заголовка формы.</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.ru.xlf
@@ -5620,6 +5620,11 @@ Do you want to replace it?</source>
         <target state="translated">Владелец этой формы.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeDescr">
+        <source>Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</source>
+        <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">Указывает, отображается ли значок в строке заголовка формы.</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.tr.xlf
@@ -5620,6 +5620,11 @@ Değiştirmek istiyor musunuz?</target>
         <target state="translated">Bu formun sahibi.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeDescr">
+        <source>Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</source>
+        <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">Formun başlık çubuğunda bir simge görüntülenip görüntülenmediğini gösterir.</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.tr.xlf
@@ -5625,6 +5625,11 @@ Değiştirmek istiyor musunuz?</target>
         <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeRequiresTopLevel">
+        <source>The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</source>
+        <target state="new">The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">Formun başlık çubuğunda bir simge görüntülenip görüntülenmediğini gösterir.</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.zh-Hans.xlf
@@ -5620,6 +5620,11 @@ Do you want to replace it?</source>
         <target state="translated">此窗体的所有者。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeDescr">
+        <source>Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</source>
+        <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">指示是否在窗体的标题栏中显示图标。</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.zh-Hans.xlf
@@ -5625,6 +5625,11 @@ Do you want to replace it?</source>
         <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeRequiresTopLevel">
+        <source>The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</source>
+        <target state="new">The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">指示是否在窗体的标题栏中显示图标。</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.zh-Hant.xlf
@@ -5625,6 +5625,11 @@ Do you want to replace it?</source>
         <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeRequiresTopLevel">
+        <source>The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</source>
+        <target state="new">The FormScreenCaptureMode property can only be changed on top-level Forms with their TopLevel property set to true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">表示是否在表單的標題列中顯示圖示。</target>

--- a/src/System.Windows.Forms/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/Resources/xlf/SR.zh-Hant.xlf
@@ -5620,6 +5620,11 @@ Do you want to replace it?</source>
         <target state="translated">此表單的擁有人。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FormScreenCaptureModeDescr">
+        <source>Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</source>
+        <target state="new">Gets or sets the behavior for preventing screen capture/video recording of the form's content via screen capture applications based on the Windows APIs.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FormShowIconDescr">
         <source>Indicates whether an icon is displayed in the title bar of the form.</source>
         <target state="translated">表示是否在表單的標題列中顯示圖示。</target>

--- a/src/System.Windows.Forms/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Form.cs
@@ -1725,41 +1725,40 @@ public partial class Form : ContainerControl
     }
 
     /// <summary>
-    ///  Gets or sets the behavior for preventing screen capture/video recording of the
-    ///  form's content via screen capture applications based on the Windows APIs.
+    ///  Gets or sets how the form’s content is protected from screen capture or video recording
+    ///  using Windows-based screen capture APIs.
     /// </summary>
     /// <remarks>
     ///  <para>
-    ///   This property determines how the form's content behaves when captured by screen capture applications
-    ///   or screenshots. Different capture modes provide varying levels of privacy and security for sensitive content.
+    ///   This property controls how the form’s content is handled when a screen capture or screenshot
+    ///   is attempted. Each capture mode offers different levels of protection for sensitive information.
     ///  </para>
     ///  <para>
-    ///   By default, forms allow their content to be captured. Setting this property to a more restrictive value
-    ///   can prevent sensitive information from being captured in screenshots or recorded in screen recordings.
+    ///   By default, forms permit their content to be captured. Choosing a more restrictive mode
+    ///   can block screenshots or recordings that include confidential data.
     ///  </para>
     ///  <para>
-    ///   The setting takes effect immediately for visible forms. For forms that aren't yet shown,
-    ///   the setting takes effect when the form becomes visible.
+    ///   Changes to this property take effect immediately for any form that is already visible. For
+    ///   forms not yet displayed, the selected mode is applied as soon as the form appears.
     ///  </para>
     ///  <para>
-    ///   Warning! Additional top-level windows, which will be spinning off the form, will not be affected
-    ///   by this setting. Please be aware, that for example sensitive information in a pop-up window
-    ///   like a MessageBox, a context menu, DropDownButton menus or PullDown-menus can not be prevented
-    ///   from being captured!
+    ///   Note that this setting applies only to the form itself. Any additional top-level windows—such
+    ///   as pop-ups, message boxes, context menus, or dropdown menus—are not affected and can still be
+    ///   captured. Similarly, other application windows remain unaffected by this property.
     ///  </para>
     ///  <para>
-    ///   Note that this setting only affects the current form and not any other windows in the application.
-    ///   Also note that this will also affect video streaming applications for video conferencing, etc.
-    ///  </para>
-    ///  <para>
-    ///   Disclaimer: Please keep in mind, that this setting can of course not prevent screen recordings by tools,
-    ///   which are either circumvent the public Windows APIs or use hardware-based screen capture methods.
+    ///   This also influences video-streaming or conferencing applications that rely on the same
+    ///   Windows capture APIs. However, it cannot prevent tools that bypass these APIs or use
+    ///   hardware-level capture methods from recording the screen.
+    ///   See the remarks for the Windows API <a href="https://aka.ms/AAwi872">SetWindowDisplayAffinity</a>
+    ///   for more details.
     ///  </para>
     /// </remarks>
     /// <value>
-    ///  One of the <see cref="ScreenCaptureMode"/> enumeration values. The default is
-    ///  <see cref="ScreenCaptureMode.Allow"/>.
+    ///  A <see cref="ScreenCaptureMode"/> enumeration value indicating the desired capture restriction.
+    ///  The default is <see cref="ScreenCaptureMode.Allow"/>.
     /// </value>
+
     [SRCategory(nameof(SR.CatWindowStyle))]
     [SRDescription(nameof(SR.FormScreenCaptureModeDescr))]
     public ScreenCaptureMode FormScreenCaptureMode
@@ -4982,6 +4981,11 @@ public partial class Form : ContainerControl
         }
 
         SetFormTitleProperties();
+
+        if (FormScreenCaptureMode != ScreenCaptureMode.Allow)
+        {
+            SetScreenCaptureModeInternal(FormScreenCaptureMode);
+        }
 
         GC.KeepAlive(this);
     }

--- a/src/System.Windows.Forms/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Form.cs
@@ -137,6 +137,7 @@ public partial class Form : ContainerControl
 
     private static readonly int s_propFormCaptionTextColor = PropertyStore.CreateKey();
     private static readonly int s_propFormCaptionBackColor = PropertyStore.CreateKey();
+    private static readonly int s_propFormScreenCaptureMode = PropertyStore.CreateKey();
 
     // Form per instance members
     // Note: Do not add anything to this list unless absolutely necessary.
@@ -154,7 +155,6 @@ public partial class Form : ContainerControl
     private MdiClient? _ctlClient;
     private NativeWindow? _ownerWindow;
     private bool _rightToLeftLayout;
-    private ScreenCaptureMode _formScreenCaptureMode = ScreenCaptureMode.Allow;
 
     private Rectangle _restoreBounds = new(-1, -1, -1, -1);
     private CloseReason _closeReason = CloseReason.None;
@@ -1764,17 +1764,21 @@ public partial class Form : ContainerControl
     [SRDescription(nameof(SR.FormScreenCaptureModeDescr))]
     public ScreenCaptureMode FormScreenCaptureMode
     {
-        get => _formScreenCaptureMode;
+        get => Properties.GetValueOrDefault(s_propFormScreenCaptureMode, ScreenCaptureMode.Allow);
         set
         {
-            if (_formScreenCaptureMode == value)
+            if (FormScreenCaptureMode == value)
             {
                 return;
             }
 
-            SourceGenerated.EnumValidator.Validate(value);
+            if (!TopLevel)
+            {
+                throw new InvalidOperationException(SR.FormScreenCaptureModeRequiresTopLevel);
+            }
 
-            _formScreenCaptureMode = value;
+            SourceGenerated.EnumValidator.Validate(value);
+            Properties.AddOrRemoveValue(s_propFormScreenCaptureMode, value);
 
             if (IsHandleCreated)
             {
@@ -1791,11 +1795,6 @@ public partial class Form : ContainerControl
 
     private void SetScreenCaptureModeInternal(ScreenCaptureMode value)
     {
-        if (!TopLevel)
-        {
-            return;
-        }
-
         WINDOW_DISPLAY_AFFINITY affinity = value switch
         {
             ScreenCaptureMode.Allow => WINDOW_DISPLAY_AFFINITY.WDA_NONE,
@@ -2692,6 +2691,7 @@ public partial class Form : ContainerControl
     /// </summary>
     [SRCategory(nameof(SR.CatAppearance))]
     [SRDescription(nameof(SR.FormBorderColorChangedDescr))]
+    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public event EventHandler? FormBorderColorChanged
     {
         add => Events.AddHandler(s_formBorderColorChanged, value);
@@ -2703,6 +2703,7 @@ public partial class Form : ContainerControl
     /// </summary>
     [SRCategory(nameof(SR.CatAppearance))]
     [SRDescription(nameof(SR.FormCaptionBackColorChangedDescr))]
+    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public event EventHandler? FormCaptionBackColorChanged
     {
         add => Events.AddHandler(s_formCaptionBackColorChanged, value);
@@ -2714,6 +2715,7 @@ public partial class Form : ContainerControl
     /// </summary>
     [SRCategory(nameof(SR.CatAppearance))]
     [SRDescription(nameof(SR.FormCaptionTextColorChangedDescr))]
+    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public event EventHandler? FormCaptionTextColorChanged
     {
         add => Events.AddHandler(s_formCaptionTextColorChanged, value);
@@ -2725,6 +2727,7 @@ public partial class Form : ContainerControl
     /// </summary>
     [SRCategory(nameof(SR.CatAppearance))]
     [SRDescription(nameof(SR.FormCornerPreferenceChangedDescr))]
+    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public event EventHandler? FormCornerPreferenceChanged
     {
         add => Events.AddHandler(s_formCornerPreferenceChanged, value);

--- a/src/System.Windows.Forms/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Form.cs
@@ -1741,12 +1741,21 @@ public partial class Form : ContainerControl
             }
 
             _formScreenCaptureMode = value;
-            SetScreenCaptureModeInternal(value);
+
+            if (IsHandleCreated)
+            {
+                SetScreenCaptureModeInternal(value);
+            }
         }
     }
 
     private void SetScreenCaptureModeInternal(ScreenCaptureMode value)
     {
+        if (!TopLevel)
+        {
+            return;
+        }
+
         WINDOW_DISPLAY_AFFINITY affinity = value switch
         {
             ScreenCaptureMode.Allow => WINDOW_DISPLAY_AFFINITY.WDA_NONE,
@@ -1761,7 +1770,6 @@ public partial class Form : ContainerControl
     private ScreenCaptureMode GetScreenCaptureModeInternal()
     {
         PInvoke.GetWindowDisplayAffinity(HWND, out uint affinityValue);
-
         WINDOW_DISPLAY_AFFINITY affinity = (WINDOW_DISPLAY_AFFINITY)affinityValue;
 
         return affinity switch

--- a/src/System.Windows.Forms/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Form.cs
@@ -1742,8 +1742,8 @@ public partial class Form : ContainerControl
     ///   the setting takes effect when the form becomes visible.
     ///  </para>
     ///  <para>
-    ///   Warning! Additional top-level window, which will be spinning off the form, will not be affected 
-    ///   by this setting. Please be aware, that for example sensitive information in a pop-up window 
+    ///   Warning! Additional top-level windows, which will be spinning off the form, will not be affected
+    ///   by this setting. Please be aware, that for example sensitive information in a pop-up window
     ///   like a MessageBox, a context menu, DropDownButton menus or PullDown-menus can not be prevented
     ///   from being captured!
     ///  </para>
@@ -1757,7 +1757,7 @@ public partial class Form : ContainerControl
     ///  </para>
     /// </remarks>
     /// <value>
-    ///  One of the <see cref="ScreenCaptureMode"/> enumeration values. The default is 
+    ///  One of the <see cref="ScreenCaptureMode"/> enumeration values. The default is
     ///  <see cref="ScreenCaptureMode.Allow"/>.
     /// </value>
     [SRCategory(nameof(SR.CatWindowStyle))]

--- a/src/System.Windows.Forms/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Form.cs
@@ -2665,7 +2665,6 @@ public partial class Form : ContainerControl
     /// </summary>
     [SRCategory(nameof(SR.CatAppearance))]
     [SRDescription(nameof(SR.FormBorderColorChangedDescr))]
-    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public event EventHandler? FormBorderColorChanged
     {
         add => Events.AddHandler(s_formBorderColorChanged, value);
@@ -2677,7 +2676,6 @@ public partial class Form : ContainerControl
     /// </summary>
     [SRCategory(nameof(SR.CatAppearance))]
     [SRDescription(nameof(SR.FormCaptionBackColorChangedDescr))]
-    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public event EventHandler? FormCaptionBackColorChanged
     {
         add => Events.AddHandler(s_formCaptionBackColorChanged, value);
@@ -2689,7 +2687,6 @@ public partial class Form : ContainerControl
     /// </summary>
     [SRCategory(nameof(SR.CatAppearance))]
     [SRDescription(nameof(SR.FormCaptionTextColorChangedDescr))]
-    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public event EventHandler? FormCaptionTextColorChanged
     {
         add => Events.AddHandler(s_formCaptionTextColorChanged, value);
@@ -2701,7 +2698,6 @@ public partial class Form : ContainerControl
     /// </summary>
     [SRCategory(nameof(SR.CatAppearance))]
     [SRDescription(nameof(SR.FormCornerPreferenceChangedDescr))]
-    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public event EventHandler? FormCornerPreferenceChanged
     {
         add => Events.AddHandler(s_formCornerPreferenceChanged, value);

--- a/src/System.Windows.Forms/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Form.cs
@@ -1725,11 +1725,43 @@ public partial class Form : ContainerControl
     }
 
     /// <summary>
-    ///  If ShowInTaskbar is true then the form will be displayed in the Windows Taskbar.
+    ///  Gets or sets the behavior for preventing screen capture/video recording of the
+    ///  form's content via screen capture applications based on the Windows APIs.
     /// </summary>
-    [DefaultValue(0)]
+    /// <remarks>
+    ///  <para>
+    ///   This property determines how the form's content behaves when captured by screen capture applications
+    ///   or screenshots. Different capture modes provide varying levels of privacy and security for sensitive content.
+    ///  </para>
+    ///  <para>
+    ///   By default, forms allow their content to be captured. Setting this property to a more restrictive value
+    ///   can prevent sensitive information from being captured in screenshots or recorded in screen recordings.
+    ///  </para>
+    ///  <para>
+    ///   The setting takes effect immediately for visible forms. For forms that aren't yet shown,
+    ///   the setting takes effect when the form becomes visible.
+    ///  </para>
+    ///  <para>
+    ///   Warning! Additional top-level window, which will be spinning off the form, will not be affected 
+    ///   by this setting. Please be aware, that for example sensitive information in a pop-up window 
+    ///   like a MessageBox, a context menu, DropDownButton menus or PullDown-menus can not be prevented
+    ///   from being captured!
+    ///  </para>
+    ///  <para>
+    ///   Note that this setting only affects the current form and not any other windows in the application.
+    ///   Also note that this will also affect video streaming applications for video conferencing, etc.
+    ///  </para>
+    ///  <para>
+    ///   Disclaimer: Please keep in mind, that this setting can of course not prevent screen recordings by tools,
+    ///   which are either circumvent the public Windows APIs or use hardware-based screen capture methods.
+    ///  </para>
+    /// </remarks>
+    /// <value>
+    ///  One of the <see cref="ScreenCaptureMode"/> enumeration values. The default is 
+    ///  <see cref="ScreenCaptureMode.Allow"/>.
+    /// </value>
     [SRCategory(nameof(SR.CatWindowStyle))]
-    [SRDescription("")]
+    [SRDescription(nameof(SR.FormScreenCaptureModeDescr))]
     public ScreenCaptureMode FormScreenCaptureMode
     {
         get => _formScreenCaptureMode;
@@ -1749,6 +1781,12 @@ public partial class Form : ContainerControl
         }
     }
 
+    private bool ShouldSerializeFormScreenCaptureMode() =>
+        FormScreenCaptureMode != ScreenCaptureMode.Allow;
+
+    private void ResetFormScreenCaptureMode() =>
+        FormScreenCaptureMode = ScreenCaptureMode.Allow;
+
     private void SetScreenCaptureModeInternal(ScreenCaptureMode value)
     {
         if (!TopLevel)
@@ -1765,19 +1803,6 @@ public partial class Form : ContainerControl
         };
 
         PInvoke.SetWindowDisplayAffinity(HWND, affinity);
-    }
-
-    private ScreenCaptureMode GetScreenCaptureModeInternal()
-    {
-        PInvoke.GetWindowDisplayAffinity(HWND, out uint affinityValue);
-        WINDOW_DISPLAY_AFFINITY affinity = (WINDOW_DISPLAY_AFFINITY)affinityValue;
-
-        return affinity switch
-        {
-            WINDOW_DISPLAY_AFFINITY.WDA_EXCLUDEFROMCAPTURE => ScreenCaptureMode.HideWindow,
-            WINDOW_DISPLAY_AFFINITY.WDA_MONITOR => ScreenCaptureMode.HideContent,
-            _ => ScreenCaptureMode.Allow,
-        };
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Form.cs
@@ -1772,6 +1772,8 @@ public partial class Form : ContainerControl
                 return;
             }
 
+            SourceGenerated.EnumValidator.Validate(value);
+
             _formScreenCaptureMode = value;
 
             if (IsHandleCreated)

--- a/src/System.Windows.Forms/System/Windows/Forms/ScreenCaptureMode.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/ScreenCaptureMode.cs
@@ -20,7 +20,11 @@ public enum ScreenCaptureMode
 
     /// <summary>
     ///  The form or control appears blurred in screenshots.
-    /// Requires Windows 10 version 2004 or higher.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Using this option requires Windows 10 version 2004 or higher.
+    ///  </para>
+    /// </remarks>
     HideWindow = 2
 }

--- a/src/System.Windows.Forms/System/Windows/Forms/ScreenCaptureMode.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/ScreenCaptureMode.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms;
+
+/// <summary>
+///  Enumeration defining the behavior when a form or control is captured in a screenshot.
+/// </summary>
+public enum ScreenCaptureMode
+{
+    /// <summary>
+    ///  The form or control can be captured normally in screenshots. Default.
+    /// </summary>
+    Allow = 0,
+
+    /// <summary>
+    ///  The form or control appears blacked out in screenshots.
+    /// </summary>
+    HideContent = 1,
+
+    /// <summary>
+    ///  The form or control appears blurred in screenshots.
+    /// Requires Windows 10 version 2004 or higher.
+    /// </summary>
+    HideWindow = 2
+}

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/FormTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/FormTests.cs
@@ -1054,7 +1054,7 @@ public class FormTests
 
         // Assert that the form is not top-level and cannot be used for screen capture mode,
         // because it would throw:
-        Assert.Throws<InvalidEnumArgumentException>(
+        Assert.Throws<InvalidOperationException>(
             () => formAsControl.FormScreenCaptureMode = ScreenCaptureMode.HideContent);
     }
 
@@ -1066,7 +1066,7 @@ public class FormTests
     public void Form_FormScreenCaptureMode_TestInvalidEnumValues(int invalidValue)
     {
         using Form form = new();
-        Assert.Throws<ArgumentException>(() => form.FormScreenCaptureMode = (ScreenCaptureMode)invalidValue);
+        Assert.Throws<InvalidEnumArgumentException>(() => form.FormScreenCaptureMode = (ScreenCaptureMode)invalidValue);
     }
 
     [WinFormsTheory]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/FormTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/FormTests.cs
@@ -165,6 +165,7 @@ public class FormTests
         Assert.False(control.VScroll);
         Assert.Equal(300, control.Width);
         Assert.Equal(FormWindowState.Normal, control.WindowState);
+        Assert.Equal(ScreenCaptureMode.Allow, control.FormScreenCaptureMode);
 
         Assert.False(control.IsHandleCreated);
     }
@@ -1029,6 +1030,43 @@ public class FormTests
 
         Assert.Equal(new Point(20, 21), form.Location);
         Assert.Equal(new Size(300, 310), form.Size);
+    }
+
+    [WinFormsFact]
+    public void Form_FormScreenCaptureMode_ThrowIfFormIsNotTopLevel()
+    {
+        if (!OsVersion.IsWindows11_OrGreater())
+        {
+            return;
+        }
+
+        using Form mainForm = new();
+        mainForm.Show();
+
+        using Form formAsControl = new()
+        {
+            TopLevel = false
+        };
+
+        // formIsControl is now a hybrid between control and MDI window.
+        mainForm.Controls.Add(formAsControl);
+        mainForm.Show();
+
+        // Assert that the form is not top-level and cannot be used for screen capture mode,
+        // because it would throw:
+        Assert.Throws<InvalidEnumArgumentException>(
+            () => formAsControl.FormScreenCaptureMode = ScreenCaptureMode.HideContent);
+    }
+
+    [WinFormsTheory]
+    [InlineData(-1)]
+    [InlineData(3)]
+    [InlineData(int.MinValue)]
+    [InlineData(int.MaxValue)]
+    public void Form_FormScreenCaptureMode_TestInvalidEnumValues(int invalidValue)
+    {
+        using Form form = new();
+        Assert.Throws<ArgumentException>(() => form.FormScreenCaptureMode = (ScreenCaptureMode)invalidValue);
     }
 
     [WinFormsTheory]


### PR DESCRIPTION
Fixes #13258.
Fixes #13450.

Looks like this, when _recorded_:

![ScreenCapture](https://github.com/user-attachments/assets/f97c768f-93cd-407b-a90c-b26d481c5559)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13561)