### PR TITLE
[Preview7/Release] Backport 13747 DarkMode: SystemControlButton rendering

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/DropDownButton.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/DropDownButton.cs
@@ -4,6 +4,7 @@
 using System.Drawing;
 using System.Windows.Forms.ButtonInternal;
 using System.Windows.Forms.VisualStyles;
+using static System.Windows.Forms.ControlPaint;
 
 namespace System.Windows.Forms.PropertyGridInternal;
 
@@ -16,6 +17,12 @@ internal sealed partial class DropDownButton : Button
         SetStyle(ControlStyles.Selectable, true);
         SetAccessibleName();
     }
+
+    // If a control uses it needs it in the context of rendering
+    // something in dark mode - this flag needs to be set.
+    public bool RequestDarkModeRendering { get; set; }
+
+    public ModernControlButtonStyle ControlButtonStyle { get; set; }
 
     // When the holder is open, we don't fire clicks.
     public bool IgnoreMouse { get; set; }
@@ -64,52 +71,82 @@ internal sealed partial class DropDownButton : Button
         }
     }
 
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     protected override void OnPaint(PaintEventArgs pevent)
     {
+        ComboBoxState state = ComboBoxState.Normal;
+
+        if (MouseIsDown)
+        {
+            state = ComboBoxState.Pressed;
+        }
+        else if (MouseIsOver)
+        {
+            state = ComboBoxState.Hot;
+        }
+
         base.OnPaint(pevent);
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        if (!Application.IsDarkModeEnabled
-            && (Application.RenderWithVisualStyles & _useComboBoxTheme))
+        if (Application.IsDarkModeEnabled && RequestDarkModeRendering)
         {
-            ComboBoxState state = ComboBoxState.Normal;
+            ModernControlButtonState buttonState = state switch
+            {
+                ComboBoxState.Disabled => ModernControlButtonState.Disabled,
+                ComboBoxState.Hot => ModernControlButtonState.Hover,
+                ComboBoxState.Pressed => ModernControlButtonState.Pressed,
+                _ => ModernControlButtonState.Normal
+            };
 
-            if (MouseIsDown)
-            {
-                state = ComboBoxState.Pressed;
-            }
-            else if (MouseIsOver)
-            {
-                state = ComboBoxState.Hot;
-            }
+            DrawModernControlButton(
+                pevent.Graphics,
+                new Rectangle(0, 0, Width, Height),
+                ControlButtonStyle,
+                buttonState,
+                isDarkMode: true);
 
-            Rectangle dropDownButtonRect = new(0, 0, Width, Height);
-            if (state == ComboBoxState.Normal)
-            {
-                pevent.Graphics.FillRectangle(SystemBrushes.Window, dropDownButtonRect);
-            }
-
-            using (DeviceContextHdcScope hdc = new(pevent))
-            {
-                ComboBoxRenderer.DrawDropDownButtonForHandle(
-                    hdc,
-                    dropDownButtonRect,
-                    state,
-                    ScaleHelper.IsScalingRequirementMet ? HWNDInternal : HWND.Null);
-            }
-
-            // Redraw focus cues.
-            //
-            // For consistency with other PropertyGrid buttons, i.e. those opening system dialogs ("..."), that
-            // always show visual cues when focused, we need to do the same for this custom button, painted as
-            // a ComboBox control part (drop-down).
-            if (Focused)
-            {
-                dropDownButtonRect.Inflate(-1, -1);
-                ControlPaint.DrawFocusRectangle(pevent.Graphics, dropDownButtonRect, ForeColor, BackColor);
-            }
+            return;
         }
+
+        if (Application.RenderWithVisualStyles & _useComboBoxTheme)
+        {
+            RenderComboBoxButtonWithVisualStyles(pevent, state);
+        }
+    }
 #pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    private void RenderComboBoxButtonWithVisualStyles(PaintEventArgs pevent, ComboBoxState state)
+    {
+        Rectangle dropDownButtonRect = new(0, 0, Width, Height);
+
+        if (state == ComboBoxState.Normal)
+        {
+            pevent.Graphics.FillRectangle(
+                SystemBrushes.Window,
+                dropDownButtonRect);
+        }
+
+        using (DeviceContextHdcScope hdc = new(pevent))
+        {
+            ComboBoxRenderer.DrawDropDownButtonForHandle(
+                hdc,
+                dropDownButtonRect,
+                state,
+                ScaleHelper.IsScalingRequirementMet ? HWNDInternal : HWND.Null);
+        }
+
+        // Redraw focus cues.
+        //
+        // For consistency with other PropertyGrid buttons, i.e. those opening system dialogs ("..."), that
+        // always show visual cues when focused, we need to do the same for this custom button, painted as
+        // a ComboBox control part (drop-down).
+        if (Focused)
+        {
+            dropDownButtonRect.Inflate(-1, -1);
+            DrawFocusRectangle(
+                pevent.Graphics,
+                dropDownButtonRect,
+                ForeColor,
+                BackColor);
+        }
     }
 
     internal void PerformButtonClick()

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/DropDownButton.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/DropDownButton.cs
@@ -18,13 +18,20 @@ internal sealed partial class DropDownButton : Button
         SetAccessibleName();
     }
 
-    // If a control uses it needs it in the context of rendering
-    // something in dark mode - this flag needs to be set.
+    /// <summary>
+    ///  Indicates whether the control should be rendered in dark mode.
+    ///  Set this property if you use this class for a control in dark mode.
+    /// </summary>
     public bool RequestDarkModeRendering { get; set; }
 
+    /// <summary>
+    ///  Gets or sets the style used for rendering the control button.
+    /// </summary>
     public ModernControlButtonStyle ControlButtonStyle { get; set; }
 
-    // When the holder is open, we don't fire clicks.
+    /// <summary>
+    ///  Gets or sets a value indicating whether mouse events should be ignored when the holder is open.
+    /// </summary>
     public bool IgnoreMouse { get; set; }
 
     /// <summary>

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
@@ -11,6 +11,7 @@ using System.Windows.Forms.VisualStyles;
 using Microsoft.Win32;
 using Windows.Win32.System.Variant;
 using Windows.Win32.UI.Accessibility;
