### PR TITLE
fix #13677 FontStyle.Bold Not Visually Applied to LinkLabel at Runtime via Code

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Labels/LinkUtilities.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Labels/LinkUtilities.cs
@@ -164,7 +164,7 @@ internal static class LinkUtilities
         LinkBehavior link,
         [AllowNull] ref Font linkFont,
         [AllowNull] ref Font hoverLinkFont,
-        bool isActive = false)
+        bool? isActive = null)
     {
         if (linkFont is not null && hoverLinkFont is not null)
         {
@@ -210,11 +210,11 @@ internal static class LinkUtilities
                 style &= ~FontStyle.Underline;
             }
 
-            if (isActive)
+            if (isActive is not null and true)
             {
                 style |= FontStyle.Bold;
             }
-            else
+            else if (isActive is not null and false)
             {
                 style &= ~FontStyle.Bold;
             }


### PR DESCRIPTION




Fixes #13677 

## Root cause

This issue was introduced by [PR6250](https://github.com/dotnet/winforms/pull/6250) to fix [Issue6116](https://github.com/dotnet/winforms/issues/6116)

This is one of it's changes.
![image](https://github.com/user-attachments/assets/82c721df-ec31-4226-baf5-1a78e2e00477)

The new parameter `isActive` is to address DataGridViewLinkCell issue, but it also break other cases.

## Proposed changes

- 
- make isActive nullable
- 

## Regression? 

- Yes

<!-- 
## Customer Impact

- 
- 



## Risk

-

 -->


## Screenshots 

### Before
![Image](https://github.com/user-attachments/assets/dbce76a0-0c8e-4847-81bd-321d4e770e85)


### After
![13677_01](https://github.com/user-attachments/assets/9cbaa94d-5633-4e42-872f-eb33582332ad)
