### PR TITLE
Add code coverage for RadioButtonBaseAdapter

### DIFF
--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/RadioButtonBaseAdapterTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/RadioButtonBaseAdapterTests.cs
@@ -1,0 +1,387 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Drawing;
+using System.Windows.Forms.ButtonInternal;
+using static System.Windows.Forms.ButtonInternal.ButtonBaseAdapter;
+
+namespace System.Windows.Forms.Tests;
+
+public class RadioButtonBaseAdapterTests
+{
+    private class TestRadioButton : RadioButton
+    {
+        public TestRadioButton()
+        {
+        }
+
+        public void InvokeOnMouseDown(MouseEventArgs e)
+        {
+            base.OnMouseDown(e);
+        }
+
+        public void InvokeOnMouseUp(MouseEventArgs e)
+        {
+            base.OnMouseUp(e);
+        }
+    }
+
+    private class TestRadioButtonBaseAdapter : RadioButtonBaseAdapter
+    {
+        public TestRadioButtonBaseAdapter(RadioButton control) : base(control)
+        {
+        }
+
+        public new RadioButton Control => base.Control;
+
+        public void CallDrawCheckFlat(PaintEventArgs e, LayoutData layout, Color checkColor, Color checkBackground, Color checkBorder)
+            => DrawCheckFlat(e, layout, checkColor, checkBackground, checkBorder);
+
+        public void CallDrawCheckBackgroundFlat(PaintEventArgs e, Rectangle bounds, Color borderColor, Color checkBackground)
+            => DrawCheckBackgroundFlat(e, bounds, borderColor, checkBackground);
+
+        public void CallDrawCheckBackground3DLite(PaintEventArgs e, Rectangle bounds, Color checkBackground, ColorData colors, bool disabledColors)
+            => DrawCheckBackground3DLite(e, bounds, checkBackground, colors, disabledColors);
+
+        public void CallDrawCheckOnly(PaintEventArgs e, LayoutData layout, Color checkColor, bool disabledColors)
+            => DrawCheckOnly(e, layout, checkColor, disabledColors);
+
+        public ButtonState CallGetState() => GetState();
+
+        public void CallDrawCheckBox(PaintEventArgs e, LayoutData layout)
+            => DrawCheckBox(e, layout);
+
+        public void CallAdjustFocusRectangle(LayoutData layout)
+            => AdjustFocusRectangle(layout);
+
+        public LayoutOptions CallCommonLayout() => CommonLayout();
+
+        internal override void PaintOver(PaintEventArgs e, CheckState state)
+        {
+        }
+
+        internal override void PaintUp(PaintEventArgs e, CheckState state)
+        {
+        }
+
+        internal override void PaintDown(PaintEventArgs e, CheckState state)
+        {
+        }
+
+        protected override LayoutOptions Layout(PaintEventArgs e)
+        {
+            return new LayoutOptions();
+        }
+
+        protected override ButtonBaseAdapter CreateButtonAdapter()
+        {
+            return this;
+        }
+    }
+
+    private static (TestRadioButton, TestRadioButtonBaseAdapter) CreateAdapter()
+    {
+        using TestRadioButton radioButton = new();
+        TestRadioButtonBaseAdapter radioButtonBaseAdapter = new(radioButton);
+
+        return (radioButton, radioButtonBaseAdapter);
+    }
+
+    [WinFormsFact]
+    public void DrawCheckFlat_CallsBackgroundAndCheckOnly()
+    {
+        (_, TestRadioButtonBaseAdapter radioButtonBaseAdapter) = CreateAdapter();
+        using Bitmap bmp = new(20, 20);
+        using Graphics g = Graphics.FromImage(bmp);
+        using PaintEventArgs e = new(g, new Rectangle(0, 0, 20, 20));
+        LayoutData layout = new(new LayoutOptions());
+
+        radioButtonBaseAdapter.CallDrawCheckFlat(e, layout, Color.Red, Color.Blue, Color.Green);
+
+        bool anyPixelChanged = false;
+        Color defaultColor = bmp.GetPixel(0, 0);
+        for (int x = 0; x < bmp.Width && !anyPixelChanged; x++)
+        {
+            for (int y = 0; y < bmp.Height && !anyPixelChanged; y++)
+            {
+                if (bmp.GetPixel(x, y) != defaultColor)
+                {
+                    anyPixelChanged = true;
+                }
+            }
+        }
+
+        anyPixelChanged.Should().BeTrue("DrawCheckFlat should modify the bitmap.");
+    }
+
+    [WinFormsFact]
+    public void DrawCheckBackgroundFlat_EnabledAndDisabled_ChangesColors()
+    {
+        (TestRadioButton radioButton, TestRadioButtonBaseAdapter radioButtonBaseAdapter) = CreateAdapter();
+        using Bitmap bmp = new(20, 20);
+        using Graphics g = Graphics.FromImage(bmp);
+        using PaintEventArgs e = new(g, new Rectangle(0, 0, 20, 20));
+        Rectangle bounds = new(1, 1, 12, 12);
+
+        radioButton.Enabled = true;
+        radioButtonBaseAdapter.CallDrawCheckBackgroundFlat(e, bounds, Color.Black, Color.White);
+
+        bool anyPixelChangedEnabled = false;
+        Color defaultColorEnabled = bmp.GetPixel(bounds.X, bounds.Y);
+        for (int x = bounds.X; x < bounds.Right && !anyPixelChangedEnabled; x++)
+        {
+            for (int y = bounds.Y; y < bounds.Bottom && !anyPixelChangedEnabled; y++)
+            {
+                if (bmp.GetPixel(x, y) != defaultColorEnabled)
+                {
+                    anyPixelChangedEnabled = true;
+                }
+            }
+        }
+
+        anyPixelChangedEnabled.Should().BeTrue("drawing the background when enabled should modify the bitmap in the bounds area");
+
+        using (Graphics clearG = Graphics.FromImage(bmp))
+        {
+            clearG.Clear(Color.Empty);
+        }
+
+        radioButton.Enabled = false;
+        radioButtonBaseAdapter.CallDrawCheckBackgroundFlat(e, bounds, Color.Black, Color.White);
+
+        bool anyPixelChangedDisabled = false;
+        Color defaultColorDisabled = bmp.GetPixel(bounds.X, bounds.Y);
+        for (int x = bounds.X; x < bounds.Right && !anyPixelChangedDisabled; x++)
+        {
+            for (int y = bounds.Y; y < bounds.Bottom && !anyPixelChangedDisabled; y++)
+            {
+                if (bmp.GetPixel(x, y) != defaultColorDisabled)
+                {
+                    anyPixelChangedDisabled = true;
+                }
+            }
+        }
+
+        anyPixelChangedDisabled.Should().BeTrue("drawing the background when disabled should modify the bitmap in the bounds area");
+    }
+
+    [WinFormsFact]
+    public void DrawCheckBackground3DLite_EnabledAndDisabled_UsesCorrectColors()
+    {
+        (TestRadioButton radioButton, TestRadioButtonBaseAdapter radioButtonBaseAdapter) = CreateAdapter();
+        using Bitmap bmp = new(20, 20);
+        using Graphics g = Graphics.FromImage(bmp);
+        using PaintEventArgs e = new(g, new Rectangle(0, 0, 20, 20));
+        Rectangle bounds = new(1, 1, 12, 12);
+        ColorData colors = new(
+            new ColorOptions(
+                g,
+                Color.Black,
+                Color.White
+            )
+        )
+        {
+            ButtonFace = Color.Gray,
+            ButtonShadow = Color.DarkGray,
+            Highlight = Color.LightGray
+        };
+
+        radioButton.Enabled = true;
+        radioButtonBaseAdapter.CallDrawCheckBackground3DLite(e, bounds, Color.White, colors, disabledColors: false);
+
+        bool anyPixelChangedEnabled = false;
+        Color defaultColorEnabled = bmp.GetPixel(bounds.X, bounds.Y);
+        for (int x = bounds.X; x < bounds.Right && !anyPixelChangedEnabled; x++)
+        {
+            for (int y = bounds.Y; y < bounds.Bottom && !anyPixelChangedEnabled; y++)
+            {
+                if (bmp.GetPixel(x, y) != defaultColorEnabled)
+                {
+                    anyPixelChangedEnabled = true;
+                }
+            }
+        }
+
+        anyPixelChangedEnabled.Should().BeTrue("drawing the 3D lite background when enabled should modify the bitmap in the bounds area");
+
+        using (Graphics clearG = Graphics.FromImage(bmp))
+        {
+            clearG.Clear(Color.Empty);
+        }
+
+        radioButton.Enabled = false;
+        radioButtonBaseAdapter.CallDrawCheckBackground3DLite(e, bounds, Color.White, colors, disabledColors: true);
+
+        bool anyPixelChangedDisabled = false;
+        Color defaultColorDisabled = bmp.GetPixel(bounds.X, bounds.Y);
+        for (int x = bounds.X; x < bounds.Right && !anyPixelChangedDisabled; x++)
+        {
+            for (int y = bounds.Y; y < bounds.Bottom && !anyPixelChangedDisabled; y++)
+            {
+                if (bmp.GetPixel(x, y) != defaultColorDisabled)
+                {
+                    anyPixelChangedDisabled = true;
+                }
+            }
+        }
+
+        anyPixelChangedDisabled.Should().BeTrue("drawing the 3D lite background when disabled should modify the bitmap in the bounds area");
+    }
+
+    [WinFormsFact]
+    public void DrawCheckOnly_CheckedAndUnchecked_DrawsOrSkips()
+    {
+        (TestRadioButton radioButton, TestRadioButtonBaseAdapter radioButtonBaseAdapter) = CreateAdapter();
+        using Bitmap bmp = new(20, 20);
+        using Graphics g = Graphics.FromImage(bmp);
+        using PaintEventArgs e = new(g, new Rectangle(0, 0, 20, 20));
+        LayoutData layoutData = new(new LayoutOptions())
+        {
+            CheckBounds = new Rectangle(2, 2, 12, 12)
+        };
+
+        radioButton.Checked = false;
+        radioButtonBaseAdapter.CallDrawCheckOnly(e, layoutData, Color.Black, disabledColors: false);
+
+        bool anyPixelChangedUnchecked = false;
+        Color defaultColorUnchecked = bmp.GetPixel(layoutData.CheckBounds.X, layoutData.CheckBounds.Y);
+        for (int x = layoutData.CheckBounds.X; x < layoutData.CheckBounds.Right && !anyPixelChangedUnchecked; x++)
+        {
+            for (int y = layoutData.CheckBounds.Y; y < layoutData.CheckBounds.Bottom && !anyPixelChangedUnchecked; y++)
+            {
+                if (bmp.GetPixel(x, y) != defaultColorUnchecked)
+                {
+                    anyPixelChangedUnchecked = true;
+                }
+            }
+        }
+
+        anyPixelChangedUnchecked.Should().BeFalse("DrawCheckOnly should not modify the bitmap when unchecked.");
+
+        radioButton.Checked = true;
+        radioButton.Enabled = true;
+        radioButtonBaseAdapter.CallDrawCheckOnly(e, layoutData, Color.Black, disabledColors: false);
+
+        bool anyPixelChangedChecked = false;
+        Color defaultColorChecked = bmp.GetPixel(layoutData.CheckBounds.X, layoutData.CheckBounds.Y);
+        for (int x = layoutData.CheckBounds.X; x < layoutData.CheckBounds.Right && !anyPixelChangedChecked; x++)
+        {
+            for (int y = layoutData.CheckBounds.Y; y < layoutData.CheckBounds.Bottom && !anyPixelChangedChecked; y++)
+            {
+                if (bmp.GetPixel(x, y) != defaultColorChecked)
+                {
+                    anyPixelChangedChecked = true;
+                }
+            }
+        }
+
+        anyPixelChangedChecked.Should().BeTrue("DrawCheckOnly should modify the bitmap when checked and enabled.");
+
+        radioButton.Enabled = false;
+        radioButtonBaseAdapter.CallDrawCheckOnly(e, layoutData, Color.Black, disabledColors: true);
+
+        bool anyPixelChangedCheckedDisabled = false;
+        Color defaultColorCheckedDisabled = bmp.GetPixel(layoutData.CheckBounds.X, layoutData.CheckBounds.Y);
+        for (int x = layoutData.CheckBounds.X; x < layoutData.CheckBounds.Right && !anyPixelChangedCheckedDisabled; x++)
+        {
+            for (int y = layoutData.CheckBounds.Y; y < layoutData.CheckBounds.Bottom && !anyPixelChangedCheckedDisabled; y++)
+            {
+                if (bmp.GetPixel(x, y) != defaultColorCheckedDisabled)
+                {
+                    anyPixelChangedCheckedDisabled = true;
+                }
+            }
+        }
+
+        anyPixelChangedCheckedDisabled.Should().BeTrue("DrawCheckOnly should modify the bitmap when checked and disabled.");
+    }
+
+    [WinFormsFact]
+    public void GetState_ReturnsCorrectButtonState()
+    {
+        (TestRadioButton radioButton, TestRadioButtonBaseAdapter radioButtonBaseAdapter) = CreateAdapter();
+
+        radioButton.Checked = false;
+        radioButton.Enabled = true;
+        radioButton.InvokeOnMouseUp(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, 0));
+        ButtonState state = radioButtonBaseAdapter.CallGetState();
+
+        state.Should().Be(ButtonState.Normal);
+
+        radioButton.Checked = true;
+        state = radioButtonBaseAdapter.CallGetState();
+
+        state.HasFlag(ButtonState.Checked).Should().BeTrue();
+
+        radioButton.Enabled = false;
+        state = radioButtonBaseAdapter.CallGetState();
+
+        state.HasFlag(ButtonState.Inactive).Should().BeTrue();
+
+        radioButton.Enabled = true;
+        radioButton.InvokeOnMouseDown(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, 0));
+        state = radioButtonBaseAdapter.CallGetState();
+
+        state.HasFlag(ButtonState.Pushed).Should().BeTrue();
+    }
+
+    [WinFormsFact]
+    public void DrawCheckBox_VisualStylesAndNoVisualStyles_DoesNotThrow()
+    {
+        (_, TestRadioButtonBaseAdapter radioButtonBaseAdapter) = CreateAdapter();
+        using Bitmap bmp = new(20, 20);
+        using Graphics g = Graphics.FromImage(bmp);
+        using PaintEventArgs e = new(g, new Rectangle(0, 0, 20, 20));
+        LayoutData layoutData = new(new LayoutOptions())
+        {
+            CheckBounds = new Rectangle(2, 2, 12, 12)
+        };
+
+        radioButtonBaseAdapter.CallDrawCheckBox(e, layoutData);
+
+        bool anyPixelChanged = false;
+        Color defaultColor = bmp.GetPixel(0, 0);
+        for (int x = 0; x < bmp.Width && !anyPixelChanged; x++)
+        {
+            for (int y = 0; y < bmp.Height && !anyPixelChanged; y++)
+            {
+                if (bmp.GetPixel(x, y) != defaultColor)
+                {
+                    anyPixelChanged = true;
+                }
+            }
+        }
+
+        anyPixelChanged.Should().BeTrue("DrawCheckBox should modify the bitmap.");
+    }
+
+    [WinFormsFact]
+    public void AdjustFocusRectangle_AutoSizeAndNoText_ChangesFocus()
+    {
+        (TestRadioButton radioButton, TestRadioButtonBaseAdapter radioButtonBaseAdapter) = CreateAdapter();
+        LayoutData layoutData = new(new LayoutOptions())
+        {
+            CheckBounds = new Rectangle(1, 2, 3, 4),
+            Field = new Rectangle(5, 6, 7, 8)
+        };
+
+        radioButton.Text = string.Empty;
+        radioButton.AutoSize = true;
+        radioButtonBaseAdapter.CallAdjustFocusRectangle(layoutData);
+        layoutData.Focus.Should().Be(layoutData.CheckBounds);
+
+        radioButton.AutoSize = false;
+        radioButtonBaseAdapter.CallAdjustFocusRectangle(layoutData);
+        layoutData.Focus.Should().Be(layoutData.Field);
+    }
+
+    [WinFormsFact]
+    public void CommonLayout_SetsCheckAlign()
+    {
+        (TestRadioButton radioButton, TestRadioButtonBaseAdapter radioButtonBaseAdapter) = CreateAdapter();
+        radioButton.CheckAlign = ContentAlignment.BottomRight;
+        LayoutOptions layoutOptions = radioButtonBaseAdapter.CallCommonLayout();
+
+        layoutOptions.CheckAlign.Should().Be(ContentAlignment.BottomRight);
+    }
+}

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/RadioButtonBaseAdapterTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/RadioButtonBaseAdapterTests.cs
@@ -34,28 +34,27 @@ public class RadioButtonBaseAdapterTests
 
         public new RadioButton Control => base.Control;
 
