### PR TITLE
Fix 13633 by correct the logic of the method "OnSelectionChanged" of the ToolStripItemDesigner

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemDesigner.cs
@@ -993,7 +993,7 @@ internal class ToolStripItemDesigner : ComponentDesigner
                         ToolStripMenuItemDesigner parentItemDesigner = (ToolStripMenuItemDesigner)designerHost.GetDesigner(parentItem);
                         parentItemDesigner?.InitializeDropDown();
 
-                        needRefresh = true;
+                        needRefresh = GetFirstDropDown(currentSelection) is not null and not ContextMenuStrip;
                     }
                     else if (parentDropDown is ContextMenuStrip)
                     {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13633

## Root Cause
 
The original logic, set the `needRefresh= true` directly when currentSelection.IsOnDropDown, this should be a bug in the code transplant process. The original code logic is [here](https://devdiv.visualstudio.com/DevDiv/_git/VS?path=/src/vsip/Designer/WinForms/System/WinForms/Design/ToolStripItemDesigner.cs&version=GBmain&line=1225&lineEnd=1227&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents).

## Proposed changes

- Correct the logic of the `OnSelectionChanged `of the ToolStripItemDesigner

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- ToolStripTextBox can be focused normally

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots 
<!-- Remove this section if PR does not change UI -->

### Before
ToolStripTextBox cannot get focus
![Image](https://github.com/user-attachments/assets/b264e70d-dc65-4236-b798-fe2ebeb5b7a7)

### After
ToolStripTextBox can be selected normally
![AfterChange](https://github.com/user-attachments/assets/11d6aa48-e6a9-4940-8268-77e282012f7b)

## Test methodology <!-- How did you ensure quality? -->

- Manually
 

## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-preview.7.25320.118

<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13695)