### PR TITLE
Refactor DarkMode management for Controls as per API Review outcome

### DIFF
--- a/src/System.Windows.Forms/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/PublicAPI.Shipped.txt
@@ -1,23 +1,10 @@
 #nullable enable
 [WFO5001]static System.Windows.Forms.Application.SetColorMode(System.Windows.Forms.SystemColorMode systemColorMode) -> void
 [WFO5001]System.Windows.Forms.ControlStyles.ApplyThemingImplicitly = 524288 -> System.Windows.Forms.ControlStyles
-[WFO5001]System.Windows.Forms.Form.FormBorderColorChanged -> System.EventHandler?
-[WFO5001]System.Windows.Forms.Form.FormCaptionBackColorChanged -> System.EventHandler?
-[WFO5001]System.Windows.Forms.Form.FormCaptionTextColorChanged -> System.EventHandler?
-[WFO5001]System.Windows.Forms.Form.FormCornerPreferenceChanged -> System.EventHandler?
-[WFO5001]System.Windows.Forms.FormCornerPreference
-[WFO5001]System.Windows.Forms.FormCornerPreference.Default = 0 -> System.Windows.Forms.FormCornerPreference
-[WFO5001]System.Windows.Forms.FormCornerPreference.DoNotRound = 1 -> System.Windows.Forms.FormCornerPreference
-[WFO5001]System.Windows.Forms.FormCornerPreference.Round = 2 -> System.Windows.Forms.FormCornerPreference
-[WFO5001]System.Windows.Forms.FormCornerPreference.RoundSmall = 3 -> System.Windows.Forms.FormCornerPreference
 [WFO5001]System.Windows.Forms.SystemColorMode
 [WFO5001]System.Windows.Forms.SystemColorMode.Classic = 0 -> System.Windows.Forms.SystemColorMode
 [WFO5001]System.Windows.Forms.SystemColorMode.Dark = 2 -> System.Windows.Forms.SystemColorMode
 [WFO5001]System.Windows.Forms.SystemColorMode.System = 1 -> System.Windows.Forms.SystemColorMode
