### PR TITLE
Add check "IsDarkModeEnabled" for SelectionForeColor of DataGridView

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
@@ -2063,7 +2063,7 @@ public partial class DataGridView : Control, ISupportInitialize
                 SelectionBackColor = DefaultSelectionBackBrush.Color,
 #pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
                 SelectionForeColor = Application.IsDarkModeEnabled ? SystemColors.ControlText : DefaultSelectionForeBrush.Color,
-#pragma warning disable WFO5001
+#pragma warning restore WFO5001
                 Font = base.Font,
                 AlignmentInternal = DataGridViewContentAlignment.MiddleLeft,
                 WrapModeInternal = DataGridViewTriState.False


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13780


## Proposed changes

- Add judgement `IsDarkModeEnabled` for ` SelectionForeColor` of DataGridView TextBoxCell


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The selected item of the control **DataGridView** can be show clearly in DarkMode

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<img width="1158" height="740" alt="Image" src="https://github.com/user-attachments/assets/088975a6-6677-4865-bdfc-ba4da0ee83d2" />

### After
<img width="1472" height="1278" alt="image" src="https://github.com/user-attachments/assets/abe1884d-74c7-4b3d-9475-0b3340d453b4" />



## Test methodology <!-- How did you ensure quality? -->

- Manually
 

## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-rc.1.25406.102


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13792)