-        public void CallDrawCheckFlat(PaintEventArgs e, LayoutData layout, Color checkColor, Color checkBackground, Color checkBorder)
+        public void DrawFlatCheckMark(PaintEventArgs e, LayoutData layout, Color checkColor, Color checkBackground, Color checkBorder)
             => DrawCheckFlat(e, layout, checkColor, checkBackground, checkBorder);
 
-        public void CallDrawCheckBackgroundFlat(PaintEventArgs e, Rectangle bounds, Color borderColor, Color checkBackground)
+        public void DrawBackgroundFlatMark(PaintEventArgs e, Rectangle bounds, Color borderColor, Color checkBackground)
             => DrawCheckBackgroundFlat(e, bounds, borderColor, checkBackground);
 
-        public void CallDrawCheckBackground3DLite(PaintEventArgs e, Rectangle bounds, Color checkBackground, ColorData colors, bool disabledColors)
+        public void DrawBackground3DLiteMark(PaintEventArgs e, Rectangle bounds, Color checkBackground, ColorData colors, bool disabledColors)
             => DrawCheckBackground3DLite(e, bounds, checkBackground, colors, disabledColors);
 
-        public void CallDrawCheckOnly(PaintEventArgs e, LayoutData layout, Color checkColor, bool disabledColors)
+        public void DrawCheckOnlyMark(PaintEventArgs e, LayoutData layout, Color checkColor, bool disabledColors)
             => DrawCheckOnly(e, layout, checkColor, disabledColors);
 
