### PR TITLE
Update SetScreenCaptureModeInternal by reset WINDOW_DISPLAY_AFFINITY to NONE before setting new affinity

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Form.cs
@@ -1790,6 +1790,9 @@ public partial class Form : ContainerControl
 
     private void SetScreenCaptureModeInternal(ScreenCaptureMode value)
     {
+        // Always reset to NONE before setting new affinity.
+        PInvoke.SetWindowDisplayAffinity(HWND, WINDOW_DISPLAY_AFFINITY.WDA_NONE);
+
         WINDOW_DISPLAY_AFFINITY affinity = value switch
         {
             ScreenCaptureMode.Allow => WINDOW_DISPLAY_AFFINITY.WDA_NONE,


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13680


## Proposed changes

- Update `SetScreenCaptureModeInternal` by reset `WINDOW_DISPLAY_AFFINITY` to `NONE` before setting new affinity

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- `FormScreenCaptureMode` still works properly after multiple calls

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
When the FormScreenCaptureMode property is set twice in succession, ScreenCaptureMode always retains the first setting.

https://github.com/user-attachments/assets/1e37db66-9b7a-48cc-a7bf-f7f896cf440c

### After

https://github.com/user-attachments/assets/16b61d36-0eb1-4022-a0cd-ec28b7b2d895

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-preview.7.25320.118


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13684)