### PR TITLE
[release/8.0] FontStyle.Bold Not Visually Applied to LinkLabel at Runtime via Code

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.cs
@@ -1009,7 +1009,7 @@ public partial class DataGridViewLinkCell : DataGridViewCell
             Font getHoverFont = null;
             bool isActive = (LinkState & LinkState.Active) == LinkState.Active;
 
-            LinkUtilities.EnsureLinkFonts(cellStyle.Font, LinkBehavior, ref getLinkFont, ref getHoverFont, isActive);
+            LinkUtilities.EnsureLinkFonts(cellStyle.Font, LinkBehavior, ref getLinkFont, ref getHoverFont);
             TextFormatFlags flags = DataGridViewUtilities.ComputeTextFormatFlagsForCellStyleAlignment(
                 DataGridView.RightToLeftInternal,
                 cellStyle.Alignment,
@@ -1088,6 +1088,18 @@ public partial class DataGridViewLinkCell : DataGridViewCell
                             valBounds,
                             linkColor,
                             flags);
+
+                        // add a visiting effect.
+                        if (isActive)
+                        {
+                            TextRenderer.DrawText(
+                                g,
+                                formattedValueStr,
+                                LinkState == LinkState.Hover ? hoverFont : linkFont,
+                                new Rectangle(valBounds.X + 1, valBounds.Y, valBounds.Width, valBounds.Height),
+                                linkColor,
+                                flags);
+                        }
                     }
                 }
                 else if (cellCurrent &&

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkUtilities.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkUtilities.cs
@@ -162,7 +162,7 @@ internal static class LinkUtilities
         LinkBehavior link,
         [AllowNull] ref Font linkFont,
         [AllowNull] ref Font hoverLinkFont,
-        bool isActive = false)
+        bool? isActive = null)
     {
         if (linkFont is not null && hoverLinkFont is not null)
         {
@@ -209,11 +209,11 @@ internal static class LinkUtilities
                 style &= ~FontStyle.Underline;
             }
 
-            if (isActive)
+            if (isActive is not null and true)
             {
                 style |= FontStyle.Bold;
             }
-            else
+            else if (isActive is not null and false)
             {
                 style &= ~FontStyle.Bold;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkUtilities.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkUtilities.cs
@@ -161,8 +161,7 @@ internal static class LinkUtilities
         Font baseFont,
         LinkBehavior link,
         [AllowNull] ref Font linkFont,
-        [AllowNull] ref Font hoverLinkFont,
-        bool? isActive = null)
+        [AllowNull] ref Font hoverLinkFont)
     {
         if (linkFont is not null && hoverLinkFont is not null)
         {
@@ -207,15 +206,6 @@ internal static class LinkUtilities
             else
             {
                 style &= ~FontStyle.Underline;
-            }
-
-            if (isActive is not null and true)
-            {
-                style |= FontStyle.Bold;
-            }
-            else if (isActive is not null and false)
-            {
-                style &= ~FontStyle.Bold;
             }
 
             hoverLinkFont = new Font(f, style);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Backport of https://github.com/dotnet/winforms/pull/13681 to release/8.0

Fixes https://github.com/dotnet/winforms/issues/13677


## Proposed changes

- Modified the signature of the `EnsureLinkFonts ` method, removed the bool `isActive ` parameter, and adjusted the related conditional logic and updated the text rendering method of **LinkLabel** in the Active state, by moving the text 1 pixel to the right to achieve a bold effect.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Allows users to correctly set the **LinkLabel** control to a bold font through `FontStyle.Bold` at runtime

## Regression? 

- Yes， introduced in https://github.com/dotnet/winforms/pull/6250

## Risk

- Low

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

- Manual testing 