-        public ButtonState CallGetState() => GetState();
+        public ButtonState GetStateMark() => GetState();
 
-        public void CallDrawCheckBox(PaintEventArgs e, LayoutData layout)
+        public void DrawCheckBoxMark(PaintEventArgs e, LayoutData layout)
             => DrawCheckBox(e, layout);
 
-        public void CallAdjustFocusRectangle(LayoutData layout)
+        public void AdjustFocusRectangleMark(LayoutData layout)
             => AdjustFocusRectangle(layout);
 
-        public LayoutOptions CallCommonLayout() => CommonLayout();
-
+        public LayoutOptions GetLayoutOptions() => CommonLayout();
         internal override void PaintOver(PaintEventArgs e, CheckState state)
         {
         }
@@ -87,15 +86,24 @@ public class RadioButtonBaseAdapterTests
         return (radioButton, radioButtonBaseAdapter);
     }
 
-    private static bool AnyPixelChanged(Bitmap bmp, Rectangle bounds)
+    /// <summary>
+    ///  Determines whether any pixel within the specified bounds of the bitmap differs from the reference pixel
+    ///  at the top-left corner of the bounds. Used to verify if drawing operations have modified the bitmap.
+    /// </summary>
+    /// <param name="bmp">The bitmap to inspect.</param>
+    /// <param name="bounds">The rectangle area within the bitmap to check for changes.</param>
+    /// <returns>
+    ///  <see langword="true"/> if any pixel in the bounds differs from the reference pixel; otherwise, <see langword="false"/>.
+    /// </returns>
+    private static bool HasPixelChanged(Bitmap bmp, Rectangle bounds)
     {
-        Color reference = bmp.GetPixel(bounds.X, bounds.Y);
+        Color referenceColor = bmp.GetPixel(bounds.X, bounds.Y);
 
         for (int x = bounds.X; x < bounds.Right; x++)
         {
             for (int y = bounds.Y; y < bounds.Bottom; y++)
             {
-                if (bmp.GetPixel(x, y) != reference)
+                if (bmp.GetPixel(x, y) != referenceColor)
                 {
                     return true;
                 }
@@ -114,9 +122,9 @@ public class RadioButtonBaseAdapterTests
         using PaintEventArgs e = new(g, new Rectangle(0, 0, 20, 20));
         LayoutData layout = new(new LayoutOptions());
 
-        radioButtonBaseAdapter.CallDrawCheckFlat(e, layout, Color.Red, Color.Blue, Color.Green);
+        radioButtonBaseAdapter.DrawFlatCheckMark(e, layout, Color.Red, Color.Blue, Color.Green);
 
-        bool anyPixelChanged = AnyPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
+        bool anyPixelChanged = HasPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
 
         anyPixelChanged.Should().BeTrue("DrawCheckFlat should modify the bitmap.");
     }
@@ -131,9 +139,9 @@ public class RadioButtonBaseAdapterTests
         Rectangle bounds = new(1, 1, 12, 12);
 
         radioButton.Enabled = true;
-        radioButtonBaseAdapter.CallDrawCheckBackgroundFlat(e, bounds, Color.Black, Color.White);
+        radioButtonBaseAdapter.DrawBackgroundFlatMark(e, bounds, Color.Black, Color.White);
 
-        bool anyPixelChangedEnabled = AnyPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
+        bool anyPixelChangedEnabled = HasPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
 
         anyPixelChangedEnabled.Should().BeTrue("drawing the background when enabled should modify the bitmap in the bounds area");
 
@@ -143,9 +151,9 @@ public class RadioButtonBaseAdapterTests
         }
 
         radioButton.Enabled = false;
-        radioButtonBaseAdapter.CallDrawCheckBackgroundFlat(e, bounds, Color.Black, Color.White);
+        radioButtonBaseAdapter.DrawBackgroundFlatMark(e, bounds, Color.Black, Color.White);
 
-        bool anyPixelChangedDisabled = AnyPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
+        bool anyPixelChangedDisabled = HasPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
 
         anyPixelChangedDisabled.Should().BeTrue("drawing the background when disabled should modify the bitmap in the bounds area");
     }
