### PR TITLE
Do not activate the form if MinimumSize changes

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Form.cs
@@ -1368,7 +1368,7 @@ public partial class Form : ContainerControl
                     Location.Y,
                     Size.Width,
                     Size.Height,
-                    SET_WINDOW_POS_FLAGS.SWP_NOZORDER);
+                    SET_WINDOW_POS_FLAGS.SWP_NOZORDER | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE);
             }
         }
 

--- a/src/test/integration/UIIntegrationTests/FormTests.cs
+++ b/src/test/integration/UIIntegrationTests/FormTests.cs
@@ -152,4 +152,26 @@ public class FormTests : ControlTestBase
             },
             testDriverAsync);
     }
+
+    [WinFormsFact]
+    public void Form_MinimumSize_DoesNotChangeDisplayOrder()
+    {
+        // Initialize Form1 and Form2.
+        using Form form1 = new Form { Text = "Form1" };
+        using Form form2 = new Form { Text = "Form2" };
+
+        // Display the forms.
+        form1.Show();
+        form2.Show();
+
+        // Set initial hierarchy: Form2 should be displayed in front of Form1.
+        form2.BringToFront();
+        Assert.True(form2.TopMost || form2.Focused, "Form2 should be displayed in front of Form1");
+
+        // Set the MinimumSize property of Form1.
+        form1.MinimumSize = new Size(300, 300);
+
+        // Verify the hierarchy remains unchanged.
+        Assert.True(form2.TopMost || form2.Focused, "Form2 should still be displayed in front after setting MinimumSize");
+    }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13698

## Root Cause

In the original code, changing the MinimumSize of a form calls `SetWindowPos` with the flag `SWP_NOZORDER`. While this ensures that the Z-order of the forms is unchanged, it is not enough to prevent the affected forms from becoming active.

## Proposed changes

- In `UpdateMinimumSize` of Form.cs add `SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE` so that the form is not automatically activated when the `MinimumSize` property changes

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Setting MinimumSize will not activate form

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

https://github.com/user-attachments/assets/f2129ffc-bcfb-4bff-8026-77712122377e

### After

https://github.com/user-attachments/assets/95d35f03-198a-4606-a66a-01089a08144f

## Test methodology <!-- How did you ensure quality? -->

- Manually 
- Unit test
 

## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-preview.7.25365.101


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13715)