-[WFO5001]virtual System.Windows.Forms.Form.OnFormBorderColorChanged(System.EventArgs! e) -> void
-[WFO5001]virtual System.Windows.Forms.Form.OnFormCaptionBackColorChanged(System.EventArgs! e) -> void
-[WFO5001]virtual System.Windows.Forms.Form.OnFormCaptionTextColorChanged(System.EventArgs! e) -> void
-[WFO5001]virtual System.Windows.Forms.Form.OnFormCornerPreferenceChanged(System.EventArgs! e) -> void
 [WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(nint hwndOwner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
 [WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(System.Windows.Forms.IWin32Window! owner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
 [WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterScreen) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!

--- a/src/System.Windows.Forms/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/PublicAPI.Unshipped.txt
@@ -1,26 +1,11 @@
+override System.Windows.Forms.DataGridView.CreateParams.get -> System.Windows.Forms.CreateParams!
+override System.Windows.Forms.TabPage.CreateParams.get -> System.Windows.Forms.CreateParams!
 System.Windows.Forms.Form.FormScreenCaptureMode.get -> System.Windows.Forms.ScreenCaptureMode
 System.Windows.Forms.Form.FormScreenCaptureMode.set -> void
 System.Windows.Forms.ScreenCaptureMode
 System.Windows.Forms.ScreenCaptureMode.Allow = 0 -> System.Windows.Forms.ScreenCaptureMode
 System.Windows.Forms.ScreenCaptureMode.HideContent = 1 -> System.Windows.Forms.ScreenCaptureMode
 System.Windows.Forms.ScreenCaptureMode.HideWindow = 2 -> System.Windows.Forms.ScreenCaptureMode
-override System.Windows.Forms.ButtonBase.InitializeControl(int deviceDpi) -> void
-override System.Windows.Forms.CheckBox.InitializeControl(int deviceDpi) -> void
-override System.Windows.Forms.DataGridView.InitializeControl(int deviceDpi) -> void
-override System.Windows.Forms.Label.InitializeControl(int deviceDpi) -> void
-override System.Windows.Forms.ListBox.InitializeControl(int deviceDpi) -> void
-override System.Windows.Forms.MonthCalendar.InitializeControl(int deviceDpi) -> void
-override System.Windows.Forms.PictureBox.InitializeControl(int deviceDpi) -> void
-override System.Windows.Forms.ProgressBar.InitializeControl(int deviceDpi) -> void
-override System.Windows.Forms.RadioButton.InitializeControl(int deviceDpi) -> void
-override System.Windows.Forms.ScrollableControl.InitializeControl(int deviceDpi) -> void
-override System.Windows.Forms.ScrollBar.InitializeControl(int deviceDpi) -> void
-override System.Windows.Forms.Splitter.InitializeControl(int deviceDpi) -> void
-override System.Windows.Forms.TabControl.InitializeControl(int deviceDpi) -> void
-override System.Windows.Forms.TabPage.InitializeControl(int deviceDpi) -> void
-override System.Windows.Forms.TrackBar.InitializeControl(int deviceDpi) -> void
-override System.Windows.Forms.TreeView.InitializeControl(int deviceDpi) -> void
-virtual System.Windows.Forms.Control.InitializeControl(int deviceDpi) -> void
 [WFO5001]System.Windows.Forms.FormCornerPreference
 [WFO5001]System.Windows.Forms.FormCornerPreference.Default = 0 -> System.Windows.Forms.FormCornerPreference
 [WFO5001]System.Windows.Forms.FormCornerPreference.DoNotRound = 1 -> System.Windows.Forms.FormCornerPreference

--- a/src/System.Windows.Forms/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/PublicAPI.Unshipped.txt
@@ -4,3 +4,33 @@ System.Windows.Forms.ScreenCaptureMode
 System.Windows.Forms.ScreenCaptureMode.Allow = 0 -> System.Windows.Forms.ScreenCaptureMode
 System.Windows.Forms.ScreenCaptureMode.HideContent = 1 -> System.Windows.Forms.ScreenCaptureMode
 System.Windows.Forms.ScreenCaptureMode.HideWindow = 2 -> System.Windows.Forms.ScreenCaptureMode
+override System.Windows.Forms.ButtonBase.InitializeControl(int deviceDpi) -> void
+override System.Windows.Forms.CheckBox.InitializeControl(int deviceDpi) -> void
+override System.Windows.Forms.DataGridView.InitializeControl(int deviceDpi) -> void
+override System.Windows.Forms.Label.InitializeControl(int deviceDpi) -> void
+override System.Windows.Forms.ListBox.InitializeControl(int deviceDpi) -> void
+override System.Windows.Forms.MonthCalendar.InitializeControl(int deviceDpi) -> void
+override System.Windows.Forms.PictureBox.InitializeControl(int deviceDpi) -> void
+override System.Windows.Forms.ProgressBar.InitializeControl(int deviceDpi) -> void
+override System.Windows.Forms.RadioButton.InitializeControl(int deviceDpi) -> void
+override System.Windows.Forms.ScrollableControl.InitializeControl(int deviceDpi) -> void
+override System.Windows.Forms.ScrollBar.InitializeControl(int deviceDpi) -> void
+override System.Windows.Forms.Splitter.InitializeControl(int deviceDpi) -> void
+override System.Windows.Forms.TabControl.InitializeControl(int deviceDpi) -> void
+override System.Windows.Forms.TabPage.InitializeControl(int deviceDpi) -> void
+override System.Windows.Forms.TrackBar.InitializeControl(int deviceDpi) -> void
+override System.Windows.Forms.TreeView.InitializeControl(int deviceDpi) -> void
+virtual System.Windows.Forms.Control.InitializeControl(int deviceDpi) -> void
+[WFO5001]System.Windows.Forms.FormCornerPreference
+[WFO5001]System.Windows.Forms.FormCornerPreference.Default = 0 -> System.Windows.Forms.FormCornerPreference
+[WFO5001]System.Windows.Forms.FormCornerPreference.DoNotRound = 1 -> System.Windows.Forms.FormCornerPreference
+[WFO5001]System.Windows.Forms.FormCornerPreference.Round = 2 -> System.Windows.Forms.FormCornerPreference
+[WFO5001]System.Windows.Forms.FormCornerPreference.RoundSmall = 3 -> System.Windows.Forms.FormCornerPreference
+[WFO5001]System.Windows.Forms.Form.FormBorderColorChanged -> System.EventHandler?
+[WFO5001]System.Windows.Forms.Form.FormCaptionBackColorChanged -> System.EventHandler?
+[WFO5001]System.Windows.Forms.Form.FormCaptionTextColorChanged -> System.EventHandler?
+[WFO5001]System.Windows.Forms.Form.FormCornerPreferenceChanged -> System.EventHandler?
+[WFO5001]virtual System.Windows.Forms.Form.OnFormBorderColorChanged(System.EventArgs! e) -> void
+[WFO5001]virtual System.Windows.Forms.Form.OnFormCaptionBackColorChanged(System.EventArgs! e) -> void
+[WFO5001]virtual System.Windows.Forms.Form.OnFormCaptionTextColorChanged(System.EventArgs! e) -> void
+[WFO5001]virtual System.Windows.Forms.Form.OnFormCornerPreferenceChanged(System.EventArgs! e) -> void

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/Button.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/Button.cs
@@ -146,6 +146,38 @@ public partial class Button : ButtonBase, IButtonControl
         }
     }
 
+#pragma warning disable WFO5001
+    /// <summary>
+    ///  Defines, whether the control is owner-drawn. Based on this,
+    ///  the UserPaint flags get set, which in turn makes it later
+    ///  a Win32 controls, which we wrap (OwnerDraw == false) or if we
+    ///  draw ourselves. If the user wants to opt out of DarkMode, we cannot
+    ///  force System-Painting for FlatStyle.Standard, so we need to know here
+    ///  and now.
+    /// </summary>
+    private protected override bool OwnerDraw
+    {
+        get
+        {
+            if (Application.IsDarkModeEnabled
+                // The SystemRenderer cannot render images. So, we flip to our
+                // own DarkMode renderer, if we need to render images, except if
+                && GetStyle(ControlStyles.ApplyThemingImplicitly)
+                // the user wants to opt out of implicit DarkMode rendering.
+                && Image is null
+                // And this only counts for FlatStyle.Standard. For the rest,
+                // we're using specific renderers, which check themselves, if
+                // they need to apply Light- or DarkMode.
+                && FlatStyle == FlatStyle.Standard)
+            {
+                return false;
+            }
+
+            return base.OwnerDraw;
+        }
+    }
+#pragma warning restore WFO5001
+
     internal override bool SupportsUiaProviders => true;
 
     /// <summary>

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonBase.cs
@@ -82,17 +82,6 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
         SetFlag(FlagShowToolTip, false);
     }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    protected override void InitializeControl(int deviceDpi)
-    {
-        // Call the base classes, and let them setup their fields.
-        base.InitializeControl(deviceDpi);
-
-        // Opt into DarkMode.
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-    }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
     /// <summary>
     ///  Gets or sets a value indicating whether the ellipsis character (...) appears at the right edge of the control,
     ///  denoting that the control text extends beyond the specified length of the control.
@@ -265,6 +254,10 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
     {
         get
         {
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+            SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
             CreateParams cp = base.CreateParams;
             if (!OwnerDraw)
             {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonBase.cs
@@ -78,13 +78,20 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
 
         SetStyle(ControlStyles.UserMouse | ControlStyles.UserPaint, OwnerDraw);
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
-
         SetFlag(FlagUseMnemonic, true);
         SetFlag(FlagShowToolTip, false);
     }
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    protected override void InitializeControl(int deviceDpi)
+    {
+        // Call the base classes, and let them setup their fields.
+        base.InitializeControl(deviceDpi);
+
+        // Opt into DarkMode.
+        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+    }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     /// <summary>
     ///  Gets or sets a value indicating whether the ellipsis character (...) appears at the right edge of the control,
@@ -617,7 +624,7 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
         }
     }
 
-    internal bool OwnerDraw => FlatStyle != FlatStyle.System;
+    private protected virtual bool OwnerDraw => FlatStyle != FlatStyle.System;
 
     bool? ICommandBindingTargetProvider.PreviousEnabledStatus { get; set; }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/CheckBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/CheckBox.cs
@@ -49,6 +49,8 @@ public partial class CheckBox : ButtonBase
         TextAlign = ContentAlignment.MiddleLeft;
     }
 
+    protected override void InitializeControl(int deviceDpi) => ScaleConstants();
+
     private bool AccObjDoDefaultAction { get; set; }
 
     /// <summary>
@@ -255,8 +257,6 @@ public partial class CheckBox : ButtonBase
         base.RescaleConstantsForDpi(deviceDpiOld, deviceDpiNew);
         ScaleConstants();
     }
