### PR TITLE
CommandParameter property: Provide designer support and control CodeDOM serialization

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonBase.cs
@@ -221,10 +221,9 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
     ///  which is assigned to the <see cref="Command"/> property.
     /// </summary>
     [Bindable(true)]
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     [SRCategory(nameof(SR.CatData))]
     [SRDescription(nameof(SR.CommandComponentCommandParameterDescr))]
+    [TypeConverter(typeof(StringConverter))]
     public object? CommandParameter
     {
         get => _commandParameter;
@@ -237,6 +236,12 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
             }
         }
     }
+
+    private void ResetCommandParameter() => CommandParameter = null;
+
+    private bool ShouldSerializeCommandParameter() =>
+        _commandParameter is string parameter
+        && !string.IsNullOrEmpty(parameter);
 
     /// <summary>
     ///  Occurs when the value of the <see cref="CommandParameter"/> property has changed.

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
@@ -442,10 +442,9 @@ public abstract partial class ToolStripItem :
     ///  which is assigned to the <see cref="Command"/> property.
     /// </summary>
     [Bindable(true)]
-    [Browsable(false)]
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     [SRCategory(nameof(SR.CatData))]
     [SRDescription(nameof(SR.CommandComponentCommandParameterDescr))]
+    [TypeConverter(typeof(StringConverter))]
     public object? CommandParameter
     {
         get => _commandParameter;
@@ -459,6 +458,12 @@ public abstract partial class ToolStripItem :
             }
         }
     }
+
+    private void ResetCommandParameter() => CommandParameter = null;
+
+    private bool ShouldSerializeCommandParameter() =>
+        _commandParameter is string parameter
+        && !string.IsNullOrEmpty(parameter);
 
     /// <summary>
     ///  Occurs when the value of the <see cref="CommandParameter"/> property has changed.

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/BinaryFormat/WinFormsBinaryFormattedObjectTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/BinaryFormat/WinFormsBinaryFormattedObjectTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
@@ -270,9 +270,9 @@ public class WinFormsBinaryFormattedObjectTests
     {
         { new Control(), new string[] { "DataContext: Object", "Tag: Object" } },
         { new Form(), new string[] { "DataContext: Object", "Tag: Object" } },
-        { new Button(), new string[] { "DataContext: Object", "Tag: Object" } },
-        { new CheckBox(), new string[] { "DataContext: Object", "Tag: Object" } },
-        { new RadioButton(), new string[] { "DataContext: Object", "Tag: Object" } },
+        { new Button(), new string[] { "CommandParameter: Object", "DataContext: Object", "Tag: Object" } },
+        { new CheckBox(), new string[] { "CommandParameter: Object", "DataContext: Object", "Tag: Object" } },
+        { new RadioButton(), new string[] { "CommandParameter: Object", "DataContext: Object", "Tag: Object" } },
         { new DataGridView(), new string[] { "DataSource: Object", "DataContext: Object", "Tag: Object" } },
         { new DateTimePicker(), new string[] { "DataContext: Object", "Tag: Object" } },
         { new GroupBox(), new string[] { "DataContext: Object", "Tag: Object" } },


### PR DESCRIPTION
Fixes #13801.

Affected Controls are

- `ButtonBase`
- `ToolStripItem`

Fixes:
- `CommandParameter` is now shown in the property browser, and string values can be directly entered.
- If `CommandParameter` is effectively of type `string`, the values are getting CodeDOM-serialized and -deseriaslized.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13802)