### PR TITLE
Update TreeView's TvnEndLabelEdit method to set label to null when no text has changed

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -2599,7 +2599,10 @@ public partial class TreeView : Control
 
         TreeNode? node = NodeFromHandle(nmtvdi.item.hItem);
         string newText = nmtvdi.item.pszText.ToString();
-        NodeLabelEditEventArgs e = new(node, (node is not null && newText != node.Text) ? newText : null);
+        string? editedText = null;
+        if (node is not null && newText != node.Text)
+            editedText = newText;
+        NodeLabelEditEventArgs e = new(node, editedText);
         OnAfterLabelEdit(e);
         if (newText is not null && !e.CancelEdit && node is not null)
         {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -2574,10 +2574,6 @@ public partial class TreeView : Control
         if (!e.CancelEdit)
         {
             _editNode = editingNode;
-        }
-
-        if (!e.CancelEdit)
-        {
             _labelEdit = new TreeViewLabelEditNativeWindow(this);
             _labelEdit.AssignHandle(PInvokeCore.SendMessage(this, PInvoke.TVM_GETEDITCONTROL));
         }
@@ -2603,7 +2599,7 @@ public partial class TreeView : Control
 
         TreeNode? node = NodeFromHandle(nmtvdi.item.hItem);
         string newText = nmtvdi.item.pszText.ToString();
-        NodeLabelEditEventArgs e = new(node, newText);
+        NodeLabelEditEventArgs e = new(node, (node is not null && newText != node.Text) ? newText : null);
         OnAfterLabelEdit(e);
         if (newText is not null && !e.CancelEdit && node is not null)
         {


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13583


## Proposed changes

-  Update TreeView's `TvnEndLabelEdit` method to set label to null when no text has changed

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The edit state of TreeNode can be exited using the Enter key

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Pressing the Enter key when a TreeNode enters the edit state will cause an exception

![beforeChange](https://github.com/user-attachments/assets/118a2bd7-f7b3-4f19-9e49-4e65db5bc00e)

### After
When a TreeNode enters the edit state, press the Enter key, the node will exit the edit state

![AfterChange](https://github.com/user-attachments/assets/61695ade-0144-4c5d-a037-20ad73d13347)


## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-preview.6.25310.107


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13588)