### PR TITLE
Fix transparent rendering with parents that have a background image

### DIFF
--- a/src/System.Private.Windows.Core/src/NativeMethods.txt
+++ b/src/System.Private.Windows.Core/src/NativeMethods.txt
@@ -118,10 +118,12 @@ GetSystemMetrics
 GetThreadLocale
 GetViewportExtEx
 GetViewportOrgEx
+GetWindowOrgEx
 GetWindowRect
 GetWindowText
 GetWindowTextLength
 GetWindowThreadProcessId
+GetWorldTransform
 GlobalAlloc
 GlobalFree
 GlobalLock

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/Gdi/HDC.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/Gdi/HDC.cs
@@ -1,10 +1,31 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Drawing;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
 namespace Windows.Win32.Graphics.Gdi;
 
 internal readonly partial struct HDC : IHandle<HDC>
 {
     HDC IHandle<HDC>.Handle => this;
     object? IHandle<HDC>.Wrapper => null;
+
+    internal Point GetViewPointOrigin() =>
+        PInvokeCore.GetViewportOrgEx(this, out Point point) ? point : Point.Empty;
+
+    internal Point GetWindowOrigin() =>
+        PInvokeCore.GetWindowOrgEx(this, out Point point) ? point : Point.Empty;
+
+    internal Matrix3x2 GetWorldTransform()
+    {
+        if (PInvokeCore.GetWorldTransform(this, out XFORM matrix))
+        {
+            return Unsafe.As<XFORM, Matrix3x2>(ref matrix);
+        }
+
+        // If we can't get the transform, return the identity matrix.
+        return Matrix3x2.Identity;
+    }
 }

--- a/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
+++ b/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
@@ -224,7 +224,6 @@ GetWindow
 GetWindowDisplayAffinity
 GetWindowDpiAwarenessContext
 GetWindowPlacement
-GetWorldTransform
 GMR_*
 HC_*
 HDHITTESTINFO

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/DeviceContextState.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/DeviceContextState.cs
@@ -32,9 +32,7 @@ internal unsafe class DeviceContextState
         TextAlign = PInvoke.GetTextAlign(hdc);
         BackgroundMode = PInvoke.GetBkMode(hdc);
 
-        Matrix3x2 transform = default;
-        PInvoke.GetWorldTransform(hdc, (XFORM*)(void*)&transform);
-        Transform = transform;
+        Transform = hdc.GetWorldTransform();
 
         Point point = default;
         PInvoke.GetBrushOrgEx(hdc, &point);

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint.cs
@@ -462,6 +462,13 @@ public static unsafe partial class ControlPaint
             }
 
             g.FillRectangle(textureBrush, clipRect);
+
+            // If the Graphics backing HDC has an offset origin (SetViewportOrgEx), drawing with a texture brush will
+            // reset it. Getting the HDC and releasing it will restore the offset.
+            //
+            // See https://github.com/dotnet/winforms/issues/13784 for a repro.
+            g.GetHdc();
+            g.ReleaseHdc();
         }
         else
         {

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/ScreenDcCache.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/ScreenDcCache.cs
@@ -111,7 +111,7 @@ internal sealed partial class ScreenDcCache : IDisposable
         Debug.Assert(PInvoke.GetBkMode(hdc) == BACKGROUND_MODE.OPAQUE);
 
         Matrix3x2 matrix = default;
-        Debug.Assert(PInvoke.GetWorldTransform(hdc, (XFORM*)(void*)&matrix));
+        Debug.Assert(PInvokeCore.GetWorldTransform(hdc, (XFORM*)(void*)&matrix));
         Debug.Assert(matrix.IsIdentity);
     }
 }


### PR DESCRIPTION
If a Graphics backing HDC has an offset origin (SetViewportOrgEx), drawing with a texture brush will reset it. Getting the HDC and releasing it will restore the offset.

Add a few helper methods to HDC to make debugging this sort of thing easier.

Fixes #13784