### PR TITLE
fix #13599 A warning dialog pops up when trying to switch the values for the FormScreenCaptureMode property

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Form.cs
@@ -1767,7 +1767,7 @@ public partial class Form : ContainerControl
                 return;
             }
 
-            if (!TopLevel)
+            if (!TopLevel && !DesignMode)
             {
                 throw new InvalidOperationException(SR.FormScreenCaptureModeRequiresTopLevel);
             }


### PR DESCRIPTION


Fixes #13599 

## Root Cause
At design time TopLevel is false
``` c#
    public ScreenCaptureMode FormScreenCaptureMode
    {
        get => Properties.GetValueOrDefault(s_propFormScreenCaptureMode, ScreenCaptureMode.Allow);
        set
        {
            if (FormScreenCaptureMode == value)
            {
                return;
            }

            if (!TopLevel)
            {
                throw new InvalidOperationException(SR.FormScreenCaptureModeRequiresTopLevel);
            }

            SourceGenerated.EnumValidator.Validate(value);
            Properties.AddOrRemoveValue(s_propFormScreenCaptureMode, value);

            if (IsHandleCreated)
            {
                SetScreenCaptureModeInternal(value);
            }
        }
    }
```


## Proposed changes

- 
- Add another condition to check if the control is in design mode
- 

<!-- 

## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-



## Screenshots 
### Before


### After


## Test methodology 
- 
- 
- 

## Accessibility testing  


## Test environment(s)

 -->
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13662)