### PR TITLE
fix  #13624 DemoConsole app: An exception pops up when focusing on "Type Here" in contextMenuStrip under DarkMode

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripSystemDarkModeRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripSystemDarkModeRenderer.cs
@@ -561,9 +561,9 @@ internal class ToolStripSystemDarkModeRenderer : ToolStripRenderer
     protected override void OnRenderArrow(ToolStripArrowRenderEventArgs e)
     {
         ArgumentNullException.ThrowIfNull(e);
-        Debug.Assert(e.Item is not null, "The ToolStripItem should not be null on rendering the Arrow.");
 
-        Color arrowColor = (e.Item.Selected || e.Item.Pressed)
+        // We need to check for null here, since at design time at this point Item can be null.
+        Color arrowColor = (e.Item is not null) && (e.Item.Selected || e.Item.Pressed)
             ? GetDarkModeColor(SystemColors.HighlightText)
             : GetDarkModeColor(e.ArrowColor);
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fix #13624 

## Root cause

When in DarkMode we use ToolStripSystemDarkModeRenderer do the rendering work.

`Type here` is not an actual ToolStripItem, so the `null` value pass to ToolStripArrowRenderEventArgs

![image](https://github.com/user-attachments/assets/de1dc110-3d0a-4a4e-8c5c-b83a48507e8b)

So not only in `DarkMode`, but also in normal color mode,  [e.Item](https://github.com/dotnet/winforms/blob/9856a7c54449559b4f5b8fd1727ac27127266109/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripRenderer.cs#L646) in `DrawArrow` is null, but the `DrawArrow` method of `ToolStripRenderer` makes a null judgment on e.Item, while [ToolStripRenderer.cs](https://github.com/dotnet/winforms/blob/9856a7c54449559b4f5b8fd1727ac27127266109/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripSystemDarkModeRenderer.cs#L566) does not, so this problem occurs.

## Proposed changes

- Add null check like we did [here](https://github.com/dotnet/winforms/blob/1a7fe8a158ff6d7b082db53a4546cfbb10585272/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripRenderer.cs#L645C9-L648C54)

<!-- 

## Customer Impact

- 

## Regression? 

- Yes

## Risk

-  Minimal

 -->


### Before

![Image](https://github.com/user-attachments/assets/33a9e321-9c0e-42da-996f-b2ffca200e00)

https://github.com/user-attachments/assets/16e49163-1cc7-4748-a804-22ec36bf37a9

### After

no Exception


## Test methodology 

- manual test

<!--  
## Accessibility testing  
-->
 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13635)