### PR TITLE
Add DesignerAPI Analyzer

### DIFF
--- a/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/CSharp/Analyzers/DesignerAPI/DesignerAPIAnalyzer.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/CSharp/Analyzers/DesignerAPI/DesignerAPIAnalyzer.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace System.Windows.Forms.CSharp.Analyzers.DesignerAPI;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class DesignerAPIAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "PARENTDESIGNER001";
+    private const string Title = "Use updated Winform Designer API";
+    private const string MessageFormat =
+        "Type '{0}' is not recommended; use '{1}' instead. Before using new API male sure 'Microsoft.WinForms.Designer.SDK' nuget package is installed.";
+    private const string Category = "Usage";
+    private static readonly Dictionary<string, string> s_classReplacements = new Dictionary<string, string>();
+
+    static DesignerAPIAnalyzer()
+    {
+        s_classReplacements.Add("System.Windows.Forms.Design.ParentControlDesigner", "Microsoft.DotNet.DesignTools.Designers.ParentControlDesigner");
+        s_classReplacements.Add("System.Windows.Forms.Design.ControlDesigner", "Microsoft.DotNet.DesignTools.Designers.ControlDesigner");
+
+    }
+
+    private static readonly DiagnosticDescriptor s_rule =
+        new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        => [s_rule];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        // Register for identifier references (typeof, casts, attributes, nameof)
+        context.RegisterSyntaxNodeAction(
+            AnalyzeIdentifierName,
+            SyntaxKind.IdentifierName);
+    }
+
+    private static void AnalyzeIdentifierName(SyntaxNodeAnalysisContext context)
+    {
+        var idNode = (IdentifierNameSyntax)context.Node;
+
+        if (context.SemanticModel.GetSymbolInfo(idNode).Symbol is not INamedTypeSymbol symbol)
+        {
+            return;
+        }
+
+        foreach (var pair in s_classReplacements)
+        {
+            if (symbol.ToDisplayString() == pair.Key)
+            {
+                var diagnostic = Diagnostic.Create(
+                    s_rule,
+                    idNode.GetLocation(),
+                    symbol.Name, pair.Value);
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+    }
+}


### PR DESCRIPTION

Related #13763

## Background

Some developers may still use .net framework winform api to do designer work. But we have changed it into a new model. They may not aware of if. So they usually couldn't get what they want because they don't use new API.

So I think it might be a good idea to add an Analyzer to give it a prompt to recommend the user to use new API.

<img width="952" height="236" alt="image" src="https://github.com/user-attachments/assets/a8df497e-aa61-4f19-be70-1753ac504ad3" />

## Note

This is not a refined PR.  So please see if it is a good idea. If so, you can give me some advice and I will continue to work on it. If not,I will consider to close it. 🫤
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13770)