### PR TITLE
Extend DarkMode opt-out option for multiple descendant scenarios.

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/Button.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/Button.cs
@@ -168,7 +168,7 @@ public partial class Button : ButtonBase, IButtonControl
                 && Image is null
 
                 // ...the user wants to opt out of implicit DarkMode rendering.
-                && GetStyle(ControlStyles.ApplyThemingImplicitly)
+                && _darkModeRequestState is true
 
                 // And all of this only counts for FlatStyle.Standard. For the
                 // rest, we're using specific renderers anyway, which check

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
@@ -4673,7 +4673,7 @@ public partial class ListView : Control
     private void ApplyDarkModeOnDemand()
     {
         if (Application.IsDarkModeEnabled
-            && GetStyle(ControlStyles.ApplyThemingImplicitly))
+            && _darkModeRequestState is true)
         {
             // Enable double buffering when in dark mode to reduce flicker.
             uint exMask = PInvoke.LVS_EX_ONECLICKACTIVATE | PInvoke.LVS_EX_TWOCLICKACTIVATE |

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TextBox/TextBoxBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TextBox/TextBoxBase.cs
@@ -290,7 +290,7 @@ public abstract partial class TextBoxBase : Control
 
                     // If we're ReadOnly and in DarkMode, we are using a different background color.
                     ? Application.IsDarkModeEnabled
-                        && GetStyle(ControlStyles.ApplyThemingImplicitly)
+                        && _darkModeRequestState is true
                             ? SystemColors.ControlDarkDark
                             : SystemColors.Control
                     : SystemColors.Window;
@@ -955,7 +955,7 @@ public abstract partial class TextBoxBase : Control
     {
         // If we have no specifically defined back color, we set the back color in case we're in dark mode.
         if (Application.IsDarkModeEnabled
-            && GetStyle(ControlStyles.ApplyThemingImplicitly))
+            && _darkModeRequestState is true)
         {
             base.BackColor = value ? SystemColors.ControlLight : SystemColors.Window;
             Invalidate();


### PR DESCRIPTION
When a control wants to automatically participate in DarkMode handling, it does so by setting the `ControlStyles.ApplyThemingImplicitly` flag first thing in the overridden property `CreateParams`.

For custom control controls, which derive von other controls than controls, and which in addition have already opted in (like `ButtonBase`) in to auto-DarkMode handling, this PR makes it possible for a control to opt out in the same way.

To this end, the derived custom control _also_ needs to overwrite the `CreateParams` property, and then needs to clear the `ApplyThemingImplicitly` flag the first thing before calling the base implementation:

```csharp
// In CreateParams, do this first to opt an inherited control out of dark mode handling:
SetFlags(ControlStyles.ApplyThemingImplicitly, false);
```

Note: It may seem redundant, but it's important to clear that flag, even if it can be assumed at this point that the flag has never been set before!

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13642)