### PR TITLE
Fix 13627 DemoConsole app: The open button cannot be seen in TreeView Tasks dialog in Dark Mode

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.EditorButton.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.EditorButton.cs
@@ -30,8 +30,8 @@ internal sealed partial class DesignerActionPanel
 
             public EditorButton()
             {
-                // We need to set OwnerDraw true to be able to draw the button ourselves. So we set FlatStyle to Popup to break parent class's OwnerDraw logic.
-                FlatStyle = FlatStyle.Popup;
+                // We need to set OwnerDraw true to be able to draw the button ourselves. So we set Image not null to break parent class's OwnerDraw logic.
+                Image = new Bitmap(1, 1);
             }
 
             protected override void OnMouseEnter(EventArgs e)

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.EditorButton.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.EditorButton.cs
@@ -30,6 +30,7 @@ internal sealed partial class DesignerActionPanel
 
             public EditorButton()
             {
+                // We need to set OwnerDraw true to be able to draw the button ourselves. So we set FlatStyle to Popup to break parent class's OwnerDraw logic.
                 FlatStyle = FlatStyle.Popup;
             }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.EditorButton.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.EditorButton.cs
@@ -28,6 +28,11 @@ internal sealed partial class DesignerActionPanel
                 }
             }
 
+            public EditorButton()
+            {
+                FlatStyle = FlatStyle.Popup;
+            }
+
             protected override void OnMouseEnter(EventArgs e)
             {
                 base.OnMouseEnter(e);


### PR DESCRIPTION

Fix #13627

## Root Cause

We did custom painting in `protected override void OnPaint(PaintEventArgs e)` and this method only get invoked when OwnerDraw is true. But now the parent class `OwnerDraw` 's logic is changed , that makes  OwnerDraw false.

## Proposed changes

- 
- We need to set OwnerDraw true to be able to draw the button ourselves. So we set FlatStyle to Popup to break parent class's OwnerDraw logic.
- 


<!-- 
## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-
 -->



## Screenshots 

### Before

![image](https://github.com/user-attachments/assets/7f2cec48-c69c-491b-9dae-87fd2c8d5dfc)

### After

![Issue_13627](https://github.com/user-attachments/assets/560ab196-5302-4dbd-8b54-51c013d73249)


## Test methodology <!-- How did you ensure quality? -->

- 
- manual test
- 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13631)