### PR TITLE
fix #13777 : Dark Mode: Divider line between Up and Down buttons is not visible in DomainUpDown/NumericUpDown when mouse-over or click them

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.UpDownButtons.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.UpDownButtons.cs
@@ -279,7 +279,7 @@ public abstract partial class UpDownBase
                 DrawModernControlButton(
                     cachedGraphics,
                     new Rectangle(0, 0, _parent._defaultButtonsWidth, half_height),
-                    ModernControlButtonStyle.Up,
+                    ModernControlButtonStyle.Up | ModernControlButtonStyle.SingleBorder,
                     _pushed == ButtonID.Up
                         ? ModernControlButtonState.Pressed
                         : (Enabled ? (_mouseOver == ButtonID.Up ? ModernControlButtonState.Hover : ModernControlButtonState.Normal)
@@ -289,7 +289,7 @@ public abstract partial class UpDownBase
                 DrawModernControlButton(
                     cachedGraphics,
                     new Rectangle(0, half_height, _parent._defaultButtonsWidth, half_height),
-                    ModernControlButtonStyle.Down,
+                    ModernControlButtonStyle.Down | ModernControlButtonStyle.SingleBorder,
                     _pushed == ButtonID.Down
                         ? ModernControlButtonState.Pressed
                         : (Enabled ? (_mouseOver == ButtonID.Down ? ModernControlButtonState.Hover : ModernControlButtonState.Normal)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.UpDownButtons.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.UpDownButtons.cs
@@ -4,6 +4,7 @@
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Windows.Forms.VisualStyles;
+using static System.Windows.Forms.ControlPaint;
 
 namespace System.Windows.Forms;
 
@@ -275,21 +276,25 @@ public abstract partial class UpDownBase
                     _parent._defaultButtonsWidth,
                     ClientSize.Height);
 
-                ControlPaint.DrawScrollButton(
+                DrawModernControlButton(
                     cachedGraphics,
                     new Rectangle(0, 0, _parent._defaultButtonsWidth, half_height),
-                    ScrollButton.Up,
+                    ModernControlButtonStyle.Up,
                     _pushed == ButtonID.Up
-                        ? ButtonState.Pushed
-                        : (Enabled ? ButtonState.Normal : ButtonState.Inactive));
+                        ? ModernControlButtonState.Pressed
+                        : (Enabled ? (_mouseOver == ButtonID.Up ? ModernControlButtonState.Hover : ModernControlButtonState.Normal)
+                                   : ModernControlButtonState.Disabled),
+                    true);
 
-                ControlPaint.DrawScrollButton(
+                DrawModernControlButton(
                     cachedGraphics,
                     new Rectangle(0, half_height, _parent._defaultButtonsWidth, half_height),
-                    ScrollButton.Down,
+                    ModernControlButtonStyle.Down,
                     _pushed == ButtonID.Down
-                        ? ButtonState.Pushed
-                        : (Enabled ? ButtonState.Normal : ButtonState.Inactive));
+                        ? ModernControlButtonState.Pressed
+                        : (Enabled ? (_mouseOver == ButtonID.Down ? ModernControlButtonState.Hover : ModernControlButtonState.Normal)
+                                   : ModernControlButtonState.Disabled),
+                    true);
 
                 e.GraphicsInternal.DrawImageUnscaled(
                     _cachedBitmap,


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13777 


## Proposed changes

- 
- add hover parameter
- 


## Screenshots 

### Before

![Issue_13777_before](https://github.com/user-attachments/assets/f5b954b9-a98e-4c32-a7c2-e2dcfd585bdb)


### After
<!-- 
![Issue_13777_after](https://github.com/user-attachments/assets/4c5231b9-013c-411c-b457-edeb3018be6d)
 -->
![Issue_13777_after2](https://github.com/user-attachments/assets/47be80bf-1400-4cb4-b0e9-2704d9e8ac93)


## Test methodology 

- 
- manual
- 