@@ -172,9 +180,9 @@ public class RadioButtonBaseAdapterTests
         };
 
         radioButton.Enabled = true;
-        radioButtonBaseAdapter.CallDrawCheckBackground3DLite(e, bounds, Color.White, colors, disabledColors: false);
+        radioButtonBaseAdapter.DrawBackground3DLiteMark(e, bounds, Color.White, colors, disabledColors: false);
 
-        bool anyPixelChangedEnabled = AnyPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
+        bool anyPixelChangedEnabled = HasPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
 
         anyPixelChangedEnabled.Should().BeTrue("drawing the 3D lite background when enabled should modify the bitmap in the bounds area");
 
@@ -184,9 +192,9 @@ public class RadioButtonBaseAdapterTests
         }
 
         radioButton.Enabled = false;
-        radioButtonBaseAdapter.CallDrawCheckBackground3DLite(e, bounds, Color.White, colors, disabledColors: true);
+        radioButtonBaseAdapter.DrawBackground3DLiteMark(e, bounds, Color.White, colors, disabledColors: true);
 
-        bool anyPixelChangedDisabled = AnyPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
+        bool anyPixelChangedDisabled = HasPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
 
         anyPixelChangedDisabled.Should().BeTrue("drawing the 3D lite background when disabled should modify the bitmap in the bounds area");
     }