-
-    private protected override void InitializeConstantsForInitialDpi(int initialDpi) => ScaleConstants();
 
     private void ScaleConstants()
     {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/CheckBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/CheckBox.cs
@@ -49,7 +49,7 @@ public partial class CheckBox : ButtonBase
         TextAlign = ContentAlignment.MiddleLeft;
     }
 
-    protected override void InitializeControl(int deviceDpi) => ScaleConstants();
+    private protected override void InitializeControl() => ScaleConstants();
 
     private bool AccObjDoDefaultAction { get; set; }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/RadioButton.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/RadioButton.cs
@@ -241,7 +241,7 @@ public partial class RadioButton : ButtonBase
         _flatSystemStyleMinimumHeight = LogicalToDeviceUnits(LogicalFlatSystemStyleMinimumHeight);
     }
 
-    protected override void InitializeControl(int deviceDpi) => ScaleConstants();
+    private protected override void InitializeControl() => ScaleConstants();
 
     internal override Size GetPreferredSizeCore(Size proposedConstraints)
     {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/RadioButton.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/RadioButton.cs
@@ -233,9 +233,6 @@ public partial class RadioButton : ButtonBase
         ScaleConstants();
     }
 
-    private protected override void InitializeConstantsForInitialDpi(int initialDpi)
-        => ScaleConstants();
-
     private void ScaleConstants()
     {
         const int LogicalFlatSystemStylePaddingWidth = 24;
@@ -243,6 +240,8 @@ public partial class RadioButton : ButtonBase
         _flatSystemStylePaddingWidth = LogicalToDeviceUnits(LogicalFlatSystemStylePaddingWidth);
         _flatSystemStyleMinimumHeight = LogicalToDeviceUnits(LogicalFlatSystemStyleMinimumHeight);
     }
+
+    protected override void InitializeControl(int deviceDpi) => ScaleConstants();
 
     internal override Size GetPreferredSizeCore(Size proposedConstraints)
     {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.FlatComboAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.FlatComboAdapter.cs
@@ -29,7 +29,7 @@ public partial class ComboBox
             s_offsetPixels = comboBox.LogicalToDeviceUnits(OFFSET_2PIXELS);
 
             _clientRect = comboBox.ClientRectangle;
-            int dropDownButtonWidth = SystemInformation.GetHorizontalScrollBarArrowWidthForDpi(comboBox._deviceDpi);
+            int dropDownButtonWidth = SystemInformation.GetHorizontalScrollBarArrowWidthForDpi(comboBox.DeviceDpiInternal);
             _outerBorder = new Rectangle(_clientRect.Location, new Size(_clientRect.Width - 1, _clientRect.Height - 1));
             _innerBorder = new Rectangle(_outerBorder.X + 1, _outerBorder.Y + 1, _outerBorder.Width - dropDownButtonWidth - 2, _outerBorder.Height - 2);
             _innerInnerBorder = new Rectangle(_innerBorder.X + 1, _innerBorder.Y + 1, _innerBorder.Width - 2, _innerBorder.Height - 2);

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
@@ -488,14 +488,6 @@ public partial class DataGridView : Control, ISupportInitialize
         Invalidate();
     }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    protected override void InitializeControl(int deviceDpi)
-    {
-        base.InitializeControl(deviceDpi);
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-    }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
@@ -1494,6 +1486,17 @@ public partial class DataGridView : Control, ISupportInitialize
 
                 OnColumnHeadersBorderStyleChanged(EventArgs.Empty);
             }
+        }
+    }
+
+    protected override CreateParams CreateParams
+    {
+        get
+        {
+#pragma warning disable WFO5001
+            SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+#pragma warning restore WFO5001
+            return base.CreateParams;
         }
     }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
@@ -387,10 +387,6 @@ public partial class DataGridView : Control, ISupportInitialize
 
         SetStyle(ControlStyles.SupportsTransparentBackColor, false);
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
-
         // this class overrides GetPreferredSizeCore, let Control automatically cache the result
         SetExtendedState(ExtendedStates.UserPreferredSizeCache, true);
 
@@ -491,6 +487,14 @@ public partial class DataGridView : Control, ISupportInitialize
         _columnHeadersHeight = LogicalToDeviceUnits(DefaultColumnHeadersHeight);
         Invalidate();
     }
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    protected override void InitializeControl(int deviceDpi)
+    {
+        base.InitializeControl(deviceDpi);
+        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+    }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Advanced)]

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewColumn.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewColumn.cs
@@ -65,7 +65,9 @@ public class DataGridViewColumn : DataGridViewBand, IComponent
     /// <param name="value"> initial value</param>
     /// <returns> scaled metric</returns>
     private static int ScaleToCurrentDpi(int value) =>
-        ScaleHelper.IsScalingRequirementMet ? ScaleHelper.ScaleToDpi(value, ScaleHelper.InitialSystemDpi) : value;
+        ScaleHelper.IsScalingRequirementMet
+            ? ScaleHelper.ScaleToDpi(value, ScaleHelper.InitialSystemDpi)
+            : value;
 
     [SRCategory(nameof(SR.CatLayout))]
     [DefaultValue(DataGridViewAutoSizeColumnMode.NotSet)]

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Labels/Label.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Labels/Label.cs
@@ -85,14 +85,6 @@ public partial class Label : Control, IAutomationLiveRegion
         _requestedWidth = Width;
     }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    protected override void InitializeControl(int deviceDpi)
-    {
-        base.InitializeControl(deviceDpi);
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-    }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
     /// <summary>
     ///  Indicates whether the control is automatically resized to fit its contents.
     /// </summary>
@@ -251,6 +243,10 @@ public partial class Label : Control, IAutomationLiveRegion
     {
         get
         {
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+            SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
             CreateParams cp = base.CreateParams;
             cp.ClassName = PInvoke.WC_STATIC;
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Labels/Label.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Labels/Label.cs
@@ -74,10 +74,6 @@ public partial class Label : Control, IAutomationLiveRegion
 
         SetStyle(ControlStyles.ResizeRedraw, true);
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
-
         CommonProperties.SetSelfAutoSizeInDefaultLayout(this, true);
 
         _labelState[s_stateFlatStyle] = (int)FlatStyle.Standard;
@@ -88,6 +84,14 @@ public partial class Label : Control, IAutomationLiveRegion
         _requestedHeight = Height;
         _requestedWidth = Width;
     }
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    protected override void InitializeControl(int deviceDpi)
+    {
+        base.InitializeControl(deviceDpi);
+        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+    }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     /// <summary>
     ///  Indicates whether the control is automatically resized to fit its contents.

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListBoxes/ListBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListBoxes/ListBox.cs
@@ -127,21 +127,7 @@ public partial class ListBox : ListControl
         _requestedHeight = Height;
     }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    protected override void InitializeControl(int deviceDpi)
