### PR TITLE
DarkMode (b): Fix rendering of disabled TextBox types

### DIFF
--- a/src/System.Windows.Forms/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+override System.Windows.Forms.ComboBox.OnEnabledChanged(System.EventArgs! e) -> void
+override System.Windows.Forms.RichTextBox.OnEnabledChanged(System.EventArgs! e) -> void

--- a/src/System.Windows.Forms/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/PublicAPI.Unshipped.txt
@@ -1,2 +1,0 @@
-override System.Windows.Forms.ComboBox.OnEnabledChanged(System.EventArgs! e) -> void
-override System.Windows.Forms.RichTextBox.OnEnabledChanged(System.EventArgs! e) -> void

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/Button.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/Button.cs
@@ -168,7 +168,7 @@ public partial class Button : ButtonBase, IButtonControl
                 && Image is null
 
                 // ...the user wants to opt out of implicit DarkMode rendering.
-                && _darkModeRequestState is true
+                && DarkModeRequestState is true
 
                 // And all of this only counts for FlatStyle.Standard. For the
                 // rest, we're using specific renderers anyway, which check

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
@@ -3696,21 +3696,22 @@ public partial class ComboBox : ListControl
                 }
 
                 // Additional handling for Simple style listbox when disabled
-                if (DropDownStyle == ComboBoxStyle.Simple && Application.IsDarkModeEnabled && !Enabled)
+                if (DropDownStyle == ComboBoxStyle.Simple
+                    && Application.IsDarkModeEnabled
+                    && !Enabled
+                    && hwndChild == _childListBox?.HWND)
                 {
-                    if (hwndChild == _childListBox?.HWND)
-                    {
-                        PInvokeCore.SetBkColor(
-                            (HDC)m.WParamInternal,
-                            ColorTranslator.ToWin32(Color.FromArgb(64, 64, 64)));
+                    PInvokeCore.SetBkColor(
+                        (HDC)m.WParamInternal,
+                        ColorTranslator.ToWin32(Color.FromArgb(64, 64, 64)));
 
-                        PInvokeCore.SetTextColor(
-                            (HDC)m.WParamInternal,
-                            ColorTranslator.ToWin32(Color.FromArgb(180, 180, 180)));
+                    PInvokeCore.SetTextColor(
+                        (HDC)m.WParamInternal,
+                        ColorTranslator.ToWin32(Color.FromArgb(180, 180, 180)));
 
-                        m.ResultInternal = (LRESULT)s_darkEditBrush;
-                        return;
-                    }
+                    m.ResultInternal = (LRESULT)s_darkEditBrush;
+
+                    return;
                 }
 #pragma warning restore WFO5001
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
@@ -4673,7 +4673,7 @@ public partial class ListView : Control
     private void ApplyDarkModeOnDemand()
     {
         if (Application.IsDarkModeEnabled
-            && _darkModeRequestState is true)
+            && DarkModeRequestState is true)
         {
             // Enable double buffering when in dark mode to reduce flicker.
             uint exMask = PInvoke.LVS_EX_ONECLICKACTIVATE | PInvoke.LVS_EX_TWOCLICKACTIVATE |

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
@@ -3428,12 +3428,15 @@ public partial class RichTextBox : TextBoxBase
         {
 #pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             case PInvokeCore.WM_PAINT:
+
+                // Important: We need to let to run the base
+                // renderer first in the case of the RTF control.
+                base.WndProc(ref m);
+
                 if (Handle == m.HWND
                     && !Enabled
                     && Application.IsDarkModeEnabled)
                 {
-                    base.WndProc(ref m);
-
                     // If the control is disabled, we don't want to let the RTF control
                     // paint anything else. We will paint the background and the unformatted
                     // text ourselves, so we don't want the RTF control to paint the background
@@ -3452,13 +3455,11 @@ public partial class RichTextBox : TextBoxBase
                         SystemColors.GrayText,
                         TextFormatFlags.Left
                         | TextFormatFlags.Top
-                        | TextFormatFlags.WordBreak,
+                        | TextFormatFlags.WordBreak
                         | TextFormatFlags.EndEllipsis);
 
                     return;
                 }
-
-                base.WndProc(ref m);
 
                 break;
 #pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
@@ -3435,8 +3435,8 @@ public partial class RichTextBox : TextBoxBase
                     base.WndProc(ref m);
 
                     // If the control is disabled, we don't want to let the RTF control
-                    // paint anything else. We will paint the background and the text
-                    // ourselves, so we don't want the RTF control to paint the background
+                    // paint anything else. We will paint the background and the unformatted
+                    // text ourselves, so we don't want the RTF control to paint the background
                     // and the text in the foreground color.
                     using Graphics g = Graphics.FromHwndInternal(Handle);
 
@@ -3450,7 +3450,10 @@ public partial class RichTextBox : TextBoxBase
                         Font,
                         ClientRectangle,
                         SystemColors.GrayText,
-                        TextFormatFlags.Left | TextFormatFlags.VerticalCenter);
+                        TextFormatFlags.Left
+                        | TextFormatFlags.Top
+                        | TextFormatFlags.WordBreak,
+                        | TextFormatFlags.EndEllipsis);
 
                     return;
                 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