+using static System.Windows.Forms.ControlPaint;
 
 namespace System.Windows.Forms.PropertyGridInternal;
 
@@ -190,33 +191,44 @@ internal sealed partial class PropertyGridView :
     ///   the selected row's <see cref="GridEntry"/>.
     ///  </para>
     /// </remarks>
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     internal DropDownButton DropDownButton
     {
         get
         {
-            if (_dropDownButton is null)
+            if (_dropDownButton is not null)
             {
-                OwnerGrid.CheckInCreate();
-
-                _dropDownButton = new()
-                {
-                    UseComboBoxTheme = true
-                };
-
-                Bitmap bitmap = CreateResizedBitmap("Arrow", DownArrowIconWidth, DownArrowIconHeight);
-                _dropDownButton.Image = bitmap;
-                _dropDownButton.BackColor = SystemColors.Control;
-                _dropDownButton.ForeColor = SystemColors.ControlText;
-                _dropDownButton.Click += OnButtonClick;
-                _dropDownButton.GotFocus += OnDropDownButtonGotFocus;
-                _dropDownButton.LostFocus += OnChildLostFocus;
-                _dropDownButton.TabIndex = 2;
-
-                CommonEditorSetup(_dropDownButton);
-                _dropDownButton.Size = ScaleHelper.IsScalingRequirementMet
-                    ? new(SystemInformation.VerticalScrollBarArrowHeightForDpi(DeviceDpiInternal), RowHeight)
-                    : new(SystemInformation.VerticalScrollBarArrowHeight, RowHeight);
+                return _dropDownButton;
             }
+
+            OwnerGrid.CheckInCreate();
+
+            _dropDownButton = new()
+            {
+                UseComboBoxTheme = true,
+                RequestDarkModeRendering = Application.IsDarkModeEnabled,
+                ControlButtonStyle = ModernControlButtonStyle.OpenDropDown | ModernControlButtonStyle.RoundedBorder
+            };
+
+            Bitmap bitmap = CreateResizedBitmap(
+                "Arrow",
+                DownArrowIconWidth,
+                DownArrowIconHeight);
+
+            // For classic mode/backwards compatibility.
+            _dropDownButton.Image = bitmap;
+            _dropDownButton.BackColor = SystemColors.Control;
+            _dropDownButton.ForeColor = SystemColors.ControlText;
+            _dropDownButton.Click += OnButtonClick;
+            _dropDownButton.GotFocus += OnDropDownButtonGotFocus;
+            _dropDownButton.LostFocus += OnChildLostFocus;
+            _dropDownButton.TabIndex = 2;
+
+            CommonEditorSetup(_dropDownButton);
+
+            _dropDownButton.Size = ScaleHelper.IsScalingRequirementMet
+                ? new(SystemInformation.VerticalScrollBarArrowHeightForDpi(DeviceDpiInternal), RowHeight)
+                : new(SystemInformation.VerticalScrollBarArrowHeight, RowHeight);
 
             return _dropDownButton;
         }
@@ -235,32 +247,42 @@ internal sealed partial class PropertyGridView :
     {
         get
         {
-            if (_dialogButton is null)
+            if (_dialogButton is not null)
             {
-                OwnerGrid.CheckInCreate();
-
-                _dialogButton = new DropDownButton
-                {
-                    BackColor = SystemColors.Control,
-                    ForeColor = SystemColors.ControlText,
-                    TabIndex = 3,
-                    Image = CreateResizedBitmap("dotdotdot", DotDotDotIconWidth, DotDotDotIconHeight)
-                };
-
-                _dialogButton.Click += OnButtonClick;
-                _dialogButton.KeyDown += OnButtonKeyDown;
-                _dialogButton.GotFocus += OnDropDownButtonGotFocus;
-                _dialogButton.LostFocus += OnChildLostFocus;
-                _dialogButton.Size = ScaleHelper.IsScalingRequirementMet
-                    ? new Size(SystemInformation.VerticalScrollBarArrowHeightForDpi(DeviceDpiInternal), RowHeight)
-                    : new Size(SystemInformation.VerticalScrollBarArrowHeight, RowHeight);
-
-                CommonEditorSetup(_dialogButton);
+                return _dialogButton;
             }
+
+            OwnerGrid.CheckInCreate();
+
+            _dialogButton = new DropDownButton
+            {
+                RequestDarkModeRendering = Application.IsDarkModeEnabled,
+                ControlButtonStyle = ModernControlButtonStyle.Ellipse | ModernControlButtonStyle.RoundedBorder,
+                BackColor = SystemColors.Control,
+                ForeColor = SystemColors.ControlText,
+                TabIndex = 3,
+
+                // For classic mode/backwards compatibility.
+                Image = CreateResizedBitmap(
+                    "dotdotdot",
+                    DotDotDotIconWidth,
+                    DotDotDotIconHeight)
+            };
+
+            _dialogButton.Click += OnButtonClick;
+            _dialogButton.KeyDown += OnButtonKeyDown;
+            _dialogButton.GotFocus += OnDropDownButtonGotFocus;
+            _dialogButton.LostFocus += OnChildLostFocus;
+            _dialogButton.Size = ScaleHelper.IsScalingRequirementMet
+                ? new Size(SystemInformation.VerticalScrollBarArrowHeightForDpi(DeviceDpiInternal), RowHeight)
+                : new Size(SystemInformation.VerticalScrollBarArrowHeight, RowHeight);
+
+            CommonEditorSetup(_dialogButton);
 
             return _dialogButton;
         }
     }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     /// <summary>
     ///  The common text box for editing values.
@@ -269,30 +291,32 @@ internal sealed partial class PropertyGridView :
     {
         get
         {
-            if (_editTextBox is null)
+            if (_editTextBox is not null)
             {
-                OwnerGrid.CheckInCreate();
-
-                _editTextBox = new(this)
-                {
-                    BorderStyle = BorderStyle.None,
-                    AutoSize = false,
-                    TabStop = false,
-                    AcceptsReturn = true,
-                    BackColor = BackColor,
-                    ForeColor = ForeColor
-                };
-
-                _editTextBox.KeyDown += OnEditKeyDown;
-                _editTextBox.KeyPress += OnEditKeyPress;
-                _editTextBox.GotFocus += OnEditGotFocus;
-                _editTextBox.LostFocus += OnEditLostFocus;
-                _editTextBox.MouseDown += OnEditMouseDown;
-                _editTextBox.TextChanged += OnEditChange;
-
-                _editTextBox.TabIndex = 1;
-                CommonEditorSetup(_editTextBox);
+                return _editTextBox;
             }
+
+            OwnerGrid.CheckInCreate();
+
+            _editTextBox = new(this)
+            {
+                BorderStyle = BorderStyle.None,
+                AutoSize = false,
+                TabStop = false,
+                AcceptsReturn = true,
+                BackColor = BackColor,
+                ForeColor = ForeColor
+            };
+
+            _editTextBox.KeyDown += OnEditKeyDown;
+            _editTextBox.KeyPress += OnEditKeyPress;
+            _editTextBox.GotFocus += OnEditGotFocus;
+            _editTextBox.LostFocus += OnEditLostFocus;
+            _editTextBox.MouseDown += OnEditMouseDown;
+            _editTextBox.TextChanged += OnEditChange;
+
+            _editTextBox.TabIndex = 1;
+            CommonEditorSetup(_editTextBox);
 
             return _editTextBox;
         }
@@ -2210,7 +2234,7 @@ internal sealed partial class PropertyGridView :
             if ((Size.Width > doubleOffset) && (Size.Height > doubleOffset))
             {
                 using Graphics g = CreateGraphicsInternal();
-                ControlPaint.DrawFocusRectangle(g, new Rectangle(_offset2Units, _offset2Units, Size.Width - doubleOffset, Size.Height - doubleOffset));
+                DrawFocusRectangle(g, new Rectangle(_offset2Units, _offset2Units, Size.Width - doubleOffset, Size.Height - doubleOffset));
             }
         }
     }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.UpDownButtons.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.UpDownButtons.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
