### PR TITLE
Fix All Dark mode Visual Style Renders

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Control.cs
@@ -162,6 +162,7 @@ public unsafe partial class Control :
     internal const string ExplorerThemeIdentifier = "Explorer";
     internal const string ItemsViewThemeIdentifier = "ItemsView";
     internal const string ComboBoxButtonThemeIdentifier = "CFD";
+    internal const string StatusBarThemeIdentifier = "ExplorerStatusBar";
 
     private const short PaintLayerBackground = 1;
     private const short PaintLayerForeground = 2;

--- a/src/System.Windows.Forms/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Form.cs
@@ -4474,12 +4474,23 @@ public partial class Form : ContainerControl
             if (Application.RenderWithVisualStyles)
             {
                 _sizeGripRenderer ??= new VisualStyleRenderer(VisualStyleElement.Status.Gripper.Normal);
-
                 using DeviceContextHdcScope hdc = new(e);
-                _sizeGripRenderer.DrawBackground(
-                    hdc,
-                    new Rectangle(size.Width - SizeGripSize, size.Height - SizeGripSize, SizeGripSize, SizeGripSize));
+                if (ScaleHelper.IsScalingRequired)
+                {
+                    Size sizeGripSize = _sizeGripRenderer.GetPartSize(hdc, ThemeSizeType.True, HWND);
+                    _sizeGripRenderer.DrawBackground(
+                   hdc,
+                   new Rectangle(size.Width - sizeGripSize.Width, size.Height - sizeGripSize.Height, sizeGripSize.Width, sizeGripSize.Height));
+                }
+
+                else
+                {
+                    _sizeGripRenderer.DrawBackground(
+                  hdc,
+                  new Rectangle(size.Width - SizeGripSize, size.Height - SizeGripSize, SizeGripSize, SizeGripSize));
+                }
             }
+
             else
             {
                 ControlPaint.DrawSizeGrip(


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11950, #11949, #12909, #11893, #11901, #12040

## Proposed changes

- Enhanced dark mode visual style generation and selection logic, with custom handling for Button, ComboBox, Toolbar, Header, Status, and TreeView controls.
- Improved consistency and accuracy of dark mode rendering, especially for high-DPI displays.

## Customer Impact

- More visually consistent dark mode experience for end users.
- High-DPI setups now render dark mode elements correctly and reliably.

## Regression? 

- No
- 
## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

https://github.com/user-attachments/assets/b7736281-09db-40ec-9c3d-5c75228a3073



### After




https://github.com/user-attachments/assets/b234ea18-dc33-4808-b6c3-0bb39070f002

## Test methodology <!-- How did you ensure quality? -->

- Manual testing across various controls in dark mode and high-DPI environments.
- Verified correct rendering for affected controls.
- Ran existing integration tests.

## Test environment(s) 

- Tested on Windows 11, Latest .NET 10 SDK build: 10.0.100-preview.6.25311.107

## UI scaling,
100% UI scaling  and other UI scaling.