### PR TITLE
Add unit test for ListViewItemStateImageIndexConverter file

### DIFF
--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ListViewItemStateImageIndexConverterTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ListViewItemStateImageIndexConverterTests.cs
@@ -52,7 +52,7 @@ public class ListViewItemStateImageIndexConverterTests
         result.Cast<object>().Should().BeEmpty();
     }
 
-    [Fact]
+    [WinFormsFact]
     public void GetStandardValues_WithStateImageList_ReturnsCorrectIndexes()
     {
         using ListView listView = new();


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/13442

## Proposed changes

- Add unit test file: ListViewItemStateImageIndexConverterTests.cs for ListViewItemStateImageIndexConverter.cs file

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13716)