@@ -2412,6 +2412,24 @@ public partial class RichTextBox : TextBoxBase
         }
     }
 
+    protected override void OnEnabledChanged(EventArgs e)
+    {
+        base.OnEnabledChanged(e);
+        HandleDarkModeDisabledBackground();
+    }
+
+    private void HandleDarkModeDisabledBackground()
+    {
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        if (Application.IsDarkModeEnabled
+            && !Enabled
+            && DarkModeRequestState is true)
+        {
+            Invalidate();
+        }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    }
+
     protected override void OnHandleCreated(EventArgs e)
     {
         // base.OnHandleCreated is called somewhere in the middle of this
@@ -2457,6 +2475,8 @@ public partial class RichTextBox : TextBoxBase
 
         // base sets the Text property. It's important to do this *after* setting EM_AUTOUrlDETECT.
         base.OnHandleCreated(e);
+
+        HandleDarkModeDisabledBackground();
 
         // For some reason, we need to set the OleCallback before setting the RTF property.
         UpdateOleCallback();
@@ -3445,6 +3465,24 @@ public partial class RichTextBox : TextBoxBase
     {
         switch (m.MsgInternal)
         {
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+            case PInvokeCore.WM_PAINT:
+                if (IsHandleCreated && !Enabled)
+                {
+                    if (Application.IsDarkModeEnabled && DarkModeRequestState is true)
+                    {
+                        // If the control is in dark mode, we need to paint the background
+                        // with the dark mode color.
+                        using Graphics g = Graphics.FromHwnd(Handle);
+                        g.Clear(SystemColors.Control);
+                    }
+                }
+
+                base.WndProc(ref m);
+                break;
+
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
             case MessageId.WM_REFLECT_NOTIFY:
                 WmReflectNotify(ref m);
                 break;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TextBox/TextBoxBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TextBox/TextBoxBase.cs
@@ -287,10 +287,9 @@ public abstract partial class TextBoxBase : Control
             else
             {
                 return ReadOnly
-
                     // If we're ReadOnly and in DarkMode, we are using a different background color.
                     ? Application.IsDarkModeEnabled
-                        && _darkModeRequestState is true
+                        && DarkModeRequestState is true
                             ? SystemColors.ControlDarkDark
                             : SystemColors.Control
                     : SystemColors.Window;
@@ -955,7 +954,7 @@ public abstract partial class TextBoxBase : Control
     {
         // If we have no specifically defined back color, we set the back color in case we're in dark mode.
         if (Application.IsDarkModeEnabled
-            && _darkModeRequestState is true)
+            && DarkModeRequestState is true)
         {
             base.BackColor = value ? SystemColors.ControlLight : SystemColors.Window;
             Invalidate();


### PR DESCRIPTION
Fixes the `ComboBox` and `RichTextBox` BackColor issue in dark mode, where the background color was the same as in Classic mode (LightMode).

Note, that ComboBox internally uses depending on the ComboBox DropDownStyle different nested controls for different modes. So, practically there are inner ListBox and TextBox controls which had to be addressed:

<img width="553" height="456" alt="image" src="https://github.com/user-attachments/assets/61821717-b509-4ecf-b703-89f7a0970c60" />

Again: Tested by CTI and made sure, that the Classic mode CodePaths remain as they were.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13721)