### PR TITLE
[release/8.0] Fixes #7154 #13672 Allows DataGridView to start row/column on index 1 on Narrator

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -20,12 +20,14 @@ internal static partial class LocalAppContextSwitches
     internal const string ServicePointManagerCheckCrlSwitchName = "System.Windows.Forms.ServicePointManagerCheckCrl";
     internal const string TrackBarModernRenderingSwitchName = "System.Windows.Forms.TrackBarModernRendering";
     private const string DoNotCatchUnhandledExceptionsSwitchName = "System.Windows.Forms.DoNotCatchUnhandledExceptions";
+    internal const string DataGridViewUIAStartRowCountAtZeroSwitchName = "System.Windows.Forms.DataGridViewUIAStartRowCountAtZero";
 
     private static int s_scaleTopLevelFormMinMaxSizeForDpi;
     private static int s_anchorLayoutV2;
     private static int s_servicePointManagerCheckCrl;
     private static int s_trackBarModernRendering;
     private static int s_doNotCatchUnhandledExceptions;
+    private static int s_dataGridViewUIAStartRowCountAtZero;
 
     private static FrameworkName? s_targetFrameworkName;
 
@@ -151,4 +153,12 @@ internal static partial class LocalAppContextSwitches
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => GetCachedSwitchValue(ServicePointManagerCheckCrlSwitchName, ref s_servicePointManagerCheckCrl);
     }
+
+    public static bool DataGridViewUIAStartRowCountAtZero
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetCachedSwitchValue(DataGridViewUIAStartRowCountAtZeroSwitchName, ref s_dataGridViewUIAStartRowCountAtZero);
+    }
+
+    internal static void SetDataGridViewUIAStartRowCountAtZero(bool value) => s_dataGridViewUIAStartRowCountAtZero = value ? 1 : 0;
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel;
 using System.Drawing;
+using System.Windows.Forms.Primitives;
 using static Interop;
 
 namespace System.Windows.Forms;
@@ -55,9 +56,9 @@ public abstract partial class DataGridViewCell
 
                 int rowIndex = _owner.DataGridView is null
                     ? -1
-                    : _owner.DataGridView.Rows.GetVisibleIndex(_owner.OwningRow);
+                    : _owner.DataGridView.Rows.GetVisibleIndex(_owner.OwningRow) + RowStartIndex;
 
-                string name = string.Format(SR.DataGridView_AccDataGridViewCellName, _owner.OwningColumn.HeaderText, rowIndex);
+                string name = string.Format(SR.DataGridView_AccDataGridViewCellName, _owner.OwningColumn.HeaderText, rowIndex).Trim();
 
                 if (_owner.OwningColumn.SortMode != DataGridViewColumnSortMode.NotSortable)
                 {
@@ -112,6 +113,8 @@ public abstract partial class DataGridViewCell
         }
 
         public override AccessibleRole Role => AccessibleRole.Cell;
+
+        private static int RowStartIndex => LocalAppContextSwitches.DataGridViewUIAStartRowCountAtZero ? 0 : 1;
 
         public override AccessibleStates State
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
@@ -4,6 +4,7 @@
 using System.Drawing;
 using System.Globalization;
 using System.Text;
+using System.Windows.Forms.Primitives;
 using static Interop;
 
 namespace System.Windows.Forms;
@@ -94,8 +95,7 @@ public partial class DataGridViewRow
                 }
 
                 int index = _owningDataGridViewRow is { Visible: true, DataGridView: { } }
-                        ? _owningDataGridViewRow.DataGridView.Rows.GetVisibleIndex(_owningDataGridViewRow)
-                        : -1;
+                    ? _owningDataGridViewRow.DataGridView.Rows.GetVisibleIndex(_owningDataGridViewRow) + RowStartIndex : -1;
 
                 return string.Format(SR.DataGridView_AccRowName, index.ToString(CultureInfo.CurrentCulture));
             }
@@ -131,6 +131,8 @@ public partial class DataGridViewRow
         }
 
         public override AccessibleRole Role => AccessibleRole.Row;
+
+        private static int RowStartIndex => LocalAppContextSwitches.DataGridViewUIAStartRowCountAtZero ? 0 : 1;
 
         internal override int[] RuntimeId
             => _runtimeId ??= new int[]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellAccessibleObjectTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
+using System.Windows.Forms.Primitives;
 using Moq;
 using Moq.Protected;
 using static Interop;
