### PR TITLE
Skip unstable test ListView_Click_On_Second_Column_Does_Not_Alter_CheckBoxesAsync

### DIFF
--- a/src/test/integration/UIIntegrationTests/ListViewTests.cs
+++ b/src/test/integration/UIIntegrationTests/ListViewTests.cs
@@ -532,7 +532,10 @@ public class ListViewTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/13291")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X86 | TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/13291")]
     public async Task ListView_Click_On_Second_Column_Does_Not_Alter_CheckBoxesAsync()
     {
         await RunTestAsync(async (form, listView) =>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13291 


## Proposed changes

- Disable unstable case `ListView_Click_On_Second_Column_Does_Not_Alter_CheckBoxesAsync`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13768)