-    {
-        // Call the base classes, and let them setup their fields.
-        base.InitializeControl(deviceDpi);
-
-        // Now we're doing our initialization. We're scaling the constants here,
-        // so that the ListBox can be used in a DPI-aware way.
-        ScaleConstants();
-
-        // And now we're setting the styles we need. In this case,
-        // we want ListBox participating implicitly in any DarkMode support.
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-    }
-#pragma warning restore WFO5001
+    private protected override void InitializeControl() => ScaleConstants();
 
     protected override void RescaleConstantsForDpi(int deviceDpiOld, int deviceDpiNew)
     {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListBoxes/ListBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListBoxes/ListBox.cs
@@ -120,10 +120,6 @@ public partial class ListBox : ListControl
     {
         SetStyle(ControlStyles.UserPaint | ControlStyles.StandardClick | ControlStyles.UseTextForAccessibility, false);
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
-
         // This class overrides GetPreferredSizeCore, let Control automatically cache the result.
         SetExtendedState(ExtendedStates.UserPreferredSizeCache, true);
 
@@ -131,13 +127,27 @@ public partial class ListBox : ListControl
         _requestedHeight = Height;
     }
 
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    protected override void InitializeControl(int deviceDpi)
+    {
+        // Call the base classes, and let them setup their fields.
+        base.InitializeControl(deviceDpi);
+
+        // Now we're doing our initialization. We're scaling the constants here,
+        // so that the ListBox can be used in a DPI-aware way.
+        ScaleConstants();
+
+        // And now we're setting the styles we need. In this case,
+        // we want ListBox participating implicitly in any DarkMode support.
+        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+    }
+#pragma warning restore WFO5001
+
     protected override void RescaleConstantsForDpi(int deviceDpiOld, int deviceDpiNew)
     {
         base.RescaleConstantsForDpi(deviceDpiOld, deviceDpiNew);
         ScaleConstants();
     }
-
-    private protected override void InitializeConstantsForInitialDpi(int initialDpi) => ScaleConstants();
 
     private void ScaleConstants()
     {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/MonthCalendar/MonthCalendar.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/MonthCalendar/MonthCalendar.cs
@@ -141,14 +141,7 @@ public partial class MonthCalendar : Control
         TabStop = true;
     }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    protected override void InitializeControl(int deviceDpi)
-    {
-        base.InitializeControl(deviceDpi);
-        ScaleConstants();
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-    }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    private protected override void InitializeControl() => ScaleConstants();
 
     protected override AccessibleObject CreateAccessibilityInstance()
         => new MonthCalendarAccessibleObject(this);
@@ -291,6 +284,10 @@ public partial class MonthCalendar : Control
     {
         get
         {
+#pragma warning disable WFO5001
+            SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+#pragma warning restore WFO5001
+
             CreateParams cp = base.CreateParams;
             cp.ClassName = PInvoke.MONTHCAL_CLASS;
             cp.Style |= (int)PInvoke.MCS_MULTISELECT | (int)PInvoke.MCS_DAYSTATE;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/MonthCalendar/MonthCalendar.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/MonthCalendar/MonthCalendar.cs
@@ -137,12 +137,18 @@ public partial class MonthCalendar : Control
         _focusedDate = _todaysDate;
         SetStyle(ControlStyles.UserPaint, false);
         SetStyle(ControlStyles.StandardClick, false);
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
 
         TabStop = true;
     }
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    protected override void InitializeControl(int deviceDpi)
+    {
+        base.InitializeControl(deviceDpi);
+        ScaleConstants();
+        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+    }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     protected override AccessibleObject CreateAccessibilityInstance()
         => new MonthCalendarAccessibleObject(this);
@@ -152,8 +158,6 @@ public partial class MonthCalendar : Control
         base.RescaleConstantsForDpi(deviceDpiOld, deviceDpiNew);
         ScaleConstants();
     }
-
-    private protected override void InitializeConstantsForInitialDpi(int initialDpi) => ScaleConstants();
 
     private void ScaleConstants()
     {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PictureBox/PictureBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PictureBox/PictureBox.cs
@@ -110,13 +110,17 @@ public partial class PictureBox : Control, ISupportInitialize
         SetStyle(ControlStyles.Opaque | ControlStyles.Selectable, false);
         SetStyle(ControlStyles.OptimizedDoubleBuffer | ControlStyles.SupportsTransparentBackColor, true);
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
-
         TabStop = false;
         _savedSize = Size;
     }
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    protected override void InitializeControl(int deviceDpi)
+    {
+        base.InitializeControl(deviceDpi);
+        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+    }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PictureBox/PictureBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PictureBox/PictureBox.cs
@@ -114,14 +114,6 @@ public partial class PictureBox : Control, ISupportInitialize
         _savedSize = Size;
     }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    protected override void InitializeControl(int deviceDpi)