@@ -207,6 +208,7 @@ public class DataGridViewCellAccessibleObjectTests : DataGridViewCell
         Assert.Equal(expected, accessibleObject.Name);
     }
 
+    // Whether UIA row indexing is 1-based or 0-based, is controlled by the DataGridViewUIAStartRowCountAtZero switch
     [WinFormsFact]
     public void DataGridViewCellAccessibleObject_Name_ReturnExpected()
     {
@@ -218,12 +220,13 @@ public class DataGridViewCellAccessibleObjectTests : DataGridViewCell
         dataGridView.Rows.Add("3");
 
         AccessibleObject accessibleObject = dataGridView.Rows[2].Cells[0].AccessibilityObject;
-        string expected = string.Format(SR.DataGridView_AccDataGridViewCellName, column.HeaderText, 2);
+        string expected = string.Format(SR.DataGridView_AccDataGridViewCellName, column.HeaderText, 3);
 
         Assert.Equal(expected, accessibleObject.Name);
         Assert.False(dataGridView.IsHandleCreated);
     }
 
+    // Whether UIA row indexing is 1-based or 0-based, is controlled by the DataGridViewUIAStartRowCountAtZero switch
     [WinFormsFact]
     public void DataGridViewCellAccessibleObject_Name_ReturnExpected_IfOneRowHidden()
     {
@@ -236,12 +239,13 @@ public class DataGridViewCellAccessibleObjectTests : DataGridViewCell
         dataGridView.Rows[0].Visible = false;
 
         AccessibleObject accessibleObject = dataGridView.Rows[2].Cells[0].AccessibilityObject;
-        string expected = string.Format(SR.DataGridView_AccDataGridViewCellName, column.HeaderText, 1);
+        string expected = string.Format(SR.DataGridView_AccDataGridViewCellName, column.HeaderText, 2);
 
         Assert.Equal(expected, accessibleObject.Name);
         Assert.False(dataGridView.IsHandleCreated);
     }
 
+    // Whether UIA row indexing is 1-based or 0-based, is controlled by the DataGridViewUIAStartRowCountAtZero switch
     [WinFormsFact]
     public void DataGridViewCellAccessibleObject_Name_ReturnExpected_IfTwoRowsHidden()
     {
@@ -255,7 +259,7 @@ public class DataGridViewCellAccessibleObjectTests : DataGridViewCell
         dataGridView.Rows[1].Visible = false;
 
         AccessibleObject accessibleObject = dataGridView.Rows[2].Cells[0].AccessibilityObject;
-        string expected = string.Format(SR.DataGridView_AccDataGridViewCellName, column.HeaderText, 0);
+        string expected = string.Format(SR.DataGridView_AccDataGridViewCellName, column.HeaderText, 1);
 
         Assert.Equal(expected, accessibleObject.Name);
         Assert.False(dataGridView.IsHandleCreated);
@@ -1430,6 +1434,23 @@ public class DataGridViewCellAccessibleObjectTests : DataGridViewCell
         }
 
         return dataGridView;
+    }
+
+    // Unit test for https://github.com/dotnet/winforms/issues/7154
+    [WinFormsFact]
+    public void DataGridView_SwitchConfigured_AdjustsCellRowStartIndices()
+    {
+        LocalAppContextSwitches.SetDataGridViewUIAStartRowCountAtZero(true);
+
+        using DataGridView dataGridView = new();
+        dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+        dataGridView.Rows.Add(new DataGridViewRow());
+
+        Assert.Equal($"{string.Format(SR.DataGridView_AccRowName, 0)}, Not sorted.", dataGridView.Rows[0].Cells[0].AccessibilityObject.Name);
+
+        LocalAppContextSwitches.SetDataGridViewUIAStartRowCountAtZero(false);
+
+        Assert.Equal($"{string.Format(SR.DataGridView_AccRowName, 1)}, Not sorted.", dataGridView.Rows[0].Cells[0].AccessibilityObject.Name);
     }
 
     private class SubDataGridViewCell : DataGridViewCell

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowAccessibleObjectTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
+using System.Windows.Forms.Primitives;
 using static Interop;
 
 namespace System.Windows.Forms.Tests;
@@ -71,6 +72,7 @@ public class DataGridViewRowAccessibleObjectTests : DataGridViewRow
         Assert.Equal(string.Format(SR.DataGridView_AccRowName, -1), accessibilityObject.Name);
     }
 
