### PR TITLE
Use programatically check instead of assertion in method ComputeVisibleColumns of DataGridView.Methods to avoid null reference exception

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
@@ -4699,15 +4699,19 @@ public partial class DataGridView
                         (Columns[firstDisplayedScrollingCol]),
                         DataGridViewElementStates.Visible,
                         DataGridViewElementStates.Frozen);
-                    ThrowInvalidOperationExceptionIfNull(dataGridViewColumn);
-                    Debug.Assert(dataGridViewColumn.Thickness > displayWidth - cx);
-                    firstDisplayedScrollingCol = dataGridViewColumn.Index;
-                    FirstDisplayedScrollingColumnHiddenWidth = dataGridViewColumn.Thickness - displayWidth + cx;
-                    _horizontalOffset -= displayWidth - cx;
-                    visibleScrollingColumnsTmp++;
-                    invalidate = true;
-                    cx = displayWidth;
-                    Debug.Assert(FirstDisplayedScrollingColumnHiddenWidth == GetNegOffsetFromHorizontalOffset(_horizontalOffset));
+
+                    // If a valid previous column is found and its width exceeds the remaining displayable space,
+                    // then perform a partial scroll.
+                    if (dataGridViewColumn is not null && dataGridViewColumn.Thickness > displayWidth - cx)
+                    {
+                        firstDisplayedScrollingCol = dataGridViewColumn.Index;
+                        FirstDisplayedScrollingColumnHiddenWidth = dataGridViewColumn.Thickness - displayWidth + cx;
+                        _horizontalOffset -= displayWidth - cx;
+                        visibleScrollingColumnsTmp++;
+                        invalidate = true;
+                        cx = displayWidth;
+                        Debug.Assert(FirstDisplayedScrollingColumnHiddenWidth == GetNegOffsetFromHorizontalOffset(_horizontalOffset));
+                    }
                 }
 
                 // update the number of visible columns to the new reality

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
@@ -4702,8 +4702,9 @@ public partial class DataGridView
 
                     // If a valid previous column is found and its width exceeds the remaining displayable space,
                     // then perform a partial scroll.
-                    if (dataGridViewColumn is not null && dataGridViewColumn.Thickness > displayWidth - cx)
+                    if (dataGridViewColumn is not null)
                     {
+                        Debug.Assert(dataGridViewColumn.Thickness > displayWidth - cx);
                         firstDisplayedScrollingCol = dataGridViewColumn.Index;
                         FirstDisplayedScrollingColumnHiddenWidth = dataGridViewColumn.Thickness - displayWidth + cx;
                         _horizontalOffset -= displayWidth - cx;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13728

## Root Cause

Due to this commit https://github.com/dotnet/winforms/commit/9cbce69154dd971c18d8e3348808ea8b6fb35815 (line 4827), the exception thrown on .net10.0 is `System.InvalidOperationException`, and the exception thrown on .net8.0 is `NullReferenceException`.

The [original code](https://github.com/dotnet/winforms/blob/91ebb7421e6248f425c79169c448246150bd4c39/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs#L4702) does not make a null judgment but adds an assertion without verifying whether `GetPreviousColumn(...)` returned a valid column. In cases where:

- no previous column satisfies Visible & !Frozen,

dataGridViewColumn would be null, triggering an exception and terminating rendering.


## Proposed changes

- Use logical judgment instead of assertion in method `ComputeVisibleColumns` of `DataGridView.Methods `to avoid null reference exception

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- When the leftmost column is hidden and the DataGridView is displaying only the last column, the rightmost column can also be successfully hidden.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Setting DataGridViewColumn.Visible may throw NullReferenceException

https://github.com/user-attachments/assets/746567be-0279-4021-9f55-3c93ebdde7dd


### After
The rightmost visible column can also be successfully hidden.


https://github.com/user-attachments/assets/e9a50a90-d1a5-48bf-abae-dbad33269414



## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-preview.7.25368.105


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13739)