### PR TITLE
Add InternalRaiseAutomationNotification in WmDateChanged of the MonthCalendar

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/MonthCalendar/MonthCalendar.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/MonthCalendar/MonthCalendar.cs
@@ -2110,7 +2110,7 @@ public partial class MonthCalendar : Control
                     (int)PInvoke.CHILDID_SELF);
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!ex.IsCriticalException())
         {
             Debug.Fail($"NotifyWinEvent failed: {ex.Message}");
         }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13657


## Proposed changes

- Send MSAA focus notification  in `WmDateChanged` of the `MonthCalendar` so that the MonthCalendar remains in the Focused state when switching dates with the keyboard

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- NVDA can announce the correct information for the calendar date on which keyboard focus is shifting

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

NVDA cannot announce the correct information for the calendar date 

https://github.com/user-attachments/assets/e189d65a-3a1e-4c98-8370-bda95e7d26e0

### After

The calendar date can be announced and the `MonthCalendar` can be focused with NVDA

https://github.com/user-attachments/assets/c89384b4-8c02-4522-ad46-a67dc56ac617



## Test methodology <!-- How did you ensure quality? -->

-  Manually
 

## Test environment(s) <!-- Remove any that don't apply -->

-  .net 10.0.0-preview.7.25365.101


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13707)