### PR TITLE
Related to #10466   Support Tab key in the demo console

### DIFF
--- a/src/test/integration/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/test/integration/DesignSurface/DemoConsole/MainForm.cs
@@ -61,6 +61,19 @@ public partial class MainForm : Form
                     case Keys.Right:
                         designSurfaceExtended.DoAction("KeyMoveRight");
                         break;
+                    case Keys.Tab:
+                        {
+                            if (e.Shift)
+                            {
+                                designSurfaceExtended.DoAction("KeySelectPrevious");
+                            }
+                            else
+                            {
+                                designSurfaceExtended.DoAction("KeySelectNext");
+                            }
+                        }
+
+                        break;
                 }
             };
         }

--- a/src/test/integration/DesignSurface/DesignSurfaceExt/DesignSurfaceExt.cs
+++ b/src/test/integration/DesignSurface/DesignSurfaceExt/DesignSurfaceExt.cs
@@ -354,6 +354,8 @@ public class DesignSurfaceExtended : DesignSurface, IDesignSurfaceExtended
                 "KEYMOVEDOWN" => MenuCommands.KeyMoveDown,
                 "KEYMOVELEFT" => MenuCommands.KeyMoveLeft,
                 "KEYMOVERIGHT" => MenuCommands.KeyMoveRight,
+                "KEYSELECTNEXT" => MenuCommands.KeySelectNext,
+                "KEYSELECTPREVIOUS" => MenuCommands.KeySelectPrevious,
                 _ => null,
             };
 


### PR DESCRIPTION

Related to #10466   Support Tab key in the demo console


## Proposed changes

- 
- Add tab
- 

<!-- 

## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-
 -->

### Before

Not supported.

### After
![PR_13570](https://github.com/user-attachments/assets/edb836c2-abd5-43ca-8475-c005bfc6ca93)

<!-- 


## Test methodology

- 
- 
- 
TODO
 -->


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13570)