### PR TITLE
Add do...while loop in the SetValue method of SerializationResourceManager.cs until resourceName is unique

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.SerializationResourceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.SerializationResourceManager.cs
@@ -779,7 +779,7 @@ internal partial class ResourceCodeDomSerializer
             // Only append the number when appendCount is set or if there is already a count.
             int count = 0;
 
-            if (appendCount || _nameTable.ContainsKey(resourceName))
+            if (appendCount || _nameTable.ContainsKey(nameBase))
             {
                 _nameTable.TryGetValue(nameBase, out count);
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.SerializationResourceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.SerializationResourceManager.cs
@@ -778,10 +778,17 @@ internal partial class ResourceCodeDomSerializer
 
             // Only append the number when appendCount is set or if there is already a count.
             int count = 0;
-            if (appendCount || _nameTable.TryGetValue(nameBase, out count))
+
+            if (appendCount || _nameTable.ContainsKey(resourceName))
             {
-                count++;
-                resourceName = $"{nameBase}{count}";
+                _nameTable.TryGetValue(nameBase, out count);
+
+                do
+                {
+                    count++;
+                    resourceName = $"{nameBase}{count}";
+                }
+                while (_nameTable.ContainsKey(resourceName));
             }
 
             // Now that we have a name, write out the resource.


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12595

## Root Cause

This issue is caused by replacing `for (;;)` with `if (appendCount || _nameTable.TryGetValue(nameBase, out count))` in PR #8332, which leads to resource name conflicts.

## Proposed changes

- Add do...while loop in the SetValue method until resourceName is unique

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- When serializing collection values, the resource numeric suffix can be incremented without duplication

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Paste after the second time, the resource will end up using the same number 1 over and over
![Image](https://github.com/user-attachments/assets/6540e3bf-481e-4853-8285-2d5ed0f22485)

### After
Resource suffixes are increasing

![AfterChange](https://github.com/user-attachments/assets/e4750933-0693-4cf4-a155-410448dbac8b)

## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-preview.6.25304.106


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13578)