### PR TITLE
Add check "IsDarkModeEnabled" for FocusForeColor of the CheckedListBox and PropertyGrid

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListBoxes/CheckedListBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListBoxes/CheckedListBox.cs
@@ -596,7 +596,9 @@ public partial class CheckedListBox : ListBox
                 if (Enabled)
                 {
                     backColor = SystemColors.Highlight;
-                    foreColor = SystemColors.HighlightText;
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+                    foreColor = Application.IsDarkModeEnabled ? SystemColors.ControlText : SystemColors.HighlightText;
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
                 }
                 else
                 {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
@@ -74,7 +74,9 @@ public partial class PropertyGrid : ContainerControl, IComPropertyBrowser, IProp
     private Color _categoryForegroundColor = SystemColors.ControlText;
     private Color _categorySplitterColor = SystemColors.Control;
     private Color _viewBorderColor = SystemColors.ControlDark;
-    private Color _selectedItemWithFocusForeColor = SystemColors.HighlightText;
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    private Color _selectedItemWithFocusForeColor = Application.IsDarkModeEnabled ? SystemColors.ControlText : SystemColors.HighlightText;
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     private Color _selectedItemWithFocusBackColor = SystemColors.Highlight;
     private bool _canShowVisualStyleGlyphs = true;
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13767


## Proposed changes

- Add judgement `IsDarkModeEnabled` for ` FocusForeColor` of the **CheckedListBox** and **PropertyGrid**

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

-  The selected item of the control **CheckedListBox** and **PropertyGrid** can be show clearly under DarkMode

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

When the application is in Dark Mode, the contrast of focusing items in CheckedListBox/PropertyGrid is insufficient.

<img width="1752" height="1214" alt="Image" src="https://github.com/user-attachments/assets/e840cba0-58d4-4738-9d40-dd9405f516fd" />

### After

The contrast of focusing items in CheckedListBox/PropertyGrid is sufficient

<img width="1739" height="1288" alt="image" src="https://github.com/user-attachments/assets/92450a56-c4d6-4998-b803-360a6d28dd2e" />



## Test methodology <!-- How did you ensure quality? -->

- Manually

 

## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-preview.7.25373.104


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13771)