### PR TITLE
fix #13086 The DemoConsole application in the Winforms repo stops running after convert added MenuItems to other type items then clicking the last 'Type Here'

### DIFF
--- a/src/test/integration/DesignSurface/DesignSurfaceExt/NameCreationServiceImp.cs
+++ b/src/test/integration/DesignSurface/DesignSurfaceExt/NameCreationServiceImp.cs
@@ -62,7 +62,26 @@ internal sealed class NameCreationService : INameCreationService
         else
         {
             int j = max + 1;
+            j = Check(j);
             return $"{type.Name}{j}";
+        }
+
+        int Check(int index)
+        {
+            return Exists($"{type.Name}{index}") ? Check(index + 1) : index;
+        }
+
+        bool Exists(string name)
+        {
+            for (int j = 0; j < cc.Count; j++)
+            {
+                if (cc[j] is Component comp && comp.Site.Name.Equals(name, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 


### PR DESCRIPTION

Fixes #13086 

## Root cause


## Proposed changes

- 
- modify NameCreationServiceImp.CreateName()
- 


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

https://github.com/user-attachments/assets/350c03de-6904-4a56-8c61-1b4a7bdddcb2

### After




## Test methodology 

- 
- manually
- 
