### PR TITLE
Improve Form.ShowAsync and Form.ShowDialogAsync

### DIFF
--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/FormAsyncExtensions.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/FormAsyncExtensions.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
+
+namespace System.Windows.Forms.Tests;
+
+internal static class FormAsyncExtensions
+{
+    public static Task WaitForHandleCreatedAsync(this Form form)
+    {
+        ArgumentNullException.ThrowIfNull(form, nameof(form));
+
+        TaskCompletionSource tcs = new TaskCompletionSource(new WeakReference(form));
+        form.HandleCreated += Form_HandleCreated;
+
+        return tcs.Task;
+
+        void Form_HandleCreated(object sender, EventArgs e)
+        {
+            ((Form)sender).HandleCreated -= Form_HandleCreated;
+            tcs.TrySetResult();
+        }
+    }
+
+    public static Form ToForm(this Task task)
+    {
+        ArgumentNullException.ThrowIfNull(task, nameof(task));
+
+        if (task.AsyncState is WeakReference<Form> weakRefToForm)
+        {
+            if (weakRefToForm.TryGetTarget(out Form form))
+            {
+                return form;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/FormTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/FormTests.cs
@@ -9,7 +9,7 @@ using Moq;
 
 namespace System.Windows.Forms.Tests;
 
-public class FormTests
+public partial class FormTests
 {
     [WinFormsFact]
     public void Form_Ctor_Default()
@@ -2655,6 +2655,71 @@ public class FormTests
         Assert.Same(parent, owner);
         Assert.False(child.IsHandleCreated);
     }
+
+#pragma warning disable WFO5002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    [WinFormsFact]
+    public async Task Form_ShowAsync_GeneralTaskTests()
+    {
+        using Form mainForm = new();
+
+        Task frmTask = mainForm.ShowAsync();
+
+        Task closerTask = Task.Run(async () =>
+        {
+            await Task.Delay(100).ConfigureAwait(false);
+            mainForm.Close();
+        });
+
+        await Task.WhenAll(frmTask, closerTask)
+            .ConfigureAwait(false);
+    }
+
+    [WinFormsFact]
+    public async Task Form_ShowAsync_GetFormFromReturnedTask()
+    {
+        Dictionary<Task, Form> formControlTasks = [];
+        Random random = new();
+
+        for (int i = 0; i < 5; i++)
+        {
+            Form form = new()
+            {
+                Text = $"Form {i}",
+                Size = new Size(200, 200),
+            };
+
+            form.Load += async (sender, e) =>
+            {
+                await Task.Delay(random.Next(20, 100))
+                    .ConfigureAwait(true);
+
+                ((Form)sender).Close();
+            };
+
+            formControlTasks.Add(
+                key: form.ShowAsync(),
+                value: form);
+        }
+
+        while (formControlTasks.Count > 0)
+        {
+            Task finishedTask = await Task
+                .WhenAny(formControlTasks.Keys)
+                .ConfigureAwait(false);
+
+            if (finishedTask.ToForm() is Form form)
+            {
+                Assert.Same(
+                    // The form, which we got through the task's AsyncState.
+                    form,
+                    // The form, which got through the lookup.
+                    formControlTasks[finishedTask]);
+            }
+
+            formControlTasks.Remove(finishedTask);
+        }
+    }
+#pragma warning restore WFO5002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     [WinFormsFact]
     public void Form_ParentThenSetShowInTaskbarToFalse()


### PR DESCRIPTION
* Added unit tests for `ShowAsync`
* Improved `ShowAsync` and `ShowDialogAsync` by associating the Form via `WeakReference` with the returned Task's `AsyncState`, so that it's easy to retrieve the Form from a returned Task in `Task.WhenAny` scenarios.
* Added unit test for that particular scenario.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13808)