### PR TITLE
[10.0-Preview4] Fix #13557 Removing flag OperationInReleasingDataSource from DataGridView.cs

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
@@ -27015,10 +27015,10 @@ public partial class DataGridView
             {
                 int oldCurrentCellX = _ptCurrentCell.X;
                 int oldCurrentCellY = _ptCurrentCell.Y;
-                if (oldCurrentCellX >= 0
+                if (IsHandleCreated
+                    && oldCurrentCellX >= 0
                     && !_dataGridViewState1[State1_TemporarilyResetCurrentCell]
-                    && !_dataGridViewOper[OperationInDispose]
-                    && !_dataGridViewOper[OperationInReleasingDataSource])
+                    && !_dataGridViewOper[OperationInDispose])
                 {
                     DataGridViewCell currentCell = CurrentCellInternal;
                     if (!EndEdit(

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
@@ -222,7 +222,6 @@ public partial class DataGridView : Control, ISupportInitialize
     private const int OperationInEndEdit = 0x00400000;
     private const int OperationResizingOperationAboutToStart = 0x00800000;
     private const int OperationTrackKeyboardColResize = 0x01000000;
-    private const int OperationInReleasingDataSource = 0x02000000;
     private const int OperationMouseOperationMask = OperationTrackColResize | OperationTrackRowResize |
         OperationTrackColRelocation | OperationTrackColHeadersResize | OperationTrackRowHeadersResize;
     private const int OperationKeyboardOperationMask = OperationTrackKeyboardColResize;
@@ -1922,16 +1921,7 @@ public partial class DataGridView : Control, ISupportInitialize
                     newDataSource.Disposed += OnDataSourceDisposed;
                 }
 
-                _dataGridViewOper[OperationInReleasingDataSource] = true;
-
-                try
-                {
-                    CurrentCell = null;
-                }
-                finally
-                {
-                    _dataGridViewOper[OperationInReleasingDataSource] = false;
-                }
+                CurrentCell = null;
 
                 if (DataConnection is null)
                 {


### PR DESCRIPTION
Backport of #13362 to release/10.0-Preview4
Fixes https://github.com/dotnet/winforms/issues/13557 

### Customer Impact
In DataGridView.CellValueChanged event handler, DataSource=null throws exception

### Fix
Set `CurrentCell = null;` in DataSource set method, and add judgment `IsHandleCreated` before invoking `EndEdit` to avoid the exception

### Testing
Manual with the customer repro case.

## Risk
Low - This change has been included in .net8, .net9, and works fine.
