### PR TITLE
Override the name property of the MonthCalendarAccessibleObject

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/MonthCalendar/MonthCalendar.MonthCalendarAccessibleObject.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/MonthCalendar/MonthCalendar.MonthCalendarAccessibleObject.cs
@@ -564,7 +564,7 @@ public partial class MonthCalendar
         internal CalendarTodayLinkAccessibleObject TodayLinkAccessibleObject
             => _todayLinkAccessibleObject ??= new CalendarTodayLinkAccessibleObject(this);
 
-        public override string? Value
+        public override string? Name
         {
             get
             {
@@ -606,7 +606,7 @@ public partial class MonthCalendar
 
                         return $"{range.Start:yyyy} - {range.End:yyyy}";
                     default:
-                        return base.Value;
+                        return Name;
                 }
             }
         }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13657

## Root Cause

1. The date in the calendar is not an independent control. NVDA cannot focus on the specific date cell, 
2. Although MSAA notifications are sent, but NVDA can only announce the `Name` of the `MonthCalendarAccessibleObject`, it cannot announce the `Value` of the `MonthCalendarAccessibleObject`

## Proposed changes

- Override the name property of `MonthCalendarAccessibleObject`, and output the `Value` content in `Name` to ensure that NVDA can read it normally

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- When switching calendar dates using the keyboard, the screen reader can correctly read the date information in the calendar table


## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Screen Reader user will not be able understand the correct data information while navigating on calendar. 

https://github.com/user-attachments/assets/e189d65a-3a1e-4c98-8370-bda95e7d26e0

### After

![AfterChange](https://github.com/user-attachments/assets/838c5356-0eb7-413f-b595-bdc4dbf5c9d6)


## Test methodology <!-- How did you ensure quality? -->

- Manually
 

## Test environment(s) <!-- Remove any that don't apply -->

- 10.0.0-preview.7.25320.118


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13665)