+using System.Drawing.Imaging;
 using System.Windows.Forms.VisualStyles;
 
 namespace System.Windows.Forms;
@@ -9,9 +10,9 @@ namespace System.Windows.Forms;
 public abstract partial class UpDownBase
 {
     /// <summary>
-    ///  A control representing the pair of buttons on the end of the upDownEdit control. This class handles
-    ///  drawing the updown buttons, and detecting mouse actions on these buttons. Acceleration on the buttons is
-    ///  handled. The control sends UpDownEventArgss to the parent UpDownBase class when a button is pressed, or
+    ///  A control representing the pair of buttons on the end of the up-down edit control. This class handles
+    ///  drawing the up-down buttons, and detecting mouse actions on these buttons. Acceleration on the buttons is
+    ///  handled. The control sends UpDownEventArgs to the parent UpDownBase class when a button is pressed, or
     ///  when the acceleration determines that another event should be generated.
     /// </summary>
     internal partial class UpDownButtons : Control
@@ -28,13 +29,18 @@ public abstract partial class UpDownBase
         private Timer? _timer; // generates UpDown events
         private int _timerInterval; // milliseconds between events
 
+        private Bitmap? _cachedBitmap;
+
         private bool _doubleClickFired;
 
+        /// <summary>
+        ///  Initializes a new instance of the <see cref="UpDownButtons"/> class.
+        /// </summary>
+        /// <param name="parent">The parent <see cref="UpDownBase"/> control.</param>
         internal UpDownButtons(UpDownBase parent) : base()
         {
             SetStyle(ControlStyles.Opaque | ControlStyles.FixedHeight | ControlStyles.FixedWidth, true);
             SetStyle(ControlStyles.Selectable, false);
-
             _parent = parent;
         }
 
@@ -47,9 +53,10 @@ public abstract partial class UpDownBase
             remove => _upDownEventHandler -= value;
         }
 
-        /// <remarks>
-        ///  <para>Called when the mouse button is pressed - we need to start spinning the value of the updown.</para>
-        /// </remarks>
+        /// <summary>
+        ///  Called when the mouse button is pressed - we need to start spinning the value of the up-down control.
+        /// </summary>
+        /// <param name="e">The mouse event arguments.</param>
         private void BeginButtonPress(MouseEventArgs e)
         {
             int half_height = Size.Height / 2;
@@ -73,16 +80,17 @@ public abstract partial class UpDownBase
             // Generate UpDown event
             OnUpDown(new UpDownEventArgs((int)_pushed));
 
-            // Start the timer for new updown events
+            // Start the timer for new up-down events
             StartTimer();
         }
 
+        /// <inheritdoc/>
         protected override AccessibleObject CreateAccessibilityInstance()
             => new UpDownButtonsAccessibleObject(this);
 
