### PR TITLE
Set FormScreenCaptureMode when the Form's Handle is created

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Form.cs
@@ -4229,7 +4229,10 @@ public partial class Form : ContainerControl
             SetFormTitleProperties();
         }
 
-        SetScreenCaptureModeInternal(FormScreenCaptureMode);
+        if (FormScreenCaptureMode != ScreenCaptureMode.Allow)
+        {
+            SetScreenCaptureModeInternal(FormScreenCaptureMode);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13694

## Root Cause

When a Form object is created, its handle is not created immediately, and the FormScreenCaptureMode property needs to be based on the Form's Handle to take effect.

## Proposed changes

- Cache the `FormScreenCaptureMode` setting and set its value in method `OnHandleCreated` 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The setting for `FormScreenCaptureMode` can work well

## Regression? 

-  No

## Risk

- MInimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

The form is still visible when setting `FormScreenCaptureMode = HideContent` in the Properties window

https://github.com/user-attachments/assets/7e9a94f9-0374-4ae4-af02-1498d5b06735

### After
The form doesn't appear in screenshots or recordings when HideContent is set

https://github.com/user-attachments/assets/aea4f53d-b176-4b59-90f9-91082b03f5cf


## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-preview.7.25320.118


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13696)