### PR TITLE
Add shortCut copy paste In DemoConsole

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
@@ -53,6 +53,8 @@ internal partial class CommandSet : IDisposable
     private StatusCommandUI _statusCommandUI; // Used to update the statusBar Information.
     private readonly IUIService? _uiService;
 
+    private ICollection? _toBeCopiedComponents;
+
     /// <summary>
     ///  Creates a new CommandSet object. This object implements the set
     ///  of commands that the UI.Win32 form designer offers.
@@ -422,6 +424,7 @@ internal partial class CommandSet : IDisposable
 
     // This function will return true if call to func is successful, false otherwise
     // Output of call to func is available in result out parameter
+    [SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "retain this unused method")]
     private static bool ExecuteSafely<T>(Func<T> func, bool throwOnException, [MaybeNullWhen(false)] out T result)
     {
         try
@@ -1383,7 +1386,6 @@ internal partial class CommandSet : IDisposable
         }
     }
 
-    private ICollection _toBeCopiedComponents;
     /// <summary>
     ///  Called when the copy menu item is selected.
     /// </summary>
@@ -1835,9 +1837,9 @@ internal partial class CommandSet : IDisposable
 
                 using DesignerTransaction trans = host.CreateTransaction(SR.CommandSetPaste);
 
-                components = DesignerUtils.CopyDragObjects(new ReadOnlyCollection<IComponent>([.. _toBeCopiedComponents.Cast<IComponent>()]), GetService<IDesignerHost>());
+                components = DesignerUtils.CopyDragObjects(new ReadOnlyCollection<IComponent>([.. _toBeCopiedComponents.Cast<IComponent>()]), GetService<IDesignerHost>()!);
 
-                if (_toBeCopiedComponents.Count == components.Count)
+                if (components is not null && _toBeCopiedComponents.Count == components.Count)
                 {
                     int i = 0;
                     foreach (IComponent component in _toBeCopiedComponents)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10466

## Root cause
Copy and paste now works in DemoConsole in netframework481 but not in net10. that's because the serializer here does not work in net10, it was deprecated long time ago.

https://github.com/dotnet/winforms/blob/b0b0e101cb69db4b70f7e3559e30406b210b1f1d/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs#L1409C1-L1415C74



## Proposed changes

- 
-  We don't  serialize CodeDomSerializationStore anymore. Copy the `selectionComponents` when CopyCommand is triggered.
- 


<!-- 
## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-
 -->


## Screenshots 

### Before

N/A

### After

![PR_13644_01](https://github.com/user-attachments/assets/03c8198e-ffad-4ccf-b764-fd28ef848920)

<!--
## Test methodology 

- 
- 
- 

## Accessibility testing  



 -->


 


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13644)