### PR TITLE
Draw background image for button in dark mode

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/Button.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/Button.cs
@@ -166,7 +166,8 @@ public partial class Button : ButtonBase, IButtonControl
                 // The SystemRenderer cannot render images. So, we flip to our
                 // own DarkMode renderer, if we need to render images, except if...
                 && Image is null
-
+                // ...or a BackgroundImage, except if...
+                && BackgroundImage is null
                 // ...the user wants to opt out of implicit DarkMode rendering.
                 && DarkModeRequestState is true
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/ButtonBaseAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/ButtonBaseAdapter.cs
@@ -545,14 +545,31 @@ internal abstract partial class ButtonBaseAdapter
     /// <summary>
     ///  Draws the button's image.
     /// </summary>
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     internal void PaintImage(PaintEventArgs e, LayoutData layout)
     {
+        if (Application.IsDarkModeEnabled && Control.DarkModeRequestState is true && Control.BackgroundImage is not null)
+        {
+            Rectangle bounds = Control.ClientRectangle;
+            bounds.Inflate(-ButtonBorderSize, -ButtonBorderSize);
+            ControlPaint.DrawBackgroundImage(
+                e.GraphicsInternal,
+                Control.BackgroundImage,
+                Color.Transparent,
+                Control.BackgroundImageLayout,
+                Control.ClientRectangle,
+                bounds,
+                Control.DisplayRectangle.Location,
+                Control.RightToLeft);
+        }
+
         if (Control.Image is not null)
         {
             // Setup new clip region & draw
             DrawImageCore(e.GraphicsInternal, Control.Image, layout.ImageBounds, layout.ImageStart, layout);
         }
     }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     internal static LayoutOptions CommonLayout(
         Rectangle clientRectangle,


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13720


## Proposed changes

-  Add `DrawBackgroundImage` in the method `PaintImage` of the `ButtonBaseAdapter.cs`

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Button background image can be displayed in Winform dark mode

## Regression? 

-  Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
The button background images are no longer displayed in dark mode.
<img width="448" height="487" alt="Image" src="https://github.com/user-attachments/assets/be3e6fac-7280-4fa9-a600-4ed21d8f4901" />

### After
The button background images can be displayed in dark mode
<img width="797" height="707" alt="image" src="https://github.com/user-attachments/assets/96431537-ef63-484e-97c6-7bbb904231ca" />



## Test methodology <!-- How did you ensure quality? -->

- Manually
 

## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-rc.1.25413.101


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13809)