-        /// <remarks>
-        ///  <para>Called when the mouse button is released - we need to stop spinning the value of the updown.</para>
-        /// </remarks>
+        /// <summary>
+        ///  Called when the mouse button is released - we need to stop spinning the value of the up-down control.
+        /// </summary>
         private void EndButtonPress()
         {
             _pushed = ButtonID.None;
@@ -100,9 +108,10 @@ public abstract partial class UpDownBase
 
         /// <summary>
         ///  Handles detecting mouse hits on the buttons. This method detects
-        ///  which button was hit (up or down), fires a updown event, captures
-        ///  the mouse, and starts a timer for repeated updown events.
+        ///  which button was hit (up or down), fires an up-down event, captures
+        ///  the mouse, and starts a timer for repeated up-down events.
         /// </summary>
+        /// <param name="e">The mouse event arguments.</param>
         protected override void OnMouseDown(MouseEventArgs e)
         {
             // Begin spinning the value
@@ -128,9 +137,10 @@ public abstract partial class UpDownBase
             _parent.OnMouseDown(_parent.TranslateMouseEvent(this, e));
         }
 
+        /// <inheritdoc/>
         protected override void OnMouseMove(MouseEventArgs e)
         {
-            // If the mouse is captured by the buttons (i.e. an updown button
+            // If the mouse is captured by the buttons (i.e. an up-down button
             // was pushed, and the mouse button has not yet been released),
             // determine the new state of the buttons depending on where
             // the mouse pointer has moved.
@@ -149,7 +159,7 @@ public abstract partial class UpDownBase
                 // Test if the mouse has moved outside the button area
                 if (rect.Contains(e.X, e.Y))
                 {
-                    // Inside button, repush the button if necessary
+                    // Inside button, re-push the button if necessary
                     if (_pushed != _captured)
                     {
                         // Restart the timer
@@ -163,11 +173,11 @@ public abstract partial class UpDownBase
                 {
                     // Outside button
                     //
-                    // Retain the capture, but pop the button up whilst the mouse
+                    // Retain the capture, but pop the button up while the mouse
                     // remains outside the button and the mouse button remains pressed.
                     if (_pushed != ButtonID.None)
                     {
-                        // Stop the timer for updown events
+                        // Stop the timer for up-down events
                         StopTimer();
 
                         _pushed = ButtonID.None;
@@ -204,6 +214,7 @@ public abstract partial class UpDownBase
         /// <summary>
         ///  Handles detecting when the mouse button is released.
         /// </summary>
+        /// <param name="e">The mouse event arguments.</param>
         protected override void OnMouseUp(MouseEventArgs e)
         {
             if (!_parent.ValidationCancelled && e.Button == MouseButtons.Left)
@@ -239,6 +250,7 @@ public abstract partial class UpDownBase
             _parent.OnMouseUp(me);
         }
 
+        /// <inheritdoc/>
         protected override void OnMouseLeave(EventArgs e)
         {
             _mouseOver = ButtonID.None;
@@ -250,12 +262,40 @@ public abstract partial class UpDownBase
         /// <summary>
         ///  Handles painting the buttons on the control.
         /// </summary>
+        /// <param name="e">The paint event arguments.</param>
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         protected override void OnPaint(PaintEventArgs e)
         {
             int half_height = ClientSize.Height / 2;
 
             // Draw the up and down buttons
-            if (Application.RenderWithVisualStyles)
+            if (Application.IsDarkModeEnabled || !Application.RenderWithVisualStyles)
+            {
+                Graphics cachedGraphics = EnsureCachedBitmap(
+                    _parent._defaultButtonsWidth,
+                    ClientSize.Height);
+
+                ControlPaint.DrawScrollButton(
+                    cachedGraphics,
+                    new Rectangle(0, 0, _parent._defaultButtonsWidth, half_height),
+                    ScrollButton.Up,
+                    _pushed == ButtonID.Up
+                        ? ButtonState.Pushed
+                        : (Enabled ? ButtonState.Normal : ButtonState.Inactive));
+
+                ControlPaint.DrawScrollButton(
+                    cachedGraphics,
+                    new Rectangle(0, half_height, _parent._defaultButtonsWidth, half_height),
+                    ScrollButton.Down,
+                    _pushed == ButtonID.Down
+                        ? ButtonState.Pushed
+                        : (Enabled ? ButtonState.Normal : ButtonState.Inactive));
+
+                e.GraphicsInternal.DrawImageUnscaled(
+                    _cachedBitmap,
+                    new Point(0, 0));
+            }
+            else
             {
                 VisualStyleRenderer vsr = new(_mouseOver == ButtonID.Up
                     ? VisualStyleElement.Spin.Up.Hot
@@ -296,20 +336,7 @@ public abstract partial class UpDownBase
                     new Rectangle(0, half_height, _parent._defaultButtonsWidth, half_height),
                     HWNDInternal);
             }
-            else
-            {
-                ControlPaint.DrawScrollButton(
-                    e.GraphicsInternal,
-                    new Rectangle(0, 0, _parent._defaultButtonsWidth, half_height),
-                    ScrollButton.Up,
-                    _pushed == ButtonID.Up ? ButtonState.Pushed : (Enabled ? ButtonState.Normal : ButtonState.Inactive));
-
-                ControlPaint.DrawScrollButton(
-                    e.GraphicsInternal,
-                    new Rectangle(0, half_height, _parent._defaultButtonsWidth, half_height),
-                    ScrollButton.Down,
-                    _pushed == ButtonID.Down ? ButtonState.Pushed : (Enabled ? ButtonState.Normal : ButtonState.Inactive));
-            }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
             if (half_height != (ClientSize.Height + 1) / 2)
             {
@@ -330,11 +357,44 @@ public abstract partial class UpDownBase
         }
 
         /// <summary>
+        ///  Ensures that the Bitmap has the correct size and returns the Graphics object from that Bitmap.
+        /// </summary>
+        /// <param name="width"></param>
+        /// <param name="height"></param>
+        /// <returns></returns>
+        [MemberNotNull(nameof(_cachedBitmap))]
+        private Graphics EnsureCachedBitmap(int width, int height)
+        {
+            if (_cachedBitmap is null || _cachedBitmap.Size != new Size(width, height))
+            {
+                _cachedBitmap?.Dispose();
+                _cachedBitmap = new Bitmap(width, height, PixelFormat.Format32bppArgb);
+            }
+
+            return Graphics.FromImage(_cachedBitmap);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (disposing)
+            {
+                _cachedBitmap?.Dispose();
+                _cachedBitmap = null;
+                _timer?.Dispose();
+                _timer = null;
+                _upDownEventHandler = null;
+            }
+        }
+
+        /// <summary>
         ///  Occurs when the UpDown buttons are pressed and when the acceleration timer tick event is raised.
         /// </summary>
+        /// <param name="upevent">The up-down event arguments.</param>
         protected virtual void OnUpDown(UpDownEventArgs upevent)
             => _upDownEventHandler?.Invoke(this, upevent);
 
+        /// <inheritdoc/>
         internal override void ReleaseUiaProvider(HWND handle)
         {
             if (IsAccessibilityObjectCreated
@@ -348,7 +408,7 @@ public abstract partial class UpDownBase
         }
 
         /// <summary>
-        ///  Starts the timer for generating updown events
+        ///  Starts the timer for generating up-down events.
         /// </summary>
         protected void StartTimer()
         {
@@ -369,7 +429,7 @@ public abstract partial class UpDownBase
         }
 
         /// <summary>
-        ///  Stops the timer for generating updown events
+        ///  Stops the timer for generating up-down events.
         /// </summary>
         protected void StopTimer()
         {
@@ -383,11 +443,14 @@ public abstract partial class UpDownBase
             _parent.OnStopTimer();
         }
 
+        /// <inheritdoc/>
         internal override bool SupportsUiaProviders => true;
 
         /// <summary>
-        ///  Generates updown events when the timer calls this function.
+        ///  Generates up-down events when the timer calls this function.
         /// </summary>
+        /// <param name="source">The source of the event.</param>
+        /// <param name="args">The event arguments.</param>
         private void TimerHandler(object? source, EventArgs args)
         {
             // Make sure we've got mouse capture
@@ -397,7 +460,7 @@ public abstract partial class UpDownBase
                 return;
             }
 
-            // onUpDown method calls customer's ValueCHanged event handler which might enter the message loop and
+            // OnUpDown method calls customer's ValueChanged event handler which might enter the message loop and
             // process the mouse button up event, which results in timer being disposed
             OnUpDown(new UpDownEventArgs((int)_pushed));
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.cs
@@ -215,6 +215,10 @@ public abstract partial class UpDownBase : ContainerControl
     {
         get
         {
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+            SetStyle(ControlStyles.ApplyThemingImplicitly, true);
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
             CreateParams cp = base.CreateParams;
 
             cp.Style &= ~(int)WINDOW_STYLE.WS_BORDER;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.cs
@@ -211,13 +211,12 @@ public abstract partial class UpDownBase : ContainerControl
     protected override AccessibleObject CreateAccessibilityInstance()
         => new UpDownBaseAccessibleObject(this);
 
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     protected override CreateParams CreateParams
     {
         get
         {
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
             CreateParams cp = base.CreateParams;
 
@@ -238,6 +237,7 @@ public abstract partial class UpDownBase : ContainerControl
             return cp;
         }
     }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     /// <summary>
     ///  Deriving classes can override this to configure a default size for their control.

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint.ModernControlButton.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint.ModernControlButton.cs
@@ -6,7 +6,7 @@ namespace System.Windows.Forms;
 public static unsafe partial class ControlPaint
 {
     [Flags]
-    internal enum ModernControlButton
+    internal enum ModernControlButtonStyle
     {
         Empty = 0x0,
         Up = 0x1,
@@ -14,9 +14,10 @@ public static unsafe partial class ControlPaint
         UpDown = 0x3,
         Right = 0x4,
         Left = 0x8,
-        LeftRight = 0xC,
+        RightLeft = 0xC,
         Ellipse = 0x10,
+        OpenDropDown = 0x20,
         SingleBorder = 0x10000,
-        RoundedBorder = 0x20000
+        RoundedBorder = 0x20000,
     }
 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint.ModernControlButton.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint.ModernControlButton.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms;
+
+public static unsafe partial class ControlPaint
+{
+    [Flags]
+    internal enum ModernControlButton
+    {
+        Empty = 0x0,
+        Up = 0x1,
+        Down = 0x2,
+        UpDown = 0x3,
+        Right = 0x4,
+        Left = 0x8,
+        LeftRight = 0xC,
+        Ellipse = 0x10,
+        SingleBorder = 0x10000,
+        RoundedBorder = 0x20000
+    }
+}

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint.ModernControlButtonState.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint.ModernControlButtonState.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms;
+
+public static unsafe partial class ControlPaint
+{
+    internal enum ModernControlButtonState
+    {
+        Normal,
+        Disabled,
+        Pressed,
+        Hover
+    }
+}

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint.cs
@@ -71,10 +71,12 @@ public static unsafe partial class ControlPaint
     private static readonly Color s_darkModeBackgroundPressed = Color.FromArgb(255, 70, 70, 70);
     private static readonly Color s_darkModeBackgroundDisabled = Color.FromArgb(255, 45, 45, 45);
     private static readonly Color s_darkModeBackgroundNormal = Color.FromArgb(255, 60, 60, 60);
+    private static readonly Color s_darkModeBackgroundHover = Color.FromArgb(255, 80, 80, 80);
 
     private static readonly Color s_darkModeBorderPressed = Color.FromArgb(255, 80, 80, 80);
     private static readonly Color s_darkModeBorderDisabled = Color.FromArgb(255, 50, 50, 50);
     private static readonly Color s_darkModeBorderNormal = Color.FromArgb(255, 90, 90, 90);
+    private static readonly Color s_darkModeBorderHover = Color.FromArgb(255, 110, 110, 110);
 
     private static readonly Color s_darkModeArrowDisabled = Color.FromArgb(255, 100, 100, 100);
     private static readonly Color s_darkModeArrowNormal = Color.FromArgb(255, 220, 220, 220);
@@ -83,10 +85,12 @@ public static unsafe partial class ControlPaint
     private static readonly Color s_lightModeBackgroundPressed = Color.FromArgb(255, 218, 218, 218);
     private static readonly Color s_lightModeBackgroundDisabled = Color.FromArgb(255, 244, 244, 244);
     private static readonly Color s_lightModeBackgroundNormal = Color.FromArgb(255, 241, 241, 241);
+    private static readonly Color s_lightModeBackgroundHover = Color.FromArgb(255, 220, 220, 220);
 
     private static readonly Color s_lightModeBorderPressed = Color.FromArgb(255, 166, 166, 166);
     private static readonly Color s_lightModeBorderDisabled = Color.FromArgb(255, 205, 205, 205);
     private static readonly Color s_lightModeBorderNormal = Color.FromArgb(255, 195, 195, 195);
+    private static readonly Color s_lightModeBorderHover = Color.FromArgb(255, 170, 170, 170);
 
     private static readonly Color s_lightModeArrowDisabled = Color.FromArgb(255, 170, 170, 170);
     private static readonly Color s_lightModeArrowNormal = Color.FromArgb(255, 68, 68, 68);
@@ -1878,16 +1882,21 @@ public static unsafe partial class ControlPaint
         // If dark mode is enabled, use the new modern rendering
         if (Application.IsDarkModeEnabled)
         {
-            Rectangle bounds = new(x, y, width, height);
-            bool isPressed = (state & ButtonState.Pushed) == ButtonState.Pushed;
-            bool isDisabled = (state & ButtonState.Inactive) == ButtonState.Inactive;
-
-            ModernControlButton modernControlButton = button switch
+            ModernControlButtonState controlButtonState = state switch
             {
-                ScrollButton.Up => ModernControlButton.Up,
-                ScrollButton.Down => ModernControlButton.Down,
-                ScrollButton.Left => ModernControlButton.Left,
-                ScrollButton.Right => ModernControlButton.Right,
+                ButtonState.Pushed => ModernControlButtonState.Pressed,
+                ButtonState.Inactive => ModernControlButtonState.Disabled,
+                _ => ModernControlButtonState.Normal
+            };
+
+            Rectangle bounds = new(x, y, width, height);
+
+            ModernControlButtonStyle modernControlButton = button switch
+            {
+                ScrollButton.Up => ModernControlButtonStyle.Up,
+                ScrollButton.Down => ModernControlButtonStyle.Down,
+                ScrollButton.Left => ModernControlButtonStyle.Left,
+                ScrollButton.Right => ModernControlButtonStyle.Right,
                 _ => throw new ArgumentOutOfRangeException(nameof(button), button, null)
             };
 
@@ -1895,8 +1904,7 @@ public static unsafe partial class ControlPaint
                 graphics,
                 bounds,
                 modernControlButton,
-                isPressed,
-                isDisabled,
+                controlButtonState,
                 isDarkMode: true);
         }
         else

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint.cs
@@ -67,6 +67,30 @@ public static unsafe partial class ControlPaint
     // Otherwise, we will recolor intermediate shades and the icon will look inconsistent (too bold).
     private const int MaximumLuminosityDifference = 20;
 
+    // Dark mode color constants
+    private static readonly Color s_darkModeBackgroundPressed = Color.FromArgb(255, 70, 70, 70);
+    private static readonly Color s_darkModeBackgroundDisabled = Color.FromArgb(255, 45, 45, 45);
+    private static readonly Color s_darkModeBackgroundNormal = Color.FromArgb(255, 60, 60, 60);
+
+    private static readonly Color s_darkModeBorderPressed = Color.FromArgb(255, 80, 80, 80);
+    private static readonly Color s_darkModeBorderDisabled = Color.FromArgb(255, 50, 50, 50);
+    private static readonly Color s_darkModeBorderNormal = Color.FromArgb(255, 90, 90, 90);
+
+    private static readonly Color s_darkModeArrowDisabled = Color.FromArgb(255, 100, 100, 100);
+    private static readonly Color s_darkModeArrowNormal = Color.FromArgb(255, 220, 220, 220);
+
+    // Light mode color constants
+    private static readonly Color s_lightModeBackgroundPressed = Color.FromArgb(255, 218, 218, 218);
+    private static readonly Color s_lightModeBackgroundDisabled = Color.FromArgb(255, 244, 244, 244);
+    private static readonly Color s_lightModeBackgroundNormal = Color.FromArgb(255, 241, 241, 241);
+
+    private static readonly Color s_lightModeBorderPressed = Color.FromArgb(255, 166, 166, 166);
+    private static readonly Color s_lightModeBorderDisabled = Color.FromArgb(255, 205, 205, 205);
+    private static readonly Color s_lightModeBorderNormal = Color.FromArgb(255, 195, 195, 195);
+
+    private static readonly Color s_lightModeArrowDisabled = Color.FromArgb(255, 170, 170, 170);
+    private static readonly Color s_lightModeArrowNormal = Color.FromArgb(255, 68, 68, 68);
+
     internal static Rectangle CalculateBackgroundImageRectangle(Rectangle bounds, Size imageSize, ImageLayout imageLayout)
     {
         Rectangle result = bounds;
@@ -1841,6 +1865,7 @@ public static unsafe partial class ControlPaint
     public static void DrawScrollButton(Graphics graphics, Rectangle rectangle, ScrollButton button, ButtonState state)
         => DrawScrollButton(graphics, rectangle.X, rectangle.Y, rectangle.Width, rectangle.Height, button, state);
 
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     /// <summary>
     ///  Draws a button for a Win32 scroll bar in the given rectangle with the given state.
     /// </summary>
@@ -1848,13 +1873,44 @@ public static unsafe partial class ControlPaint
         Graphics graphics,
         int x, int y, int width, int height,
         ScrollButton button,
-        ButtonState state) => DrawFrameControl(
-            graphics,
-            x, y, width, height,
-            DFC_TYPE.DFC_SCROLL,
-            (DFCS_STATE)button | (DFCS_STATE)state,
-            Color.Empty,
-            Color.Empty);
+        ButtonState state)
+    {
+        // If dark mode is enabled, use the new modern rendering
+        if (Application.IsDarkModeEnabled)
+        {
+            Rectangle bounds = new(x, y, width, height);
+            bool isPressed = (state & ButtonState.Pushed) == ButtonState.Pushed;
+            bool isDisabled = (state & ButtonState.Inactive) == ButtonState.Inactive;
+
+            ModernControlButton modernControlButton = button switch
+            {
+                ScrollButton.Up => ModernControlButton.Up,
+                ScrollButton.Down => ModernControlButton.Down,
+                ScrollButton.Left => ModernControlButton.Left,
+                ScrollButton.Right => ModernControlButton.Right,
+                _ => throw new ArgumentOutOfRangeException(nameof(button), button, null)
+            };
+
+            DrawModernControlButton(
+                graphics,
+                bounds,
+                modernControlButton,
+                isPressed,
+                isDisabled,
+                isDarkMode: true);
+        }
+        else
+        {
+            // Fall back to classic Windows rendering
+            DrawFrameControl(
+                graphics,
+                x, y, width, height,
+                DFC_TYPE.DFC_SCROLL,
+                (DFCS_STATE)button | (DFCS_STATE)state,
+                Color.Empty,
+                Color.Empty);
+        }
+    }
 
     /// <summary>
     ///  Draws a standard selection frame. A selection frame is a frame that is

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint_ModernControlButtonRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint_ModernControlButtonRenderer.cs
@@ -1,0 +1,292 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Drawing;
+using System.Drawing.Drawing2D;
+
+namespace System.Windows.Forms;
+
+public static unsafe partial class ControlPaint
+{
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    /// <summary>
+    ///  Draws a modern up/down button suitable for both light and dark modes.
+    /// </summary>
+    internal static void DrawModernControlButton(
+        Graphics graphics,
+        Rectangle bounds,
+        ModernControlButton button,
+        bool isPressed,
+        bool isDisabled,
+        bool isDarkMode)
+    {
+        ArgumentNullException.ThrowIfNull(graphics);
+
+        // Define colors for different states
+        Color backgroundColor;
+        Color borderColor;
+        Color arrowColor;
+
+        if (isDarkMode)
+        {
+            // Dark mode colors
+            backgroundColor =
+                isPressed
+                    ? s_darkModeBackgroundPressed
+                    : isDisabled
+                        ? s_darkModeBackgroundDisabled
+                        : s_darkModeBackgroundNormal;
+
+            borderColor =
+                isPressed
+                    ? s_darkModeBorderPressed
+                    : isDisabled
+                        ? s_darkModeBorderDisabled
+                        : s_darkModeBorderNormal;
+
+            arrowColor = isDisabled
+                ? s_darkModeArrowDisabled
+                : s_darkModeArrowNormal;
+        }
+        else
+        {
+            // Light mode colors
+            backgroundColor =
+                isPressed
+                    ? s_lightModeBackgroundPressed
+                    : isDisabled
+                        ? s_lightModeBackgroundDisabled
+                        : s_lightModeBackgroundNormal;
+
+            borderColor =
+                isPressed
+                    ? s_lightModeBorderPressed
+                    : isDisabled
+                        ? s_lightModeBorderDisabled
+                        : s_lightModeBorderNormal;
+
+            arrowColor = isDisabled
+                ? s_lightModeArrowDisabled
+                : s_lightModeArrowNormal;
+        }
+
+        // Enable anti-aliasing for smooth rendering
+        SmoothingMode oldMode = graphics.SmoothingMode;
+        graphics.SmoothingMode = SmoothingMode.AntiAlias;
+
+        try
+        {
+            // Extract border flags
+            bool hasBorder = (button & ModernControlButton.SingleBorder) != 0 || (button & ModernControlButton.RoundedBorder) != 0;
+            bool hasRoundedBorder = (button & ModernControlButton.RoundedBorder) != 0;
+
+            // Draw background
+            using (var backgroundBrush = backgroundColor.GetCachedSolidBrushScope())
+            {
+                if (hasRoundedBorder)
+                {
+                    Size radius = new(4, 4);
+                    graphics.FillRoundedRectangle(backgroundBrush, bounds, radius);
+                }
+                else
+                {
+                    graphics.FillRectangle(backgroundBrush, bounds);
+                }
+            }
+
+            // Draw border if needed
+            if (hasBorder)
+            {
+                using var borderPen = borderColor.GetCachedPenScope();
+
+                if (hasRoundedBorder)
+                {
+                    Size radius = new(4, 4);
+                    graphics.DrawRoundedRectangle(borderPen, bounds, radius);
+                }
+                else
+                {
+                    graphics.DrawRectangle(borderPen, bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);
+                }
+            }
+
+            // Draw the content
+            ModernControlButton contentType = button & ~(ModernControlButton.SingleBorder | ModernControlButton.RoundedBorder);
+            DrawButtonContent(graphics, bounds, contentType, arrowColor, isPressed);
+        }
+        finally
+        {
+            graphics.SmoothingMode = oldMode;
+        }
+    }
+
+    /// <summary>
+    ///  Draws the button content based on the button type.
+    /// </summary>
+    private static void DrawButtonContent(
+        Graphics graphics,
+        Rectangle bounds,
+        ModernControlButton buttonType,
+        Color contentColor,
+        bool isPressed)
+    {
+        // Calculate center point
+        int centerX = bounds.X + bounds.Width / 2;
+        int centerY = bounds.Y + bounds.Height / 2;
+
+        // Apply pressed offset
+        if (isPressed)
+        {
+            centerX += 1;
+            centerY += 1;
+        }
+
+        using var contentBrush = contentColor.GetCachedSolidBrushScope();
+
+        switch (buttonType)
+        {
+            case ModernControlButton.Empty:
+                // Nothing to draw
+                break;
+
+            case ModernControlButton.Up:
+                DrawUpArrow(graphics, contentBrush, centerX, centerY, CalculateArrowSize(bounds));
+                break;
+
+            case ModernControlButton.Down:
+                DrawDownArrow(graphics, contentBrush, centerX, centerY, CalculateArrowSize(bounds));
+                break;
+
+            case ModernControlButton.UpDown:
+                DrawUpDownArrows(graphics, contentBrush, centerX, centerY, bounds);
+                break;
+
+            case ModernControlButton.Left:
+                DrawLeftArrow(graphics, contentBrush, centerX, centerY, CalculateArrowSize(bounds));
+                break;
+
+            case ModernControlButton.Right:
+                DrawRightArrow(graphics, contentBrush, centerX, centerY, CalculateArrowSize(bounds));
+                break;
+
+            case ModernControlButton.LeftRight:
+                DrawLeftRightArrows(graphics, contentBrush, centerX, centerY, bounds);
+                break;
+
+            case ModernControlButton.Ellipse:
+                DrawEllipse(graphics, contentBrush, centerX, centerY, bounds);
+                break;
+        }
+    }
+
+    /// <summary>
+    ///  Calculates the arrow size based on button bounds.
+    /// </summary>
+    private static int CalculateArrowSize(Rectangle bounds)
+    {
+        int arrowSize = Math.Min(bounds.Width, bounds.Height) / 2;
+
+        return Math.Max(3, Math.Min(arrowSize, 7)); // Clamp between 3 and 7 pixels
+    }
+
+    /// <summary>
+    ///  Draws combined up/down arrows with kerning.
+    /// </summary>
+    private static void DrawUpDownArrows(Graphics graphics, Brush brush, int centerX, int centerY, Rectangle bounds)
+    {
+        int arrowSize = CalculateArrowSize(bounds) - 1; // Slightly smaller for combined
+        int spacing = 2; // Minimal spacing between arrows
+
+        // Draw up arrow (top half)
+        int upCenterY = centerY - spacing;
+        DrawUpArrow(graphics, brush, upCenterY - arrowSize / 2, centerX, arrowSize);
+
+        // Draw down arrow (bottom half)
+        int downCenterY = centerY + spacing;
+        DrawDownArrow(graphics, brush, downCenterY + arrowSize / 2, centerX, arrowSize);
+    }
+
+    /// <summary>
+    ///  Draws combined left/right arrows with kerning.
+    /// </summary>
+    private static void DrawLeftRightArrows(Graphics graphics, Brush brush, int centerX, int centerY, Rectangle bounds)
+    {
+        int arrowSize = CalculateArrowSize(bounds) - 1; // Slightly smaller for combined
+        int spacing = 2; // Minimal spacing between arrows
+
+        // Draw left arrow
+        int leftCenterX = centerX - spacing;
+        DrawLeftArrow(graphics, brush, leftCenterX - arrowSize / 2, centerY, arrowSize);
+
+        // Draw right arrow
+        int rightCenterX = centerX + spacing;
+        DrawRightArrow(graphics, brush, rightCenterX + arrowSize / 2, centerY, arrowSize);
+    }
+
+    /// <summary>
+    ///  Draws an ellipse symbol (...).
+    /// </summary>
+    private static void DrawEllipse(Graphics graphics, Brush brush, int centerX, int centerY, Rectangle bounds)
+    {
+        int dotSize = Math.Max(2, Math.Min(bounds.Height / 8, 3));
+        int spacing = dotSize + 1;
+        int totalWidth = (dotSize * 3) + (spacing * 2);
+
+        // Center the dots
+        int startX = centerX - totalWidth / 2 + dotSize / 2;
+
+        for (int i = 0; i < 3; i++)
+        {
+            int x = startX + (i * (dotSize + spacing));
+            graphics.FillEllipse(brush, x - dotSize / 2, centerY - dotSize / 2, dotSize, dotSize);
+        }
+    }
+
+    private static void DrawUpArrow(Graphics graphics, Brush brush, int centerX, int centerY, int size)
+    {
+        Point[] points =
+        [
+            new Point(centerX, centerY - size / 2),      // Top point
+            new Point(centerX - size / 2, centerY + size / 2), // Bottom left
+            new Point(centerX + size / 2, centerY + size / 2), // Bottom right
+        ];
+
+        graphics.FillPolygon(brush, points);
+    }
+
+    private static void DrawDownArrow(Graphics graphics, Brush brush, int centerX, int centerY, int size)
+    {
+        Point[] points =
+        [
+            new Point(centerX, centerY + size / 2),      // Bottom point
+            new Point(centerX - size / 2, centerY - size / 2), // Top left
+            new Point(centerX + size / 2, centerY - size / 2), // Top right
+        ];
+
+        graphics.FillPolygon(brush, points);
+    }
+
+    private static void DrawLeftArrow(Graphics graphics, Brush brush, int centerX, int centerY, int size)
+    {
+        Point[] points =
+        [
+            new Point(centerX - size / 2, centerY),      // Left point
+            new Point(centerX + size / 2, centerY - size / 2), // Top right
+            new Point(centerX + size / 2, centerY + size / 2), // Bottom right
+        ];
+
+        graphics.FillPolygon(brush, points);
+    }
+
+    private static void DrawRightArrow(Graphics graphics, Brush brush, int centerX, int centerY, int size)
+    {
+        Point[] points =
+        [
+            new Point(centerX + size / 2, centerY),      // Right point
+            new Point(centerX - size / 2, centerY - size / 2), // Top left
+            new Point(centerX - size / 2, centerY + size / 2), // Bottom left
+        ];
+
+        graphics.FillPolygon(brush, points);
+    }
+}


### PR DESCRIPTION
Fixes System Control Button rendering issues in dark mode, where a control button is either rendering not in dark mode, or has rendering artefacts when rendering in the context of the property grid.

These issues have been pointed out by customers, and are, among others, one of the blockers for GitHub Extensions, which are emotionally discussed on their GitHub issues

https://github.com/gitextensions/gitextensions/issues/9191#issuecomment-2293935942

(and also might even save lives https://github.com/gitextensions/gitextensions/issues/11904)

Note while the latter is certainly an ironic-funny remark, those discussions around dark mode for WinForms app shows the high participation of the community and the desire to make this work, and note also that other issues which have been pointed out in other projects show us clearly, why we should accomodate rendering issues as early as possible to unblock them: GitExtension in particular but also other projects can provide their aspired .NET 10 based DarkMode-enabled versions as soon as .NET 10 becomes available.

Fixes rendering issues in dark mode rendering, where a button is used in the context of another control:

* DropDownArrow
* UpDown based controls
* Ellipse-Control in Property browsers

These buttons have not been rendered correctly in dark mode, and a new system control button renderer (tested by CTI) fixes these issues.

Note that this PR does not change the Classic (Light Mode) code paths in any way.

Examples:

<img width="230" height="60" alt="image" src="https://github.com/user-attachments/assets/9bd4750b-076d-45cd-9160-997b50ff98ad" />

---

<img width="565" height="72" alt="image" src="https://github.com/user-attachments/assets/26c4eba5-11cd-44ad-8964-bb3d586fee41" />

---

<img width="763" height="151" alt="image" src="https://github.com/user-attachments/assets/ce4f409f-051b-422a-aa1f-26c5a8470e0f" />

---

Current versions have been tested by CTI and they also reassured  that the Classic mode CodePaths (LightMode rendering) remain unchanged to minimize any risks.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13748)