### PR TITLE
fix issue #13648  DemoConsole app: The extra number displayed on Name & Text Propeties for the ToolStrip control

### DIFF
--- a/src/test/integration/DesignSurface/DemoConsole/NameCreationService.cs
+++ b/src/test/integration/DesignSurface/DemoConsole/NameCreationService.cs
@@ -31,28 +31,22 @@ internal sealed class NameCreationService : INameCreationService
             if (cc[i] is Component comp)
             {
                 string name = comp.Site.Name;
-                int numberStartIndex = name.Length - 1;
-
-                while (numberStartIndex >= 0 && char.IsDigit(name[numberStartIndex]))
+                if (name.StartsWith(type.Name, StringComparison.Ordinal))
                 {
-                    numberStartIndex--;
-                }
-
-                string typeName = name[..(numberStartIndex + 1)];
-                string number = name[(numberStartIndex + 1)..];
-
-                if (typeName == type.Name)
-                {
-                    count++;
-                    try
+                    string suffix = name[type.Name.Length..];
+                    if (!string.IsNullOrEmpty(suffix) && suffix.All(char.IsDigit))
                     {
-                        int value = int.Parse(number);
-                        if (value < min)
-                            min = value;
-                        if (value > max)
-                            max = value;
+                        count++;
+                        try
+                        {
+                            int value = int.Parse(suffix);
+                            if (value < min)
+                                min = value;
+                            if (value > max)
+                                max = value;
+                        }
+                        catch (Exception) { }
                     }
-                    catch (Exception) { }
                 }
             }
 


### PR DESCRIPTION

Fixes #13648  


## Proposed changes

- 
- We need to match the exact type name shouldn't just use StartsWith since we removed type check in [pr13573](https://github.com/dotnet/winforms/pull/13573)
- 

```diff
        while (i < cc.Count)
        {
-            if (cc[i] is Component comp && comp.GetType() == type)
+            if (cc[i] is Component comp)
             {
                string name = comp.Site.Name;
                if (name.StartsWith(type.Name, StringComparison.Ordinal))


```

<!-- 

## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-


 -->
## Screenshots 

### Before

![image](https://github.com/user-attachments/assets/fe2eefbf-12d1-47cc-a2fc-fdd191b61312)

### After

![image](https://github.com/user-attachments/assets/0a131f9b-5042-4e13-b0b6-4d51d2d2235f)


## Test methodology <!-- How did you ensure quality? -->

- 
- manual 
- 


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13650)