### PR TITLE
Add focused state for DropDownButton and reduces the icon width of the dropdown model button

### DIFF
--- a/src/System.Windows.Forms/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+System.Windows.Forms.VisualStyles.ComboBoxState.Focused = 5 -> System.Windows.Forms.VisualStyles.ComboBoxState

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/DropDownButton.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/DropDownButton.cs
@@ -83,13 +83,21 @@ internal sealed partial class DropDownButton : Button
     {
         ComboBoxState state = ComboBoxState.Normal;
 
-        if (MouseIsDown)
+        if (!Enabled)
+        {
+            state = ComboBoxState.Disabled;
+        }
+        else if (MouseIsDown)
         {
             state = ComboBoxState.Pressed;
         }
         else if (MouseIsOver)
         {
             state = ComboBoxState.Hot;
+        }
+        else if (Focused)
+        {
+            state = ComboBoxState.Focused;
         }
 
         base.OnPaint(pevent);
@@ -101,6 +109,7 @@ internal sealed partial class DropDownButton : Button
                 ComboBoxState.Disabled => ModernControlButtonState.Disabled,
                 ComboBoxState.Hot => ModernControlButtonState.Hover,
                 ComboBoxState.Pressed => ModernControlButtonState.Pressed,
+                ComboBoxState.Focused => ModernControlButtonState.Focused,
                 _ => ModernControlButtonState.Normal
             };
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint.ModernControlButtonState.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint.ModernControlButtonState.cs
@@ -10,6 +10,7 @@ public static unsafe partial class ControlPaint
         Normal,
         Disabled,
         Pressed,
-        Hover
+        Hover,
+        Focused
     }
 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint_ModernControlButtonRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint_ModernControlButtonRenderer.cs
@@ -91,6 +91,8 @@ public static unsafe partial class ControlPaint
 
             bool hasRoundedBorder = (button & ModernControlButtonStyle.RoundedBorder) != 0;
 
+            bool isFocused = state == ModernControlButtonState.Focused;
+
             // Draw background
             using (var backgroundBrush = backgroundColor.GetCachedSolidBrushScope())
             {
@@ -119,6 +121,14 @@ public static unsafe partial class ControlPaint
                 {
                     graphics.DrawRectangle(borderPen, bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);
                 }
+            }
+
+            if (isFocused)
+            {
+                // Draw focus rectangle
+                Rectangle focusRect = bounds;
+                focusRect.Inflate(-1, -1); // Deflate to avoid drawing over the border
+                DrawFocusRectangle(graphics, focusRect, Color.Empty, backgroundColor);
             }
 
             // Draw the content
@@ -280,7 +290,7 @@ public static unsafe partial class ControlPaint
     {
         // Calculate dot size as a proportion of button height
         int minDimension = Math.Min(bounds.Width, bounds.Height);
-        int dotSize = Math.Max(1, (int)(minDimension * 0.15 * ContentScaleFactor));
+        int dotSize = Math.Max(1, (int)(minDimension * 0.1 * ContentScaleFactor));
 
         // Calculate proportional spacing
         int spacing = Math.Max(1, dotSize / 2);
@@ -310,7 +320,7 @@ public static unsafe partial class ControlPaint
     private static void DrawOpenDropDownChevron(Graphics graphics, Brush brush, int centerX, int centerY, int size)
     {
         // Calculate chevron dimensions proportionally
-        int chevronWidth = size + (size / 2);
+        int chevronWidth = size;
         int chevronHeight = (size * 2) / 3;
 
         // Stroke thickness scales with size

--- a/src/System.Windows.Forms/System/Windows/Forms/VisualStyles/ComboBoxState.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/VisualStyles/ComboBoxState.cs
@@ -8,5 +8,6 @@ public enum ComboBoxState
     Normal = 1,
     Hot = 2,
     Pressed = 3,
-    Disabled = 4
+    Disabled = 4,
+    Focused = 5,
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13766, #13765


## Proposed changes

- Added a Focused state to the property page's drop-down button.
- Reduces the icon width of the model button.


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The drop-down button of the Property page can be focused under DarkMode

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Dropdown arrow and ellipse symbol in PropertyGrid appears larger in DarkMode and the focus indicator (e.g., dotted line or outline) is not visible when navigating to the DropDownButton or Ellipse Button controls by keyboard 

Dark mode on 100% DPI:
<img width="468" height="42" alt="image" src="https://github.com/user-attachments/assets/7f556f54-f4d7-43bd-a37f-bb6722cc7c90" />

<img width="462" height="66" alt="image" src="https://github.com/user-attachments/assets/29044324-78a6-4ae7-b396-10c8e1228d50" />

Dark mode on 250% DPI:
<img width="1377" height="112" alt="image" src="https://github.com/user-attachments/assets/038bab90-10b9-4f9b-9d61-dde7ab72edb2" />

<img width="1391" height="106" alt="image" src="https://github.com/user-attachments/assets/5427dd45-fba3-47ca-b9fe-6db0387df029" />



### After
The dropdown arrow appears normal and it can be focued

100% DPI:
<img width="468" height="63" alt="image" src="https://github.com/user-attachments/assets/e2eadd54-eef3-4b62-a78e-8cf5d12eb176" />

<img width="493" height="82" alt="image" src="https://github.com/user-attachments/assets/ce2250c8-bcd8-4d2c-b2ad-5abb4d6b394a" />


250% DPI:
<img width="857" height="120" alt="image" src="https://github.com/user-attachments/assets/960221c6-e1cf-4645-b2fe-af9b638b7c0c" />

<img width="1112" height="171" alt="image" src="https://github.com/user-attachments/assets/b589a411-a7d4-4c36-a873-2ca1359d0400" />



## Test methodology <!-- How did you ensure quality? -->

- manually
 

## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-preview.7.25377.103


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13773)