### PR TITLE
Add unit test for ToolStrip.ToolStripAccessibleObjectWrapperForItemsOnOverflow.cs file

### DIFF
--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStrip.ToolStripAccessibleObjectWrapperForItemsOnOverflowTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStrip.ToolStripAccessibleObjectWrapperForItemsOnOverflowTests.cs
@@ -86,4 +86,20 @@ public class ToolStrip_ToolStripAccessibleObjectWrapperForItemsOnOverflowTests
         Assert.Equal(role, actual);
         Assert.False(toolStrip.IsHandleCreated);
     }
+
+    [WinFormsFact]
+    public void ToolStripAccessibleObjectWrapperForItemsOnOverflow_State_Includes_Offscreen_And_Invisible()
+    {
+        using ToolStripButton toolStripItem = new();
+
+        Type type = typeof(ToolStrip)
+            .GetNestedType("ToolStripAccessibleObjectWrapperForItemsOnOverflow", BindingFlags.Instance | BindingFlags.NonPublic);
+        ToolStripItemAccessibleObject accessibleObject =
+            (ToolStripItemAccessibleObject)Activator.CreateInstance(type, toolStripItem);
+
+        AccessibleStates state = accessibleObject.State;
+
+        state.Should().HaveFlag(AccessibleStates.Offscreen);
+        state.Should().HaveFlag(AccessibleStates.Invisible);
+    }
 }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStrip.ToolStripAccessibleObjectWrapperForItemsOnOverflowTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStrip.ToolStripAccessibleObjectWrapperForItemsOnOverflowTests.cs
@@ -94,12 +94,13 @@ public class ToolStrip_ToolStripAccessibleObjectWrapperForItemsOnOverflowTests
 
         Type wrapperType = typeof(ToolStrip)
             .GetNestedType("ToolStripAccessibleObjectWrapperForItemsOnOverflow", BindingFlags.Instance | BindingFlags.NonPublic);
-        ToolStripItemAccessibleObject accessibleObject =
-            (ToolStripItemAccessibleObject)Activator.CreateInstance(wrapperType, toolStripItem);
-
-        AccessibleStates state = accessibleObject.State;
 
         wrapperType.Should().NotBeNull("ToolStripAccessibleObjectWrapperForItemsOnOverflow nested type must exist on ToolStrip");
+
+        ToolStripItemAccessibleObject accessibleObject =
+            (ToolStripItemAccessibleObject)Activator.CreateInstance(wrapperType, toolStripItem);
+        AccessibleStates state = accessibleObject.State;
+
         state.Should().HaveFlag(AccessibleStates.Offscreen);
         state.Should().HaveFlag(AccessibleStates.Invisible);
     }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStrip.ToolStripAccessibleObjectWrapperForItemsOnOverflowTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStrip.ToolStripAccessibleObjectWrapperForItemsOnOverflowTests.cs
@@ -92,10 +92,9 @@ public class ToolStrip_ToolStripAccessibleObjectWrapperForItemsOnOverflowTests
     {
         using ToolStripButton toolStripItem = new();
 
-        Type type = typeof(ToolStrip)
-            .GetNestedType("ToolStripAccessibleObjectWrapperForItemsOnOverflow", BindingFlags.Instance | BindingFlags.NonPublic);
+        Type wrapperType = GetToolStripAccessibleObjectWrapperForItemsOnOverflowType();
         ToolStripItemAccessibleObject accessibleObject =
-            (ToolStripItemAccessibleObject)Activator.CreateInstance(type, toolStripItem);
+            (ToolStripItemAccessibleObject)Activator.CreateInstance(wrapperType, toolStripItem);
 
         AccessibleStates state = accessibleObject.State;
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStrip.ToolStripAccessibleObjectWrapperForItemsOnOverflowTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStrip.ToolStripAccessibleObjectWrapperForItemsOnOverflowTests.cs
@@ -99,6 +99,7 @@ public class ToolStrip_ToolStripAccessibleObjectWrapperForItemsOnOverflowTests
 
         AccessibleStates state = accessibleObject.State;
 
+        wrapperType.Should().NotBeNull("ToolStripAccessibleObjectWrapperForItemsOnOverflow nested type must exist on ToolStrip");
         state.Should().HaveFlag(AccessibleStates.Offscreen);
         state.Should().HaveFlag(AccessibleStates.Invisible);
     }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStrip.ToolStripAccessibleObjectWrapperForItemsOnOverflowTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStrip.ToolStripAccessibleObjectWrapperForItemsOnOverflowTests.cs
@@ -92,7 +92,8 @@ public class ToolStrip_ToolStripAccessibleObjectWrapperForItemsOnOverflowTests
     {
         using ToolStripButton toolStripItem = new();
 
-        Type wrapperType = GetToolStripAccessibleObjectWrapperForItemsOnOverflowType();
+        Type wrapperType = typeof(ToolStrip)
+            .GetNestedType("ToolStripAccessibleObjectWrapperForItemsOnOverflow", BindingFlags.Instance | BindingFlags.NonPublic);
         ToolStripItemAccessibleObject accessibleObject =
             (ToolStripItemAccessibleObject)Activator.CreateInstance(wrapperType, toolStripItem);
 


### PR DESCRIPTION
Add more test for uncovered public method of ToolStrip.ToolStripAccessibleObjectWrapperForItemsOnOverflow.cs file to get a full coverage.
 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13793)