+    // Whether UIA row indexing is 1-based or 0-based, is controlled by the DataGridViewUIAStartRowCountAtZero switch
     [Fact]
     public void DataGridViewRowAccessibleObject_Name_Get_ReturnsExpected()
     {
@@ -84,9 +86,9 @@ public class DataGridViewRowAccessibleObjectTests : DataGridViewRow
         AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
         AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
 
-        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 0), accessibleObject1.Name);
-        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 1), accessibleObject2.Name);
-        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 2), accessibleObject3.Name);
+        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 1), accessibleObject1.Name);
+        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 2), accessibleObject2.Name);
+        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 3), accessibleObject3.Name);
         Assert.False(dataGridView.IsHandleCreated);
     }
 
@@ -105,11 +107,12 @@ public class DataGridViewRowAccessibleObjectTests : DataGridViewRow
         AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
 
         Assert.Equal(string.Format(SR.DataGridView_AccRowName, -1), accessibleObject1.Name);
-        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 0), accessibleObject2.Name);
-        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 1), accessibleObject3.Name);
+        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 1), accessibleObject2.Name);
+        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 2), accessibleObject3.Name);
         Assert.False(dataGridView.IsHandleCreated);
     }
 
+    // Whether UIA row indexing is 1-based or 0-based, is controlled by the DataGridViewUIAStartRowCountAtZero switch
     [Fact]
     public void DataGridViewRowAccessibleObject_Name_Get_ReturnsExpected_IfSecondRowHidden()
     {
@@ -124,12 +127,13 @@ public class DataGridViewRowAccessibleObjectTests : DataGridViewRow
         AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
         AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
 
-        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 0), accessibleObject1.Name);
+        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 1), accessibleObject1.Name);
         Assert.Equal(string.Format(SR.DataGridView_AccRowName, -1), accessibleObject2.Name);
-        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 1), accessibleObject3.Name);
+        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 2), accessibleObject3.Name);
         Assert.False(dataGridView.IsHandleCreated);
     }
 
+    // Whether UIA row indexing is 1-based or 0-based, is controlled by the DataGridViewUIAStartRowCountAtZero switch
     [Fact]
     public void DataGridViewRowAccessibleObject_Name_Get_ReturnsExpected_IfLastRowHidden()
     {
@@ -144,8 +148,8 @@ public class DataGridViewRowAccessibleObjectTests : DataGridViewRow
         AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
         AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
 
-        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 0), accessibleObject1.Name);
-        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 1), accessibleObject2.Name);
+        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 1), accessibleObject1.Name);
+        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 2), accessibleObject2.Name);
         Assert.Equal(string.Format(SR.DataGridView_AccRowName, -1), accessibleObject3.Name);
         Assert.False(dataGridView.IsHandleCreated);
     }
@@ -2362,6 +2366,23 @@ public class DataGridViewRowAccessibleObjectTests : DataGridViewRow
 
         Assert.Equal(0, rowAccessibleObject.GetChildCount());
         Assert.False(dataGridView.IsHandleCreated);
+    }
+
+    // Unit test for https://github.com/dotnet/winforms/issues/7154
+    [WinFormsFact]
+    public void DataGridView_SwitchConfigured_AdjustsRowStartIndices()
+    {
+        LocalAppContextSwitches.SetDataGridViewUIAStartRowCountAtZero(true);
+
+        using DataGridView dataGridView = new();
+        dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+        dataGridView.Rows.Add(new DataGridViewRow());
+
+        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 0), dataGridView.Rows[0].AccessibilityObject.Name);
+
+        LocalAppContextSwitches.SetDataGridViewUIAStartRowCountAtZero(false);
+
+        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 1), dataGridView.Rows[0].AccessibilityObject.Name);
     }
 
     [WinFormsFact]


### PR DESCRIPTION
Back port [PR10243](https://github.com/dotnet/winforms/pull/10243) to release/8.0

Fixes #7154 , #13672 on .Net 8.0

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13706)

## Proposed changes

- Creates a new switch that allows developers to configure their application to make the starting index of rows/cells in DataGridView to be read by Narrator from 1, instead of 0;
- Adds checks on rows and cells of DataGridView to see if the switch is true. If true, starting index of rows/cells will be 1, instead of 0.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Developers will be able to configure their WinForms DataGridView rows/cells to be read by Narrator from index 1, instead of 0.

## Regression? 

- No

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->

- Manual (Narrator, NVDA)
- Unit tests