### PR TITLE
Fix leak in UpDownBaseTests

### DIFF
--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/UpDownBaseTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/UpDownBaseTests.cs
@@ -3086,6 +3086,8 @@ public class UpDownBaseTests
 
     public class SubUpDownBase : UpDownBase
     {
+        private int _onHandleCreatedCount;
+
         public new const int ScrollStateAutoScrolling = ScrollableControl.ScrollStateAutoScrolling;
 
         public new const int ScrollStateHScrollVisible = ScrollableControl.ScrollStateHScrollVisible;
@@ -3191,7 +3193,11 @@ public class UpDownBaseTests
 
         public new void OnFontChanged(EventArgs e) => base.OnFontChanged(e);
 
-        public new void OnHandleCreated(EventArgs e) => base.OnHandleCreated(e);
+        public new void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+            _onHandleCreatedCount++;
+        }
 
         public new void OnHandleDestroyed(EventArgs e) => base.OnHandleDestroyed(e);
 
@@ -3226,6 +3232,31 @@ public class UpDownBaseTests
         public new void RescaleConstantsForDpi(int deviceDpiOld, int deviceDpiNew) => base.RescaleConstantsForDpi(deviceDpiOld, deviceDpiNew);
 
         public new void SetBoundsCore(int x, int y, int width, int height, BoundsSpecified specified) => base.SetBoundsCore(x, y, width, height, specified);
+
+        protected override void Dispose(bool disposing)
+        {
+            // See https://github.com/dotnet/winforms/issues/13596.
+            // Some tests call OnHandleCreated (even multiple times!), but doesn't really create handle.
+            // In this case, we are subscribing to UserPreferenceChanged (multiple times!).
+            // We need to call OnHandleDestroyed to avoid leaks.
+            // We need to call it the "right" number of times though.
+            // We start with _onHandleCreatedCount.
+            var destroyCount = disposing ? _onHandleCreatedCount : 0;
+
+            if (IsHandleCreated)
+            {
+                // If a "real" handle was created, base.Dispose will destroy.
+                // So, we subtract 1.
+                destroyCount--;
+            }
+
+            for (int i = 0; i < destroyCount; i++)
+            {
+                OnHandleDestroyed(EventArgs.Empty);
+            }
+
+            base.Dispose(disposing);
+        }
 
         public override void UpButton()
         {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #


## Proposed changes

- 
- 
- 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- 
- 
- 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- <!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->