-    {
-        base.InitializeControl(deviceDpi);
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-    }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public override bool AllowDrop
@@ -201,6 +193,9 @@ public partial class PictureBox : Control, ISupportInitialize
     {
         get
         {
+#pragma warning disable WFO5001
+            SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+#pragma warning restore WFO5001
             CreateParams cp = base.CreateParams;
 
             switch (_borderStyle)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ProgressBar/ProgressBar.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ProgressBar/ProgressBar.cs
@@ -38,12 +38,16 @@ public partial class ProgressBar : Control
     public ProgressBar() : base()
     {
         SetStyle(ControlStyles.UserPaint | ControlStyles.UseTextForAccessibility | ControlStyles.Selectable, false);
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
-
         ForeColor = s_defaultForeColor;
     }
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    protected override void InitializeControl(int deviceDpi)
+    {
+        base.InitializeControl(deviceDpi);
+        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+    }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     protected override CreateParams CreateParams
     {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ProgressBar/ProgressBar.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ProgressBar/ProgressBar.cs
@@ -41,18 +41,14 @@ public partial class ProgressBar : Control
         ForeColor = s_defaultForeColor;
     }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    protected override void InitializeControl(int deviceDpi)
-    {
-        base.InitializeControl(deviceDpi);
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-    }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
     protected override CreateParams CreateParams
     {
         get
         {
+#pragma warning disable WFO5001
+            SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+#pragma warning restore WFO5001
+
             CreateParams cp = base.CreateParams;
             cp.ClassName = PInvoke.PROGRESS_CLASS;
             if (Style == ProgressBarStyle.Continuous)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
@@ -2593,7 +2593,7 @@ public partial class PropertyGrid : ContainerControl, IComPropertyBrowser, IProp
         {
             // PropertyGrid does a special handling on scaling and positioning its
             // child controls. These are not scaled by their parent when Dpi/Font change.
-            if (_oldDeviceDpi != _deviceDpi)
+            if (FormerDeviceDpi != DeviceDpiInternal)
             {
                 RescaleConstants();
                 SetupToolbar(fullRebuild: true);

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/HelpPane.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/HelpPane.cs
@@ -57,6 +57,8 @@ internal partial class HelpPane : PropertyGrid.SnappableControl
         SetStyle(ControlStyles.Selectable, false);
     }
 
+    protected override void InitializeControl(int deviceDpi) => ScaleConstants();
+
     public virtual int Lines
     {
         get
@@ -177,8 +179,6 @@ internal partial class HelpPane : PropertyGrid.SnappableControl
         base.RescaleConstantsForDpi(deviceDpiOld, deviceDpiNew);
         ScaleConstants();
     }
-
-    private protected override void InitializeConstantsForInitialDpi(int initialDpi) => ScaleConstants();
 
     private void ScaleConstants()
     {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/HelpPane.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/HelpPane.cs
@@ -57,7 +57,7 @@ internal partial class HelpPane : PropertyGrid.SnappableControl
         SetStyle(ControlStyles.Selectable, false);
     }
 
-    protected override void InitializeControl(int deviceDpi) => ScaleConstants();
+    private protected override void InitializeControl() => ScaleConstants();
 
     public virtual int Lines
     {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
@@ -214,7 +214,7 @@ internal sealed partial class PropertyGridView :
 
                 CommonEditorSetup(_dropDownButton);
                 _dropDownButton.Size = ScaleHelper.IsScalingRequirementMet
-                    ? new(SystemInformation.VerticalScrollBarArrowHeightForDpi(_deviceDpi), RowHeight)
+                    ? new(SystemInformation.VerticalScrollBarArrowHeightForDpi(DeviceDpiInternal), RowHeight)
                     : new(SystemInformation.VerticalScrollBarArrowHeight, RowHeight);
             }
 
@@ -252,7 +252,7 @@ internal sealed partial class PropertyGridView :
                 _dialogButton.GotFocus += OnDropDownButtonGotFocus;
                 _dialogButton.LostFocus += OnChildLostFocus;
                 _dialogButton.Size = ScaleHelper.IsScalingRequirementMet
-                    ? new Size(SystemInformation.VerticalScrollBarArrowHeightForDpi(_deviceDpi), RowHeight)
+                    ? new Size(SystemInformation.VerticalScrollBarArrowHeightForDpi(DeviceDpiInternal), RowHeight)
                     : new Size(SystemInformation.VerticalScrollBarArrowHeight, RowHeight);
 
                 CommonEditorSetup(_dialogButton);
@@ -4331,7 +4331,7 @@ internal sealed partial class PropertyGridView :
         {
             Control button = needsDropDownButton ? DropDownButton : DialogButton;
             Size sizeBtn = ScaleHelper.IsScalingRequirementMet
-                ? new Size(SystemInformation.VerticalScrollBarArrowHeightForDpi(_deviceDpi), RowHeight)
+                ? new Size(SystemInformation.VerticalScrollBarArrowHeightForDpi(DeviceDpiInternal), RowHeight)
                 : new Size(SystemInformation.VerticalScrollBarArrowHeight, RowHeight);
 
             Rectangle rectTarget = new(
@@ -5144,7 +5144,7 @@ internal sealed partial class PropertyGridView :
                 bool isScalingRequirementMet = ScaleHelper.IsScalingRequirementMet;
                 if (isScalingRequirementMet)
                 {
-                    _dropDownButton.Size = new(SystemInformation.VerticalScrollBarArrowHeightForDpi(_deviceDpi), RowHeight);
+                    _dropDownButton.Size = new(SystemInformation.VerticalScrollBarArrowHeightForDpi(DeviceDpiInternal), RowHeight);
                 }
                 else
                 {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Splitter/Splitter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Splitter/Splitter.cs
@@ -55,14 +55,6 @@ public partial class Splitter : Control
         Dock = DockStyle.Left;
     }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    protected override void InitializeControl(int deviceDpi)
-    {
-        base.InitializeControl(deviceDpi);
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-    }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
     /// <summary>
     ///  The current value of the anchor property. The anchor property
     ///  determines which edges of the control are anchored to the container's
@@ -211,6 +203,10 @@ public partial class Splitter : Control
     {
         get
         {
+#pragma warning disable WFO5001
+            SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+#pragma warning restore WFO5001
+
             CreateParams cp = base.CreateParams;
             cp.Style &= ~(int)WINDOW_STYLE.WS_BORDER;
             cp.ExStyle &= ~(int)WINDOW_EX_STYLE.WS_EX_CLIENTEDGE;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Splitter/Splitter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Splitter/Splitter.cs
@@ -47,9 +47,6 @@ public partial class Splitter : Control
     public Splitter() : base()
     {
         SetStyle(ControlStyles.Selectable, false);
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
 
         TabStop = false;
         _minSize = 25;
@@ -57,6 +54,14 @@ public partial class Splitter : Control
 
         Dock = DockStyle.Left;
     }
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    protected override void InitializeControl(int deviceDpi)
+    {
+        base.InitializeControl(deviceDpi);
+        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+    }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     /// <summary>
     ///  The current value of the anchor property. The anchor property

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabControl.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabControl.cs
@@ -85,14 +85,6 @@ public partial class TabControl : Control
         SetStyle(ControlStyles.UserPaint, false);
     }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    protected override void InitializeControl(int deviceDpi)
-    {
-        base.InitializeControl(deviceDpi);
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-    }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
     /// <summary>
     ///  Returns on what area of the control the tabs reside on (A TabAlignment value).
     ///  The possibilities are Top (the default), Bottom, Left, and Right. When alignment
@@ -275,6 +267,10 @@ public partial class TabControl : Control
     {
         get
         {
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+            SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
             CreateParams cp = base.CreateParams;
             cp.ClassName = PInvoke.WC_TABCONTROL;
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabControl.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabControl.cs
@@ -83,10 +83,15 @@ public partial class TabControl : Control
 
         _tabCollection = new TabPageCollection(this);
         SetStyle(ControlStyles.UserPaint, false);
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
     }
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    protected override void InitializeControl(int deviceDpi)
+    {
+        base.InitializeControl(deviceDpi);
+        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+    }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     /// <summary>
     ///  Returns on what area of the control the tabs reside on (A TabAlignment value).

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabPage.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabPage.cs
@@ -46,14 +46,6 @@ public partial class TabPage : Panel
         Text = text;
     }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    protected override void InitializeControl(int deviceDpi)
-    {
-        base.InitializeControl(deviceDpi);
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-    }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
     internal override bool AllowsKeyboardToolTip()
         => ParentInternal is TabControl tabControl && tabControl.ShowToolTips;
 
@@ -142,6 +134,18 @@ public partial class TabPage : Panel
 
     protected override AccessibleObject CreateAccessibilityInstance()
         => new TabPageAccessibleObject(this);
+
+    protected override CreateParams CreateParams
+    {
+        get
+        {
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+            SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+            return base.CreateParams;
+        }
+    }
 
     /// <summary>
     ///  Constructs the new instance of the Controls collection objects.

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabPage.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabPage.cs
@@ -35,9 +35,6 @@ public partial class TabPage : Panel
     public TabPage() : base()
     {
         SetStyle(ControlStyles.CacheText, true);
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
         Text = null;
     }
 
@@ -48,6 +45,14 @@ public partial class TabPage : Panel
     {
         Text = text;
     }
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    protected override void InitializeControl(int deviceDpi)
+    {
+        base.InitializeControl(deviceDpi);
+        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+    }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     internal override bool AllowsKeyboardToolTip()
         => ParentInternal is TabControl tabControl && tabControl.ShowToolTips;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TextBox/TextBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TextBox/TextBox.cs
@@ -404,12 +404,12 @@ public partial class TextBox : TextBoxBase
 
         if (Multiline && !WordWrap && (ScrollBars & ScrollBars.Horizontal) != 0)
         {
-            scrollBarPadding.Height += SystemInformation.GetHorizontalScrollBarHeightForDpi(_deviceDpi);
+            scrollBarPadding.Height += SystemInformation.GetHorizontalScrollBarHeightForDpi(DeviceDpiInternal);
         }
 
         if (Multiline && (ScrollBars & ScrollBars.Vertical) != 0)
         {
-            scrollBarPadding.Width += SystemInformation.GetVerticalScrollBarWidthForDpi(_deviceDpi);
+            scrollBarPadding.Width += SystemInformation.GetVerticalScrollBarWidthForDpi(DeviceDpiInternal);
         }
 
         // Subtract the scroll bar padding before measuring

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TextBox/TextBoxBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TextBox/TextBoxBase.cs
@@ -98,15 +98,19 @@ public abstract partial class TextBoxBase : Control
                 | ControlStyles.UseTextForAccessibility
                 | ControlStyles.UserPaint, false);
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
-
         // cache requestedHeight. Note: Control calls DefaultSize (overridable) in the constructor
         // to set the control's cached height that is returned when calling Height, so we just
         // need to get the cached height here.
         _requestedHeight = Height;
     }
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    protected override void InitializeControl(int deviceDpi)
+    {
+        base.InitializeControl(deviceDpi);
+        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+    }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     /// <summary>
     ///  Gets or sets

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TextBox/TextBoxBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TextBox/TextBoxBase.cs
@@ -104,14 +104,6 @@ public abstract partial class TextBoxBase : Control
         _requestedHeight = Height;
     }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    protected override void InitializeControl(int deviceDpi)
-    {
-        base.InitializeControl(deviceDpi);
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-    }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
     /// <summary>
     ///  Gets or sets
     ///  a value indicating whether pressing the TAB key
@@ -405,6 +397,10 @@ public abstract partial class TextBoxBase : Control
     {
         get
         {
+#pragma warning disable WFO5001
+            SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+#pragma warning restore WFO5001
+
             CreateParams cp = base.CreateParams;
             cp.ClassName = PInvoke.WC_EDIT;
             cp.Style |= PInvoke.ES_AUTOHSCROLL | PInvoke.ES_AUTOVSCROLL;
@@ -804,7 +800,7 @@ public abstract partial class TextBoxBase : Control
             int height = FontHeight;
             if (_borderStyle != BorderStyle.None)
             {
-                height += SystemInformation.GetBorderSizeForDpi(_deviceDpi).Height * 4 + 3;
+                height += SystemInformation.GetBorderSizeForDpi(DeviceDpiInternal).Height * 4 + 3;
             }
 
             return height;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDownItem.cs
@@ -775,7 +775,7 @@ public abstract class ToolStripDropDownItem : ToolStripItem
             {
                 // The following does not get set, since dropDown has no parent/is not part of the
                 // controls collection, so this gets never called through the normal inheritance chain.
-                item._dropDown._deviceDpi = newDpi;
+                item._dropDown.DeviceDpiInternal = newDpi;
                 item._dropDown.ResetScaling(newDpi);
 
                 foreach (ToolStripItem childItem in item.DropDown.Items)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TrackBar/TrackBar.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TrackBar/TrackBar.cs
@@ -57,14 +57,6 @@ public partial class TrackBar : Control, ISupportInitialize
         _requestedDim = PreferredDimension;
     }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    protected override void InitializeControl(int deviceDpi)
-    {
-        base.InitializeControl(deviceDpi);
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-    }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
     /// <summary>
     ///  Indicates if the control is being auto-sized. If true, the
     ///  TrackBar will adjust either its height or width [depending on
@@ -152,6 +144,10 @@ public partial class TrackBar : Control, ISupportInitialize
     {
         get
         {
+#pragma warning disable WFO5001
+            SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+#pragma warning restore WFO5001
+
             // If the user opts out of TrackBarModernRendering
             // then _autoDrawTicks will be set to true
             _autoDrawTicks = ShouldAutoDrawTicks();

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TrackBar/TrackBar.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TrackBar/TrackBar.cs
@@ -54,11 +54,16 @@ public partial class TrackBar : Control, ISupportInitialize
         SetStyle(ControlStyles.UserPaint, false);
         SetStyle(ControlStyles.UseTextForAccessibility, false);
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
         _requestedDim = PreferredDimension;
     }
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    protected override void InitializeControl(int deviceDpi)
+    {
+        base.InitializeControl(deviceDpi);
+        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+    }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     /// <summary>
     ///  Indicates if the control is being auto-sized. If true, the

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -172,14 +172,6 @@ public partial class TreeView : Control
         SetStyle(ControlStyles.UseTextForAccessibility, false);
     }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    protected override void InitializeControl(int deviceDpi)
-    {
-        base.InitializeControl(deviceDpi);
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-    }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
     internal override void ReleaseUiaProvider(HWND handle)
     {
         foreach (TreeNode rootNode in Nodes)
@@ -312,6 +304,10 @@ public partial class TreeView : Control
     {
         get
         {
+#pragma warning disable WFO5001
+            SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+#pragma warning restore WFO5001
+
             CreateParams cp = base.CreateParams;
             cp.ClassName = PInvoke.WC_TREEVIEW;
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -170,10 +170,15 @@ public partial class TreeView : Control
         SetStyle(ControlStyles.UserPaint, false);
         SetStyle(ControlStyles.StandardClick, false);
         SetStyle(ControlStyles.UseTextForAccessibility, false);
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
     }
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    protected override void InitializeControl(int deviceDpi)
+    {
+        base.InitializeControl(deviceDpi);
+        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+    }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     internal override void ReleaseUiaProvider(HWND handle)
     {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.UpDownButtons.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.UpDownButtons.cs
@@ -35,15 +35,11 @@ public abstract partial class UpDownBase
             SetStyle(ControlStyles.Opaque | ControlStyles.FixedHeight | ControlStyles.FixedWidth, true);
             SetStyle(ControlStyles.Selectable, false);
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-            SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
-
             _parent = parent;
         }
 
         /// <summary>
-        ///  Adds a handler for the updown button event.
+        ///  Adds a handler for the UpDown button event.
         /// </summary>
         public event UpDownEventHandler? UpDown
         {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.cs
@@ -67,10 +67,6 @@ public abstract partial class UpDownBase : ContainerControl
         SetStyle(ControlStyles.Opaque | ControlStyles.FixedHeight | ControlStyles.ResizeRedraw, true);
         SetStyle(ControlStyles.StandardClick, false);
         SetStyle(ControlStyles.UseTextForAccessibility, false);
-
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
     }
 
     [Browsable(false)]

--- a/src/System.Windows.Forms/System/Windows/Forms/ErrorProvider/ErrorProvider.ErrorWindow.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/ErrorProvider/ErrorProvider.ErrorWindow.cs
@@ -449,12 +449,12 @@ public partial class ErrorProvider
             base.WmDpiChangedBeforeParent(ref m);
 
             int currentDpi = (int)PInvoke.GetDpiForWindow(this);
-            if (currentDpi == _parent._deviceDpi)
+            if (currentDpi == _parent.DeviceDpiInternal)
             {
                 return;
             }
 
-            double factor = ((double)currentDpi) / _parent._deviceDpi;
+            double factor = ((double)currentDpi) / _parent.DeviceDpiInternal;
             Icon icon = _provider.Icon;
             _provider.CurrentDpi = currentDpi;
             _provider.Icon = new Icon(icon, (int)(icon.Width * factor), (int)(icon.Height * factor));

--- a/src/System.Windows.Forms/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Form.cs
@@ -206,10 +206,6 @@ public partial class Form : ContainerControl
 
         SetState(States.Visible, false);
         SetState(States.TopLevel, true);
-
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
     }
 
     /// <summary>
@@ -4341,16 +4337,9 @@ public partial class Form : ContainerControl
             }
         }
 
-        // Finally fire the new OnShown(unless the form has already been closed).
         if (IsHandleCreated)
         {
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-            if (Application.IsDarkModeEnabled)
-            {
-                PInvoke.SetWindowTheme(HWND, $"{DarkModeIdentifier}_{ExplorerThemeIdentifier}", null);
-            }
-#pragma warning restore WFO5001
-
+            // Finally fire the new OnShown(unless the form has already been closed).
             BeginInvoke(new MethodInvoker(CallShownEvent));
         }
     }

--- a/src/System.Windows.Forms/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Form.cs
@@ -4516,7 +4516,7 @@ public partial class Form : ContainerControl
         if (e.DeviceDpiNew != e.DeviceDpiOld)
         {
             CommonProperties.xClearAllPreferredSizeCaches(this);
-            _oldDeviceDpi = e.DeviceDpiOld;
+            FormerDeviceDpi = e.DeviceDpiOld;
 
             // call any additional handlers
             ((DpiChangedEventHandler?)Events[s_dpiChangedEvent])?.Invoke(this, e);
@@ -4578,8 +4578,8 @@ public partial class Form : ContainerControl
     {
         DefWndProc(ref m);
 
-        DpiChangedEventArgs e = new(_deviceDpi, m);
-        _deviceDpi = e.DeviceDpiNew;
+        DpiChangedEventArgs e = new(DeviceDpiInternal, m);
+        DeviceDpiInternal = e.DeviceDpiNew;
 
         OnDpiChanged(e);
     }
@@ -4631,7 +4631,7 @@ public partial class Form : ContainerControl
 
         Size desiredSize = default;
         if ((_dpiFormSizes is not null && _dpiFormSizes.TryGetValue(m.WParamInternal.LOWORD, out desiredSize))
-            || OnGetDpiScaledSize(_deviceDpi, m.WParamInternal.LOWORD, ref desiredSize))
+            || OnGetDpiScaledSize(DeviceDpiInternal, m.WParamInternal.LOWORD, ref desiredSize))
         {
             SIZE* size = (SIZE*)m.LParamInternal;
             size->cx = desiredSize.Width;

--- a/src/System.Windows.Forms/System/Windows/Forms/Layout/Containers/ContainerControl.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Layout/Containers/ContainerControl.cs
@@ -329,7 +329,7 @@ public class ContainerControl : ScrollableControl, IContainerControl
                 // Screen Dpi
                 if (ScaleHelper.IsThreadPerMonitorV2Aware)
                 {
-                    currentAutoScaleDimensions = new SizeF(_deviceDpi, _deviceDpi);
+                    currentAutoScaleDimensions = new SizeF(DeviceDpiInternal, DeviceDpiInternal);
                 }
                 else
                 {

--- a/src/System.Windows.Forms/System/Windows/Forms/MDI/MDIClient.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/MDI/MDIClient.cs
@@ -29,15 +29,17 @@ public sealed partial class MdiClient : Control
     public MdiClient() : base()
     {
         SetStyle(ControlStyles.Selectable, false);
-
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-
         BackColor = SystemColors.AppWorkspace;
-#pragma warning restore WFO5001
-
         Dock = DockStyle.Fill;
     }
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    protected override void InitializeControl(int deviceDpi)
+    {
+        base.InitializeControl(deviceDpi);
+        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+    }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     /// <summary>
     ///  Gets or sets the background image displayed in the <see cref="MdiClient" /> control.

--- a/src/System.Windows.Forms/System/Windows/Forms/MDI/MDIClient.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/MDI/MDIClient.cs
@@ -33,14 +33,6 @@ public sealed partial class MdiClient : Control
         Dock = DockStyle.Fill;
     }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    protected override void InitializeControl(int deviceDpi)
-    {
-        base.InitializeControl(deviceDpi);
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-    }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
     /// <summary>
     ///  Gets or sets the background image displayed in the <see cref="MdiClient" /> control.
     /// </summary>
@@ -87,6 +79,10 @@ public sealed partial class MdiClient : Control
     {
         get
         {
+#pragma warning disable WFO5001
+            SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+#pragma warning restore WFO5001
+
             CreateParams cp = base.CreateParams;
 
             cp.ClassName = "MDICLIENT";

--- a/src/System.Windows.Forms/System/Windows/Forms/Panels/Panel.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Panels/Panel.cs
@@ -30,10 +30,6 @@ public partial class Panel : ScrollableControl
         TabStop = false;
         SetStyle(ControlStyles.Selectable | ControlStyles.AllPaintingInWmPaint, false);
         SetStyle(ControlStyles.SupportsTransparentBackColor, true);
-
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/System/Windows/Forms/Scrolling/ScrollBar.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Scrolling/ScrollBar.cs
@@ -35,21 +35,20 @@ public abstract partial class ScrollBar : Control
         SetStyle(ControlStyles.StandardClick, false);
         SetStyle(ControlStyles.UseTextForAccessibility, false);
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
-
         TabStop = false;
 
-        if ((CreateParams.Style & (int)SCROLLBAR_CONSTANTS.SB_VERT) != 0)
-        {
-            _scrollOrientation = ScrollOrientation.VerticalScroll;
-        }
-        else
-        {
-            _scrollOrientation = ScrollOrientation.HorizontalScroll;
-        }
+        _scrollOrientation = (CreateParams.Style & (int)SCROLLBAR_CONSTANTS.SB_VERT) != 0
+            ? ScrollOrientation.VerticalScroll
+            : ScrollOrientation.HorizontalScroll;
     }
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    protected override void InitializeControl(int deviceDpi)
+    {
+        base.InitializeControl(deviceDpi);
+        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+    }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     /// <summary>
     ///  Hide AutoSize: it doesn't make sense for this control

--- a/src/System.Windows.Forms/System/Windows/Forms/Scrolling/ScrollBar.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Scrolling/ScrollBar.cs
@@ -42,14 +42,6 @@ public abstract partial class ScrollBar : Control
             : ScrollOrientation.HorizontalScroll;
     }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    protected override void InitializeControl(int deviceDpi)
-    {
-        base.InitializeControl(deviceDpi);
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-    }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
     /// <summary>
     ///  Hide AutoSize: it doesn't make sense for this control
     /// </summary>
@@ -122,6 +114,10 @@ public abstract partial class ScrollBar : Control
     {
         get
         {
+#pragma warning disable WFO5001
+            SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+#pragma warning restore WFO5001
+
             CreateParams cp = base.CreateParams;
             cp.ClassName = PInvoke.WC_SCROLLBAR;
             cp.Style &= ~(int)WINDOW_STYLE.WS_BORDER;

--- a/src/System.Windows.Forms/System/Windows/Forms/Scrolling/ScrollableControl.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Scrolling/ScrollableControl.cs
@@ -60,11 +60,15 @@ public partial class ScrollableControl : Control, IArrangedElement
         SetStyle(ControlStyles.ContainerControl, true);
         SetStyle(ControlStyles.AllPaintingInWmPaint, false);
         SetScrollState(ScrollStateAutoScrolling, false);
+    }
 
 #pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    protected override void InitializeControl(int deviceDpi)
+    {
+        base.InitializeControl(deviceDpi);
         SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
     }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     /// <summary>
     ///  Gets or sets a value indicating whether the container will allow the user to

--- a/src/System.Windows.Forms/System/Windows/Forms/Scrolling/ScrollableControl.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Scrolling/ScrollableControl.cs
@@ -62,14 +62,6 @@ public partial class ScrollableControl : Control, IArrangedElement
         SetScrollState(ScrollStateAutoScrolling, false);
     }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    protected override void InitializeControl(int deviceDpi)
-    {
-        base.InitializeControl(deviceDpi);
-        SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-    }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
     /// <summary>
     ///  Gets or sets a value indicating whether the container will allow the user to
     ///  scroll to any controls placed outside of its visible boundaries.
@@ -162,6 +154,10 @@ public partial class ScrollableControl : Control, IArrangedElement
     {
         get
         {
+#pragma warning disable WFO5001
+            SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+#pragma warning restore WFO5001
+
             CreateParams cp = base.CreateParams;
 
             if (HScroll || HorizontalScroll.Visible)

--- a/src/System.Windows.Forms/System/Windows/Forms/Scrolling/VScrollBar.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Scrolling/VScrollBar.cs
@@ -30,7 +30,9 @@ public partial class VScrollBar : ScrollBar
         {
             if (ScaleHelper.IsScalingRequirementMet)
             {
-                return new Size(SystemInformation.GetVerticalScrollBarWidthForDpi(_deviceDpi), LogicalToDeviceUnits(DefaultHeight));
+                return new Size(
+                    SystemInformation.GetVerticalScrollBarWidthForDpi(DeviceDpiInternal),
+                    LogicalToDeviceUnits(DefaultHeight));
             }
 
             return new Size(SystemInformation.VerticalScrollBarWidth, DefaultHeight);


### PR DESCRIPTION
For a Control to indicate that it wants to participate in DarkMode theming, it needs to indicate that by setting the style flag `ApplyThemingImplicitly`. 

Because of the general architecture of the Controls inheritance hierarchy, Controls need to make sure to opt into (or opt out) DarkMode handling _before_ its own constructor runs, which means they have to override `CreateParams` and set the respective flags before calling the base implementation.