@@ -204,24 +212,24 @@ public class RadioButtonBaseAdapterTests
         };
 
         radioButton.Checked = false;
-        radioButtonBaseAdapter.CallDrawCheckOnly(e, layoutData, Color.Black, disabledColors: false);
+        radioButtonBaseAdapter.DrawCheckOnlyMark(e, layoutData, Color.Black, disabledColors: false);
 
-        bool anyPixelChangedUnchecked = AnyPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
+        bool anyPixelChangedUnchecked = HasPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
 
         anyPixelChangedUnchecked.Should().BeFalse("DrawCheckOnly should not modify the bitmap when unchecked.");
 
         radioButton.Checked = true;
         radioButton.Enabled = true;
-        radioButtonBaseAdapter.CallDrawCheckOnly(e, layoutData, Color.Black, disabledColors: false);
+        radioButtonBaseAdapter.DrawCheckOnlyMark(e, layoutData, Color.Black, disabledColors: false);
 
-        bool anyPixelChangedChecked = AnyPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
+        bool anyPixelChangedChecked = HasPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
 
         anyPixelChangedChecked.Should().BeTrue("DrawCheckOnly should modify the bitmap when checked and enabled.");
 
         radioButton.Enabled = false;
-        radioButtonBaseAdapter.CallDrawCheckOnly(e, layoutData, Color.Black, disabledColors: true);
+        radioButtonBaseAdapter.DrawCheckOnlyMark(e, layoutData, Color.Black, disabledColors: true);
 
-        bool anyPixelChangedCheckedDisabled = AnyPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
+        bool anyPixelChangedCheckedDisabled = HasPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
 
         anyPixelChangedCheckedDisabled.Should().BeTrue("DrawCheckOnly should modify the bitmap when checked and disabled.");
     }
@@ -234,23 +242,23 @@ public class RadioButtonBaseAdapterTests
         radioButton.Checked = false;
         radioButton.Enabled = true;
         radioButton.InvokeOnMouseUp(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, 0));
-        ButtonState state = radioButtonBaseAdapter.CallGetState();
+        ButtonState state = radioButtonBaseAdapter.GetStateMark();
 
         state.Should().Be(ButtonState.Normal);
 
         radioButton.Checked = true;
-        state = radioButtonBaseAdapter.CallGetState();
+        state = radioButtonBaseAdapter.GetStateMark();
 
         state.HasFlag(ButtonState.Checked).Should().BeTrue();
 
         radioButton.Enabled = false;
-        state = radioButtonBaseAdapter.CallGetState();
+        state = radioButtonBaseAdapter.GetStateMark();
 
         state.HasFlag(ButtonState.Inactive).Should().BeTrue();
 
         radioButton.Enabled = true;
         radioButton.InvokeOnMouseDown(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, 0));
-        state = radioButtonBaseAdapter.CallGetState();
+        state = radioButtonBaseAdapter.GetStateMark();
 
         state.HasFlag(ButtonState.Pushed).Should().BeTrue();
     }
@@ -267,9 +275,9 @@ public class RadioButtonBaseAdapterTests
             CheckBounds = new Rectangle(2, 2, 12, 12)
         };
 
-        radioButtonBaseAdapter.CallDrawCheckBox(e, layoutData);
+        radioButtonBaseAdapter.DrawCheckBoxMark(e, layoutData);
 
-        bool anyPixelChanged = AnyPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
+        bool anyPixelChanged = HasPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
 
         anyPixelChanged.Should().BeTrue("DrawCheckBox should modify the bitmap.");
     }
@@ -286,11 +294,11 @@ public class RadioButtonBaseAdapterTests
 
         radioButton.Text = string.Empty;
         radioButton.AutoSize = true;
-        radioButtonBaseAdapter.CallAdjustFocusRectangle(layoutData);
+        radioButtonBaseAdapter.AdjustFocusRectangleMark(layoutData);
         layoutData.Focus.Should().Be(layoutData.CheckBounds);
 
         radioButton.AutoSize = false;
-        radioButtonBaseAdapter.CallAdjustFocusRectangle(layoutData);
+        radioButtonBaseAdapter.AdjustFocusRectangleMark(layoutData);
         layoutData.Focus.Should().Be(layoutData.Field);
     }
 
@@ -299,7 +307,7 @@ public class RadioButtonBaseAdapterTests
     {
         (TestRadioButton radioButton, TestRadioButtonBaseAdapter radioButtonBaseAdapter) = CreateAdapter();
         radioButton.CheckAlign = ContentAlignment.BottomRight;
-        LayoutOptions layoutOptions = radioButtonBaseAdapter.CallCommonLayout();
+        LayoutOptions layoutOptions = radioButtonBaseAdapter.CommonLayout();
 
         layoutOptions.CheckAlign.Should().Be(ContentAlignment.BottomRight);
     }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/RadioButtonBaseAdapterTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/RadioButtonBaseAdapterTests.cs
@@ -87,6 +87,24 @@ public class RadioButtonBaseAdapterTests
         return (radioButton, radioButtonBaseAdapter);
     }
 
+    private static bool AnyPixelChanged(Bitmap bmp, Rectangle bounds)
+    {
+        Color reference = bmp.GetPixel(bounds.X, bounds.Y);
+
+        for (int x = bounds.X; x < bounds.Right; x++)
+        {
+            for (int y = bounds.Y; y < bounds.Bottom; y++)
+            {
+                if (bmp.GetPixel(x, y) != reference)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     [WinFormsFact]
     public void DrawCheckFlat_CallsBackgroundAndCheckOnly()
     {
@@ -98,18 +116,7 @@ public class RadioButtonBaseAdapterTests
 
         radioButtonBaseAdapter.CallDrawCheckFlat(e, layout, Color.Red, Color.Blue, Color.Green);
 
-        bool anyPixelChanged = false;
-        Color defaultColor = bmp.GetPixel(0, 0);
-        for (int x = 0; x < bmp.Width && !anyPixelChanged; x++)
-        {
-            for (int y = 0; y < bmp.Height && !anyPixelChanged; y++)
-            {
-                if (bmp.GetPixel(x, y) != defaultColor)
-                {
-                    anyPixelChanged = true;
-                }
-            }
-        }
+        bool anyPixelChanged = AnyPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
 
         anyPixelChanged.Should().BeTrue("DrawCheckFlat should modify the bitmap.");
     }
@@ -126,18 +133,7 @@ public class RadioButtonBaseAdapterTests
         radioButton.Enabled = true;
         radioButtonBaseAdapter.CallDrawCheckBackgroundFlat(e, bounds, Color.Black, Color.White);
 
-        bool anyPixelChangedEnabled = false;
-        Color defaultColorEnabled = bmp.GetPixel(bounds.X, bounds.Y);
-        for (int x = bounds.X; x < bounds.Right && !anyPixelChangedEnabled; x++)
-        {
-            for (int y = bounds.Y; y < bounds.Bottom && !anyPixelChangedEnabled; y++)
-            {
-                if (bmp.GetPixel(x, y) != defaultColorEnabled)
-                {
-                    anyPixelChangedEnabled = true;
-                }
-            }
-        }
+        bool anyPixelChangedEnabled = AnyPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
 
         anyPixelChangedEnabled.Should().BeTrue("drawing the background when enabled should modify the bitmap in the bounds area");
 
@@ -149,18 +145,7 @@ public class RadioButtonBaseAdapterTests
         radioButton.Enabled = false;
         radioButtonBaseAdapter.CallDrawCheckBackgroundFlat(e, bounds, Color.Black, Color.White);
 
-        bool anyPixelChangedDisabled = false;
-        Color defaultColorDisabled = bmp.GetPixel(bounds.X, bounds.Y);
-        for (int x = bounds.X; x < bounds.Right && !anyPixelChangedDisabled; x++)
-        {
-            for (int y = bounds.Y; y < bounds.Bottom && !anyPixelChangedDisabled; y++)
-            {
-                if (bmp.GetPixel(x, y) != defaultColorDisabled)
-                {
-                    anyPixelChangedDisabled = true;
-                }
-            }
-        }
+        bool anyPixelChangedDisabled = AnyPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
 
         anyPixelChangedDisabled.Should().BeTrue("drawing the background when disabled should modify the bitmap in the bounds area");
     }
@@ -189,18 +174,7 @@ public class RadioButtonBaseAdapterTests
         radioButton.Enabled = true;
         radioButtonBaseAdapter.CallDrawCheckBackground3DLite(e, bounds, Color.White, colors, disabledColors: false);
 
-        bool anyPixelChangedEnabled = false;
-        Color defaultColorEnabled = bmp.GetPixel(bounds.X, bounds.Y);
-        for (int x = bounds.X; x < bounds.Right && !anyPixelChangedEnabled; x++)
-        {
-            for (int y = bounds.Y; y < bounds.Bottom && !anyPixelChangedEnabled; y++)
-            {
-                if (bmp.GetPixel(x, y) != defaultColorEnabled)
-                {
-                    anyPixelChangedEnabled = true;
-                }
-            }
-        }
+        bool anyPixelChangedEnabled = AnyPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
 
         anyPixelChangedEnabled.Should().BeTrue("drawing the 3D lite background when enabled should modify the bitmap in the bounds area");
 
@@ -212,18 +186,7 @@ public class RadioButtonBaseAdapterTests
         radioButton.Enabled = false;
         radioButtonBaseAdapter.CallDrawCheckBackground3DLite(e, bounds, Color.White, colors, disabledColors: true);
 
-        bool anyPixelChangedDisabled = false;
-        Color defaultColorDisabled = bmp.GetPixel(bounds.X, bounds.Y);
-        for (int x = bounds.X; x < bounds.Right && !anyPixelChangedDisabled; x++)
-        {
-            for (int y = bounds.Y; y < bounds.Bottom && !anyPixelChangedDisabled; y++)
-            {
-                if (bmp.GetPixel(x, y) != defaultColorDisabled)
-                {
-                    anyPixelChangedDisabled = true;
-                }
-            }
-        }
+        bool anyPixelChangedDisabled = AnyPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
 
         anyPixelChangedDisabled.Should().BeTrue("drawing the 3D lite background when disabled should modify the bitmap in the bounds area");
     }
@@ -243,18 +206,7 @@ public class RadioButtonBaseAdapterTests
         radioButton.Checked = false;
         radioButtonBaseAdapter.CallDrawCheckOnly(e, layoutData, Color.Black, disabledColors: false);
 
-        bool anyPixelChangedUnchecked = false;
-        Color defaultColorUnchecked = bmp.GetPixel(layoutData.CheckBounds.X, layoutData.CheckBounds.Y);
-        for (int x = layoutData.CheckBounds.X; x < layoutData.CheckBounds.Right && !anyPixelChangedUnchecked; x++)
-        {
-            for (int y = layoutData.CheckBounds.Y; y < layoutData.CheckBounds.Bottom && !anyPixelChangedUnchecked; y++)
-            {
-                if (bmp.GetPixel(x, y) != defaultColorUnchecked)
-                {
-                    anyPixelChangedUnchecked = true;
-                }
-            }
-        }
+        bool anyPixelChangedUnchecked = AnyPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
 
         anyPixelChangedUnchecked.Should().BeFalse("DrawCheckOnly should not modify the bitmap when unchecked.");
 
@@ -262,36 +214,14 @@ public class RadioButtonBaseAdapterTests
         radioButton.Enabled = true;
         radioButtonBaseAdapter.CallDrawCheckOnly(e, layoutData, Color.Black, disabledColors: false);
 
-        bool anyPixelChangedChecked = false;
-        Color defaultColorChecked = bmp.GetPixel(layoutData.CheckBounds.X, layoutData.CheckBounds.Y);
-        for (int x = layoutData.CheckBounds.X; x < layoutData.CheckBounds.Right && !anyPixelChangedChecked; x++)
-        {
-            for (int y = layoutData.CheckBounds.Y; y < layoutData.CheckBounds.Bottom && !anyPixelChangedChecked; y++)
-            {
-                if (bmp.GetPixel(x, y) != defaultColorChecked)
-                {
-                    anyPixelChangedChecked = true;
-                }
-            }
-        }
+        bool anyPixelChangedChecked = AnyPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
 
         anyPixelChangedChecked.Should().BeTrue("DrawCheckOnly should modify the bitmap when checked and enabled.");
 
         radioButton.Enabled = false;
         radioButtonBaseAdapter.CallDrawCheckOnly(e, layoutData, Color.Black, disabledColors: true);
 
-        bool anyPixelChangedCheckedDisabled = false;
-        Color defaultColorCheckedDisabled = bmp.GetPixel(layoutData.CheckBounds.X, layoutData.CheckBounds.Y);
-        for (int x = layoutData.CheckBounds.X; x < layoutData.CheckBounds.Right && !anyPixelChangedCheckedDisabled; x++)
-        {
-            for (int y = layoutData.CheckBounds.Y; y < layoutData.CheckBounds.Bottom && !anyPixelChangedCheckedDisabled; y++)
-            {
-                if (bmp.GetPixel(x, y) != defaultColorCheckedDisabled)
-                {
-                    anyPixelChangedCheckedDisabled = true;
-                }
-            }
-        }
+        bool anyPixelChangedCheckedDisabled = AnyPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
 
         anyPixelChangedCheckedDisabled.Should().BeTrue("DrawCheckOnly should modify the bitmap when checked and disabled.");
     }
@@ -339,18 +269,7 @@ public class RadioButtonBaseAdapterTests
 
         radioButtonBaseAdapter.CallDrawCheckBox(e, layoutData);
 
-        bool anyPixelChanged = false;
-        Color defaultColor = bmp.GetPixel(0, 0);
-        for (int x = 0; x < bmp.Width && !anyPixelChanged; x++)
-        {
-            for (int y = 0; y < bmp.Height && !anyPixelChanged; y++)
-            {
-                if (bmp.GetPixel(x, y) != defaultColor)
-                {
-                    anyPixelChanged = true;
-                }
-            }
-        }
+        bool anyPixelChanged = AnyPixelChanged(bmp, new Rectangle(0, 0, bmp.Width, bmp.Height));
 
         anyPixelChanged.Should().BeTrue("DrawCheckBox should modify the bitmap.");
     }


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/13442

## Proposed changes
Add unit test file:RadioButtonBaseAdapterTests.cs for public/protected methods/properties of the RadioButtonBaseAdapter.cs
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13726)