### PR TITLE
Remove Experimental attribute for dark mode

### DIFF
--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/ApplyApplicationDefaultsEventArgs.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/ApplyApplicationDefaultsEventArgs.vb
@@ -17,8 +17,6 @@ Namespace Microsoft.VisualBasic.ApplicationServices
     Public Class ApplyApplicationDefaultsEventArgs
         Inherits EventArgs
 
-#Disable Warning WFO5001
-
         Friend Sub New(minimumSplashScreenDisplayTime As Integer,
                 highDpiMode As HighDpiMode,
                 colorMode As SystemColorMode)
@@ -28,13 +26,10 @@ Namespace Microsoft.VisualBasic.ApplicationServices
             Me.ColorMode = colorMode
         End Sub
 
-#Enable Warning WFO5001
-
         ''' <summary>
         '''  Setting this property inside the event handler determines the
         '''  <see cref="Application.ColorMode"/> for the application.
         ''' </summary>
-        <Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat:=DiagnosticIDs.UrlFormat)>
         Public Property ColorMode As SystemColorMode
 
         ''' <summary>

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
@@ -65,13 +65,9 @@ Namespace Microsoft.VisualBasic.ApplicationServices
 
         Private _appSynchronizationContext As SynchronizationContext
 
-#Disable Warning WFO5001 ' Type is for evaluation purposes only and is subject to change or removal in future updates.
-
         ' The ColorMode (Classic/Light, System, Dark) the user assigned to the ApplyApplicationsDefault event.
         ' Note: We aim to expose this to the App Designer in later runtime/VS versions.
         Private _colorMode As SystemColorMode = SystemColorMode.Classic
-
-#Enable Warning WFO5001
 
         ' We only need to show the splash screen once.
         ' Protect the user from himself if they are overriding our app model.
@@ -747,7 +743,6 @@ Namespace Microsoft.VisualBasic.ApplicationServices
             '    Once all this is done, we give the User another chance to change the value by code through
             '    the ApplyDefaults event.
             ' Note: Overriding MinimumSplashScreenDisplayTime needs still to keep working!
-#Disable Warning WFO5001 ' Type is for evaluation purposes only and is subject to change or removal in future updates.
             Dim applicationDefaultsEventArgs As New ApplyApplicationDefaultsEventArgs(
                 MinimumSplashScreenDisplayTime,
                 HighDpiMode,
@@ -755,7 +750,6 @@ Namespace Microsoft.VisualBasic.ApplicationServices
             {
                 .MinimumSplashScreenDisplayTime = MinimumSplashScreenDisplayTime
             }
-#Enable Warning WFO5001
 
             RaiseEvent ApplyApplicationDefaults(Me, applicationDefaultsEventArgs)
 
@@ -770,9 +764,6 @@ Namespace Microsoft.VisualBasic.ApplicationServices
             AsyncOperationManager.SynchronizationContext = New WindowsFormsSynchronizationContext()
 
             _highDpiMode = applicationDefaultsEventArgs.HighDpiMode
-
-#Disable Warning WFO5001 ' Type is for evaluation purposes only and is subject to change or removal in future updates.
-
             _colorMode = applicationDefaultsEventArgs.ColorMode
 
             ' Then, it's applying what we got back as HighDpiMode.
@@ -781,6 +772,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
             If dpiSetResult Then
                 _highDpiMode = Application.HighDpiMode
             End If
+
             Debug.Assert(dpiSetResult, "We could not set the HighDpiMode.")
 
             ' Now, let's set VisualStyles and ColorMode:
@@ -789,8 +781,6 @@ Namespace Microsoft.VisualBasic.ApplicationServices
             End If
 
             Application.SetColorMode(_colorMode)
-
-#Enable Warning WFO5001
 
             ' We'll handle "/nosplash" for you.
             If Not (commandLineArgs.Contains("/nosplash") OrElse Me.CommandLineArgs.Contains("-nosplash")) Then

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
@@ -194,7 +194,6 @@ Namespace Microsoft.VisualBasic.ApplicationServices
         ''' <value>
         '''  The <see cref="SystemColorMode"/> that the application is running in.
         ''' </value>
-        <Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat:=DiagnosticIDs.UrlFormat)>
         <EditorBrowsable(EditorBrowsableState.Never)>
         Protected Property ColorMode As SystemColorMode
             Get

--- a/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/WindowsFormsApplicationBaseTests.vb
+++ b/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/WindowsFormsApplicationBaseTests.vb
@@ -17,11 +17,9 @@ Namespace Microsoft.VisualBasic.Forms.Tests
         Public Sub Properties()
             UseCompatibleTextRendering.Should.BeFalse()
 
-#Disable Warning WFO5001 ' Type is for evaluation purposes only and is subject to change or removal in future updates.
             ColorMode.Should.Be(SystemColorMode.Classic)
             ColorMode = SystemColorMode.Dark
             ColorMode.Should.Be(SystemColorMode.Dark)
-#Enable Warning WFO5001
 
             EnableVisualStyles.Should.Be(False)
             EnableVisualStyles = True

--- a/src/System.Windows.Forms/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/PublicAPI.Shipped.txt
@@ -1,47 +1,4 @@
 #nullable enable
-[WFO5001]static System.Windows.Forms.Application.SetColorMode(System.Windows.Forms.SystemColorMode systemColorMode) -> void
-[WFO5001]System.Windows.Forms.ControlStyles.ApplyThemingImplicitly = 524288 -> System.Windows.Forms.ControlStyles
-[WFO5001]System.Windows.Forms.Form.FormBorderColorChanged -> System.EventHandler?
-[WFO5001]System.Windows.Forms.Form.FormCaptionBackColorChanged -> System.EventHandler?
-[WFO5001]System.Windows.Forms.Form.FormCaptionTextColorChanged -> System.EventHandler?
-[WFO5001]System.Windows.Forms.Form.FormCornerPreferenceChanged -> System.EventHandler?
-[WFO5001]System.Windows.Forms.FormCornerPreference
-[WFO5001]System.Windows.Forms.FormCornerPreference.Default = 0 -> System.Windows.Forms.FormCornerPreference
-[WFO5001]System.Windows.Forms.FormCornerPreference.DoNotRound = 1 -> System.Windows.Forms.FormCornerPreference
-[WFO5001]System.Windows.Forms.FormCornerPreference.Round = 2 -> System.Windows.Forms.FormCornerPreference
-[WFO5001]System.Windows.Forms.FormCornerPreference.RoundSmall = 3 -> System.Windows.Forms.FormCornerPreference
-[WFO5001]System.Windows.Forms.SystemColorMode
-[WFO5001]System.Windows.Forms.SystemColorMode.Classic = 0 -> System.Windows.Forms.SystemColorMode
-[WFO5001]System.Windows.Forms.SystemColorMode.Dark = 2 -> System.Windows.Forms.SystemColorMode
-[WFO5001]System.Windows.Forms.SystemColorMode.System = 1 -> System.Windows.Forms.SystemColorMode
-[WFO5001]virtual System.Windows.Forms.Form.OnFormBorderColorChanged(System.EventArgs! e) -> void
-[WFO5001]virtual System.Windows.Forms.Form.OnFormCaptionBackColorChanged(System.EventArgs! e) -> void
-[WFO5001]virtual System.Windows.Forms.Form.OnFormCaptionTextColorChanged(System.EventArgs! e) -> void
-[WFO5001]virtual System.Windows.Forms.Form.OnFormCornerPreferenceChanged(System.EventArgs! e) -> void
-[WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(nint hwndOwner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
-[WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(System.Windows.Forms.IWin32Window! owner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
-[WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterScreen) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
-[WFO5002]System.Windows.Forms.Form.ShowAsync(System.Windows.Forms.IWin32Window? owner = null) -> System.Threading.Tasks.Task!
-[WFO5002]System.Windows.Forms.Form.ShowDialogAsync() -> System.Threading.Tasks.Task<System.Windows.Forms.DialogResult>!
-[WFO5002]System.Windows.Forms.Form.ShowDialogAsync(System.Windows.Forms.IWin32Window! owner) -> System.Threading.Tasks.Task<System.Windows.Forms.DialogResult>!
-[WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(nint hwndOwner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
-[WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(System.Windows.Forms.IWin32Window! owner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
-[WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterScreen) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
-[WFO5002]System.Windows.Forms.Form.ShowAsync(System.Windows.Forms.IWin32Window? owner = null) -> System.Threading.Tasks.Task!
-[WFO5002]System.Windows.Forms.Form.ShowDialogAsync() -> System.Threading.Tasks.Task<System.Windows.Forms.DialogResult>!
-[WFO5002]System.Windows.Forms.Form.ShowDialogAsync(System.Windows.Forms.IWin32Window! owner) -> System.Threading.Tasks.Task<System.Windows.Forms.DialogResult>!
-[WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(nint hwndOwner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
-[WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(System.Windows.Forms.IWin32Window! owner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
-[WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterScreen) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
-[WFO5002]System.Windows.Forms.Form.ShowAsync(System.Windows.Forms.IWin32Window? owner = null) -> System.Threading.Tasks.Task!
-[WFO5002]System.Windows.Forms.Form.ShowDialogAsync() -> System.Threading.Tasks.Task<System.Windows.Forms.DialogResult>!
-[WFO5002]System.Windows.Forms.Form.ShowDialogAsync(System.Windows.Forms.IWin32Window! owner) -> System.Threading.Tasks.Task<System.Windows.Forms.DialogResult>!
-[WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(nint hwndOwner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
-[WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(System.Windows.Forms.IWin32Window! owner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
-[WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterScreen) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
-[WFO5002]System.Windows.Forms.Form.ShowAsync(System.Windows.Forms.IWin32Window? owner = null) -> System.Threading.Tasks.Task!
-[WFO5002]System.Windows.Forms.Form.ShowDialogAsync() -> System.Threading.Tasks.Task<System.Windows.Forms.DialogResult>!
-[WFO5002]System.Windows.Forms.Form.ShowDialogAsync(System.Windows.Forms.IWin32Window! owner) -> System.Threading.Tasks.Task<System.Windows.Forms.DialogResult>!
 [WFO5003]System.Windows.Forms.IAsyncDropTarget
 [WFO5003]System.Windows.Forms.IAsyncDropTarget.OnAsyncDragDrop(System.Windows.Forms.DragEventArgs! e) -> void
 ~abstract System.Windows.Forms.DataGridColumnStyle.Commit(System.Windows.Forms.CurrencyManager dataSource, int rowNum) -> bool

--- a/src/System.Windows.Forms/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/PublicAPI.Shipped.txt
@@ -18,6 +18,30 @@
 [WFO5001]virtual System.Windows.Forms.Form.OnFormCaptionBackColorChanged(System.EventArgs! e) -> void
 [WFO5001]virtual System.Windows.Forms.Form.OnFormCaptionTextColorChanged(System.EventArgs! e) -> void
 [WFO5001]virtual System.Windows.Forms.Form.OnFormCornerPreferenceChanged(System.EventArgs! e) -> void
+[WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(nint hwndOwner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
+[WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(System.Windows.Forms.IWin32Window! owner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
+[WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterScreen) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
+[WFO5002]System.Windows.Forms.Form.ShowAsync(System.Windows.Forms.IWin32Window? owner = null) -> System.Threading.Tasks.Task!
+[WFO5002]System.Windows.Forms.Form.ShowDialogAsync() -> System.Threading.Tasks.Task<System.Windows.Forms.DialogResult>!
+[WFO5002]System.Windows.Forms.Form.ShowDialogAsync(System.Windows.Forms.IWin32Window! owner) -> System.Threading.Tasks.Task<System.Windows.Forms.DialogResult>!
+[WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(nint hwndOwner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
+[WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(System.Windows.Forms.IWin32Window! owner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
+[WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterScreen) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
+[WFO5002]System.Windows.Forms.Form.ShowAsync(System.Windows.Forms.IWin32Window? owner = null) -> System.Threading.Tasks.Task!
+[WFO5002]System.Windows.Forms.Form.ShowDialogAsync() -> System.Threading.Tasks.Task<System.Windows.Forms.DialogResult>!
+[WFO5002]System.Windows.Forms.Form.ShowDialogAsync(System.Windows.Forms.IWin32Window! owner) -> System.Threading.Tasks.Task<System.Windows.Forms.DialogResult>!
+[WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(nint hwndOwner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
+[WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(System.Windows.Forms.IWin32Window! owner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
+[WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterScreen) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
+[WFO5002]System.Windows.Forms.Form.ShowAsync(System.Windows.Forms.IWin32Window? owner = null) -> System.Threading.Tasks.Task!
+[WFO5002]System.Windows.Forms.Form.ShowDialogAsync() -> System.Threading.Tasks.Task<System.Windows.Forms.DialogResult>!
+[WFO5002]System.Windows.Forms.Form.ShowDialogAsync(System.Windows.Forms.IWin32Window! owner) -> System.Threading.Tasks.Task<System.Windows.Forms.DialogResult>!
+[WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(nint hwndOwner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
+[WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(System.Windows.Forms.IWin32Window! owner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
+[WFO5002]static System.Windows.Forms.TaskDialog.ShowDialogAsync(System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterScreen) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
+[WFO5002]System.Windows.Forms.Form.ShowAsync(System.Windows.Forms.IWin32Window? owner = null) -> System.Threading.Tasks.Task!
+[WFO5002]System.Windows.Forms.Form.ShowDialogAsync() -> System.Threading.Tasks.Task<System.Windows.Forms.DialogResult>!
+[WFO5002]System.Windows.Forms.Form.ShowDialogAsync(System.Windows.Forms.IWin32Window! owner) -> System.Threading.Tasks.Task<System.Windows.Forms.DialogResult>!
 [WFO5003]System.Windows.Forms.IAsyncDropTarget
 [WFO5003]System.Windows.Forms.IAsyncDropTarget.OnAsyncDragDrop(System.Windows.Forms.DragEventArgs! e) -> void
 ~abstract System.Windows.Forms.DataGridColumnStyle.Commit(System.Windows.Forms.CurrencyManager dataSource, int rowNum) -> bool

--- a/src/System.Windows.Forms/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/PublicAPI.Unshipped.txt
@@ -5,3 +5,23 @@ System.Windows.Forms.Form.ShowAsync(System.Windows.Forms.IWin32Window? owner = n
 System.Windows.Forms.Form.ShowDialogAsync() -> System.Threading.Tasks.Task<System.Windows.Forms.DialogResult>!
 System.Windows.Forms.Form.ShowDialogAsync(System.Windows.Forms.IWin32Window! owner) -> System.Threading.Tasks.Task<System.Windows.Forms.DialogResult>!
 System.Windows.Forms.VisualStyles.ComboBoxState.Focused = 5 -> System.Windows.Forms.VisualStyles.ComboBoxState
+static System.Windows.Forms.Application.SetColorMode(System.Windows.Forms.SystemColorMode systemColorMode) -> void
+System.Windows.Forms.ControlStyles.ApplyThemingImplicitly = 524288 -> System.Windows.Forms.ControlStyles
+System.Windows.Forms.Form.FormBorderColorChanged -> System.EventHandler?
+System.Windows.Forms.Form.FormCaptionBackColorChanged -> System.EventHandler?
+System.Windows.Forms.Form.FormCaptionTextColorChanged -> System.EventHandler?
+System.Windows.Forms.Form.FormCornerPreferenceChanged -> System.EventHandler?
+System.Windows.Forms.FormCornerPreference
+System.Windows.Forms.FormCornerPreference.Default = 0 -> System.Windows.Forms.FormCornerPreference
+System.Windows.Forms.FormCornerPreference.DoNotRound = 1 -> System.Windows.Forms.FormCornerPreference
+System.Windows.Forms.FormCornerPreference.Round = 2 -> System.Windows.Forms.FormCornerPreference
+System.Windows.Forms.FormCornerPreference.RoundSmall = 3 -> System.Windows.Forms.FormCornerPreference
+System.Windows.Forms.SystemColorMode
+System.Windows.Forms.SystemColorMode.Classic = 0 -> System.Windows.Forms.SystemColorMode
+System.Windows.Forms.SystemColorMode.Dark = 2 -> System.Windows.Forms.SystemColorMode
+System.Windows.Forms.SystemColorMode.System = 1 -> System.Windows.Forms.SystemColorMode
+virtual System.Windows.Forms.Form.OnFormBorderColorChanged(System.EventArgs! e) -> void
+virtual System.Windows.Forms.Form.OnFormCaptionBackColorChanged(System.EventArgs! e) -> void
+virtual System.Windows.Forms.Form.OnFormCaptionTextColorChanged(System.EventArgs! e) -> void
+virtual System.Windows.Forms.Form.OnFormCornerPreferenceChanged(System.EventArgs! e) -> void
+System.Windows.Forms.VisualStyles.ComboBoxState.Focused = 5 -> System.Windows.Forms.VisualStyles.ComboBoxState

--- a/src/System.Windows.Forms/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/PublicAPI.Unshipped.txt
@@ -1,16 +1,15 @@
+static System.Windows.Forms.Application.SetColorMode(System.Windows.Forms.SystemColorMode systemColorMode) -> void
 static System.Windows.Forms.TaskDialog.ShowDialogAsync(nint hwndOwner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
 static System.Windows.Forms.TaskDialog.ShowDialogAsync(System.Windows.Forms.IWin32Window! owner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
 static System.Windows.Forms.TaskDialog.ShowDialogAsync(System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterScreen) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
-System.Windows.Forms.Form.ShowAsync(System.Windows.Forms.IWin32Window? owner = null) -> System.Threading.Tasks.Task!
-System.Windows.Forms.Form.ShowDialogAsync() -> System.Threading.Tasks.Task<System.Windows.Forms.DialogResult>!
-System.Windows.Forms.Form.ShowDialogAsync(System.Windows.Forms.IWin32Window! owner) -> System.Threading.Tasks.Task<System.Windows.Forms.DialogResult>!
-System.Windows.Forms.VisualStyles.ComboBoxState.Focused = 5 -> System.Windows.Forms.VisualStyles.ComboBoxState
-static System.Windows.Forms.Application.SetColorMode(System.Windows.Forms.SystemColorMode systemColorMode) -> void
 System.Windows.Forms.ControlStyles.ApplyThemingImplicitly = 524288 -> System.Windows.Forms.ControlStyles
 System.Windows.Forms.Form.FormBorderColorChanged -> System.EventHandler?
 System.Windows.Forms.Form.FormCaptionBackColorChanged -> System.EventHandler?
 System.Windows.Forms.Form.FormCaptionTextColorChanged -> System.EventHandler?
 System.Windows.Forms.Form.FormCornerPreferenceChanged -> System.EventHandler?
+System.Windows.Forms.Form.ShowAsync(System.Windows.Forms.IWin32Window? owner = null) -> System.Threading.Tasks.Task!
+System.Windows.Forms.Form.ShowDialogAsync() -> System.Threading.Tasks.Task<System.Windows.Forms.DialogResult>!
+System.Windows.Forms.Form.ShowDialogAsync(System.Windows.Forms.IWin32Window! owner) -> System.Threading.Tasks.Task<System.Windows.Forms.DialogResult>!
 System.Windows.Forms.FormCornerPreference
 System.Windows.Forms.FormCornerPreference.Default = 0 -> System.Windows.Forms.FormCornerPreference
 System.Windows.Forms.FormCornerPreference.DoNotRound = 1 -> System.Windows.Forms.FormCornerPreference
@@ -20,8 +19,8 @@ System.Windows.Forms.SystemColorMode
 System.Windows.Forms.SystemColorMode.Classic = 0 -> System.Windows.Forms.SystemColorMode
 System.Windows.Forms.SystemColorMode.Dark = 2 -> System.Windows.Forms.SystemColorMode
 System.Windows.Forms.SystemColorMode.System = 1 -> System.Windows.Forms.SystemColorMode
+System.Windows.Forms.VisualStyles.ComboBoxState.Focused = 5 -> System.Windows.Forms.VisualStyles.ComboBoxState
 virtual System.Windows.Forms.Form.OnFormBorderColorChanged(System.EventArgs! e) -> void
 virtual System.Windows.Forms.Form.OnFormCaptionBackColorChanged(System.EventArgs! e) -> void
 virtual System.Windows.Forms.Form.OnFormCaptionTextColorChanged(System.EventArgs! e) -> void
 virtual System.Windows.Forms.Form.OnFormCornerPreferenceChanged(System.EventArgs! e) -> void
-System.Windows.Forms.VisualStyles.ComboBoxState.Focused = 5 -> System.Windows.Forms.VisualStyles.ComboBoxState

--- a/src/System.Windows.Forms/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Application.cs
@@ -6,7 +6,6 @@ using System.Drawing;
 using System.Globalization;
 using System.Reflection;
 using System.Text;
-using System.Windows.Forms.Analyzers.Diagnostics;
 using System.Windows.Forms.VisualStyles;
 using Microsoft.Office;
 using Microsoft.Win32;
@@ -44,9 +43,7 @@ public sealed partial class Application
     private static readonly Lock s_internalSyncObject = new();
     private static bool s_useWaitCursor;
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     private static SystemColorMode? s_colorMode;
-#pragma warning restore WFO5001
 
     private const string DarkModeKeyPath = "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
     private const string DarkModeKey = "AppsUseLightTheme";
@@ -250,7 +247,6 @@ public sealed partial class Application
     ///   static (shared in VB) <see cref="SystemColorMode"/> property.
     ///  </para>
     /// </remarks>
-    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public static SystemColorMode ColorMode => s_colorMode ?? SystemColorMode.Classic;
 
     /// <summary>
@@ -259,31 +255,68 @@ public sealed partial class Application
     internal static bool ColorModeSet => s_colorMode is not null;
 
     /// <summary>
-    ///  Sets the default color mode (dark mode) for the application.
+    ///  Sets the default color mode (Classic/Light Mode, Dark Mode, or the system-defined Light/Dark Mode) for the entire application.
     /// </summary>
-    /// <param name="systemColorMode">The application's default color mode (dark mode) to set.</param>
+    /// <param name="systemColorMode">The application's default color mode to set.</param>
     /// <remarks>
     ///  <para>
-    ///   You should use this method to set the default color mode (dark mode) for the application. Set it,
-    ///   before creating any UI elements, to ensure that the correct color mode is used. You can set it to
-    ///   dark mode (<see cref="SystemColorMode.Dark"/>), light mode (<see cref="SystemColorMode.Classic"/>)
-    ///   or to the system setting (<see cref="SystemColorMode.System"/>).
+    ///   Use this method to set the color mode for the entire application. Set it before creating any UI
+    ///   elements to ensure the correct color mode is applied. You can choose Dark Mode
+    ///   (<see cref="SystemColorMode.Dark"/>), Classic (light) Mode (<see cref="SystemColorMode.Classic"/>),
+    ///   or the system-defined mode (<see cref="SystemColorMode.System"/>).
     ///  </para>
     ///  <para>
-    ///   If you set it to <see cref="SystemColorMode.System"/>, the actual color mode is determined by the
-    ///   Windows system settings. If the system setting is changed, the application will not automatically
-    ///   adapt to the new setting.
+    ///   If you set <see cref="SystemColorMode.System"/>, the actual color mode is determined by the Windows system settings.
+    ///   If the system setting changes, the application will not automatically adapt; you must restart the application
+    ///   to apply the new system setting.
     ///  </para>
     ///  <para>
-    ///   Note that the dark color mode is only available from Windows 11 on or later versions. If the system
-    ///   is set to a high contrast mode, the dark mode is not available.
+    ///   Note that Dark Mode is only available on Windows 11 and later. If Windows is set to High Contrast mode,
+    ///   that mode always takes precedence over other settings.
     ///  </para>
     ///  <para>
-    ///   <b>Note for Visual Basic:</b> If you are using the Visual Basic Application Framework, you should set the
-    ///   color mode by handling the Application Events (see "WindowsFormsApplicationBase.ApplyApplicationDefaults").
+    ///   <b>Note for Visual Basic:</b> If you are using the Visual Basic Application Framework, set the color mode
+    ///   by handling the Application Events (see "WindowsFormsApplicationBase.ApplyApplicationDefaults").
     ///  </para>
+    ///  <para>
+    ///   <b>Important Considerations for Dark Mode in WinForms:</b>
+    ///  </para>
+    ///  <list type="bullet">
+    ///   <item>
+    ///    <description>
+    ///     <b>WinForms and Win32 Limitations:</b> WinForms is a managed wrapper around native Win32 controls.
+    ///     This architecture introduces inherent limitations in theming and rendering, especially in Dark Mode.
+    ///     While Windows continues to evolve its support for theming, some constraints remain.
+    ///    </description>
+    ///   </item>
+    ///   <item>
+    ///    <description>
+    ///     <b>Rendering Limitations:</b> Certain controls may not render perfectly in Dark Mode due to underlying Win32
+    ///     behavior. These imperfections are expected and will not be treated as bugs.
+    ///    </description>
+    ///   </item>
+    ///   <item>
+    ///    <description>
+    ///     <b>Security and Compatibility First:</b> Security and backward compatibility are prioritized over perfect visual fidelity.
+    ///     Changes that risk breaking classic rendering or introduce regressions will be avoided.
+    ///    </description>
+    ///   </item>
+    ///   <item>
+    ///    <description>
+    ///     <b>Ongoing Improvements:</b> As Windows improves Win32 theming, WinForms will adapt accordingly. Dark Mode rendering
+    ///     will improve over time, but not all issues will be resolved immediately.
+    ///    </description>
+    ///   </item>
+    ///   <item>
+    ///    <description>
+    ///     <b>Contrast and Accessibility Edge Cases:</b> Some edge cases may result in suboptimal contrast or may not meet certain
+    ///     accessibility guidelines. While Dark Mode addresses major accessibility concerns for many users (such as reducing eye
+    ///     strain from bright screens), if your application requires strict contrast compliance, we recommend using
+    ///     Classic (light) mode or High Contrast mode.
+    ///    </description>
+    ///   </item>
+    ///  </list>
     /// </remarks>
-    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public static void SetColorMode(SystemColorMode systemColorMode)
     {
         try
@@ -306,12 +339,16 @@ public sealed partial class Application
         }
         finally
         {
+#pragma warning disable SYSLIB5002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             bool useAlternateColorSet = SystemColors.UseAlternativeColorSet;
+#pragma warning restore SYSLIB5002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             bool darkModeEnabled = IsDarkModeEnabled;
 
             if (useAlternateColorSet != darkModeEnabled)
             {
+#pragma warning disable SYSLIB5002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
                 SystemColors.UseAlternativeColorSet = darkModeEnabled;
+#pragma warning restore SYSLIB5002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
                 NotifySystemEventsOfColorChange();
             }
         }
@@ -362,7 +399,6 @@ public sealed partial class Application
     ///   SystemColorModes is not supported, if the Windows OS <c>High Contrast Mode</c> has been enabled in the system settings.
     ///  </para>
     /// </remarks>
-    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public static SystemColorMode SystemColorMode =>
         GetSystemColorModeInternal() == 0
             ? SystemColorMode.Dark
@@ -400,7 +436,6 @@ public sealed partial class Application
     ///  Gets a value indicating whether the application is running in a dark system color context.
     ///  Note: In a high contrast mode, this will always return <see langword="false"/>.
     /// </summary>
-    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public static bool IsDarkModeEnabled =>
         !SystemInformation.HighContrast
         && (ColorMode == SystemColorMode.Dark

--- a/src/System.Windows.Forms/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Application.cs
@@ -312,7 +312,7 @@ public sealed partial class Application
     ///     <b>Contrast and Accessibility Edge Cases:</b> Some edge cases may result in suboptimal contrast or may not meet certain
     ///     accessibility guidelines. While Dark Mode addresses major accessibility concerns for many users (such as reducing eye
     ///     strain from bright screens), if your application requires strict contrast compliance, we recommend using
-    ///     Classic (light) mode or High Contrast mode.
+    ///     Classic (light) mode or applying a Windows Accessibility contrast theme.
     ///    </description>
     ///   </item>
     ///  </list>

--- a/src/System.Windows.Forms/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Application.cs
@@ -21,12 +21,12 @@ namespace System.Windows.Forms;
 public sealed partial class Application
 {
     /// <summary>
-    ///  Hash table for our event list
+    ///  Hash table for our event list.
     /// </summary>
     private static EventHandlerList? s_eventHandlers;
     private static Font? s_defaultFont;
     /// <summary>
-    ///  Scaled version of non system <see cref="s_defaultFont"/>.
+    ///  Scaled version of non-system <see cref="s_defaultFont"/>.
     /// </summary>
     private static Font? s_defaultFontScaled;
     private static string? s_startupPath;
@@ -50,7 +50,7 @@ public sealed partial class Application
     private const int SystemDarkModeDisabled = 1;
 
     /// <summary>
-    ///  Events the user can hook into
+    ///  Events the user can hook into.
     /// </summary>
     private static readonly object s_eventApplicationExit = new();
     private static readonly object s_eventThreadExit = new();
@@ -65,7 +65,7 @@ public sealed partial class Application
     private static bool s_parkingWindowCreated;
 
     /// <summary>
-    ///  This class is static, there is no need to ever create it.
+    ///  This class is static; there is no need to ever create it.
     /// </summary>
     private Application()
     {
@@ -73,8 +73,8 @@ public sealed partial class Application
 
     /// <summary>
     ///  Determines if the caller should be allowed to quit the application. This will return false,
-    ///  for example, if being called from a windows forms control being hosted within a web browser. The
-    ///  windows forms control should not attempt to quit the application.
+    ///  for example, if being called from a Windows Forms control being hosted within a web browser. The
+    ///  Windows Forms control should not attempt to quit the application.
     /// </summary>
     public static bool AllowQuit => ThreadContext.GetAllowQuit();
 
@@ -271,8 +271,8 @@ public sealed partial class Application
     ///   to apply the new system setting.
     ///  </para>
     ///  <para>
-    ///   Note that Dark Mode is only available on Windows 11 and later. If Windows is set to High Contrast mode,
-    ///   that mode always takes precedence over other settings.
+    ///   Note that the dark color mode is only available from Windows 11 on or later versions. If the system
+    ///   is set to a accessibility contrast theme, the dark mode is not available.
     ///  </para>
     ///  <para>
     ///   <b>Note for Visual Basic:</b> If you are using the Visual Basic Application Framework, set the color mode
@@ -389,14 +389,15 @@ public sealed partial class Application
     /// <remarks>
     ///  <para>
     ///   The color setting is determined based on the operating system version and its system settings.
-    ///   It returns <see cref="SystemColorMode.Dark"/> if the dark mode is enabled in the system settings,
-    ///   <see cref="SystemColorMode.Classic"/> if the color mode equals the light, standard color setting.
+    ///   It returns <see cref="SystemColorMode.Dark"/> if dark mode is enabled in the system settings,
+    ///   or <see cref="SystemColorMode.Classic"/> if the color mode is set to the light, standard color setting.
     ///  </para>
     ///  <para>
-    ///   SystemColorMode is supported on Windows 11 or later versions.
+    ///   <see cref="SystemColorMode"/> is supported on Windows 11 or later versions.
     ///  </para>
     ///  <para>
-    ///   SystemColorModes is not supported, if the Windows OS <c>High Contrast Mode</c> has been enabled in the system settings.
+    ///   <see cref="SystemColorMode"/> is not supported if a Windows OS high contrast theme has been
+    ///   enabled in the system settings.
     ///  </para>
     /// </remarks>
     public static SystemColorMode SystemColorMode =>
@@ -434,7 +435,7 @@ public sealed partial class Application
 
     /// <summary>
     ///  Gets a value indicating whether the application is running in a dark system color context.
-    ///  Note: In a high contrast mode, this will always return <see langword="false"/>.
+    ///  Note: With a accessibility contrast theme selected in the OS, this will always return <see langword="false"/>.
     /// </summary>
     public static bool IsDarkModeEnabled =>
         !SystemInformation.HighContrast
@@ -949,7 +950,7 @@ public sealed partial class Application
 
     /// <summary>
     ///  Enables visual styles for all subsequent <see cref="Run()"/> and <see cref="Control.CreateHandle"/> calls.
-    ///  Uses the default theming manifest file shipped with the redist.
+    ///  Uses the default theming manifest file shipped with the redistributable package.
     /// </summary>
     [UnconditionalSuppressMessage("SingleFile", "IL3002", Justification = "Single-file case is handled")]
     public static void EnableVisualStyles()
@@ -1363,6 +1364,10 @@ public sealed partial class Application
     ///  This switch determines the default text rendering engine to use by some controls that support
     ///  switching rendering engine.
     /// </summary>
+    /// <param name="defaultValue">The default value to use for compatible text rendering.</param>
+    /// <exception cref="InvalidOperationException">
+    ///  Thrown if any window handle has already been created in the application.
+    /// </exception>
     public static void SetCompatibleTextRenderingDefault(bool defaultValue)
     {
         if (NativeWindow.AnyHandleCreated)
@@ -1374,7 +1379,7 @@ public sealed partial class Application
     }
 
     /// <summary>
-    ///  Sets the default <see cref="Font"/> for process.
+    ///  Sets the default <see cref="Font"/> for the process.
     /// </summary>
     /// <param name="font">The font to be used as a default across the application.</param>
     /// <exception cref="ArgumentNullException"><paramref name="font"/> is <see langword="null"/>.</exception>
@@ -1383,11 +1388,11 @@ public sealed partial class Application
     /// </exception>
     /// <remarks>
     ///  <para>
-    ///   The system text scale factor will be applied to the font, i.e. if the default font is set to "Calibri, 11f"
-    ///   and the text scale factor is set to 150% the resulting default font will be set to "Calibri, 16.5f".
+    ///   The system text scale factor will be applied to the font. For example, if the default font is set to "Calibri, 11f"
+    ///   and the text scale factor is set to 150%, the resulting default font will be set to "Calibri, 16.5f".
     ///  </para>
     ///  <para>
-    ///   Users can adjust text scale with the Make text bigger slider on the Settings -> Ease of Access -> Vision/Display screen.
+    ///   Users can adjust text scale with the "Make text bigger" slider on the Settings → Accessibility → Display screen.
     ///  </para>
     /// </remarks>
     /// <seealso href="https://docs.microsoft.com/windows/uwp/design/input/text-scaling">Windows Text scaling</seealso>
@@ -1403,7 +1408,7 @@ public sealed partial class Application
     }
 
     /// <summary>
-    ///  Scale <see cref="s_defaultFont"/> or <see cref="s_defaultFontScaled"/> if needed.
+    ///  Scales <see cref="s_defaultFont"/> or <see cref="s_defaultFontScaled"/> if needed.
     /// </summary>
     internal static void ScaleDefaultFont()
     {

--- a/src/System.Windows.Forms/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Control.cs
@@ -7403,7 +7403,6 @@ public unsafe partial class Control :
                 SetExtendedState(ExtendedStates.SetScrollPosition, false);
             }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
             if (Application.IsDarkModeEnabled
                 && DarkModeRequestState is true
                 && !RecreatingHandle)
@@ -7413,7 +7412,6 @@ public unsafe partial class Control :
                     pszSubAppName: $"{DarkModeIdentifier}_{ExplorerThemeIdentifier}",
                     pszSubIdList: null);
             }
-#pragma warning restore WFO5001
         }
 
         ((EventHandler?)Events[s_handleCreatedEvent])?.Invoke(this, e);
@@ -9368,7 +9366,7 @@ public unsafe partial class Control :
             // than when we create the handle for the first time. The reason is that recreating the handle
             // often also recreates the handles of any child controls, and we want to
             // ensure that the theming is applied to all child controls as well.
-#pragma warning disable WFO5001
+
             if (Application.IsDarkModeEnabled
                 && DarkModeRequestState is true)
             {
@@ -9377,7 +9375,6 @@ public unsafe partial class Control :
                     pszSubAppName: $"{DarkModeIdentifier}_{ExplorerThemeIdentifier}",
                     pszSubIdList: null);
             }
-#pragma warning restore WFO5001
 
             // Restore control focus
             if (focused)
@@ -10351,7 +10348,7 @@ public unsafe partial class Control :
     ///  NOTE: This is control style, not the Win32 style of the hWnd.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
     protected void SetStyle(ControlStyles flag, bool value)
     {
         // WARNING: if we ever add argument checking to "flag", we will need
@@ -10371,7 +10368,6 @@ public unsafe partial class Control :
             DarkModeRequestState = value;
         }
     }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     internal virtual void SetToolTip(ToolTip toolTip)
     {
@@ -10423,7 +10419,6 @@ public unsafe partial class Control :
 
             bool fireChange = false;
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
             if (GetTopLevel())
             {
                 // The processing of WmShowWindow will set the visibility
@@ -10441,7 +10436,7 @@ public unsafe partial class Control :
                     PInvoke.ShowWindow(HWND, value ? ShowParams : SHOW_WINDOW_CMD.SW_HIDE);
                 }
             }
-#pragma warning restore WFO5001
+
             else if (IsHandleCreated || (value && _parent?.Created == true))
             {
                 // We want to mark the control as visible so that CreateControl

--- a/src/System.Windows.Forms/System/Windows/Forms/ControlStyles.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/ControlStyles.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
-using System.Windows.Forms.Analyzers.Diagnostics;
 
 namespace System.Windows.Forms;
 
@@ -144,6 +143,5 @@ public enum ControlStyles
     ///  from this setting. Note that using this settings will cause some
     ///  win32 control theming renderers to become inactive for a specific theme.
     /// </summary>
-    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     ApplyThemingImplicitly = 0x00080000
 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/Button.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/Button.cs
@@ -148,7 +148,6 @@ public partial class Button : ButtonBase, IButtonControl
         }
     }
 
-#pragma warning disable WFO5001
     /// <summary>
     ///  Defines, whether the control is owner-drawn. Based on this,
     ///  the UserPaint flags get set, which in turn makes it later
@@ -182,7 +181,6 @@ public partial class Button : ButtonBase, IButtonControl
             return base.OwnerDraw;
         }
     }
-#pragma warning restore WFO5001
 
     internal override bool SupportsUiaProviders => true;
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonBase.cs
@@ -261,9 +261,7 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
     {
         get
         {
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
             CreateParams cp = base.CreateParams;
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/ButtonBaseAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/ButtonBaseAdapter.cs
@@ -545,7 +545,6 @@ internal abstract partial class ButtonBaseAdapter
     /// <summary>
     ///  Draws the button's image.
     /// </summary>
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     internal void PaintImage(PaintEventArgs e, LayoutData layout)
     {
         if (Application.IsDarkModeEnabled && Control.DarkModeRequestState is true && Control.BackgroundImage is not null)
@@ -569,7 +568,6 @@ internal abstract partial class ButtonBaseAdapter
             DrawImageCore(e.GraphicsInternal, Control.Image, layout.ImageBounds, layout.ImageStart, layout);
         }
     }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     internal static LayoutOptions CommonLayout(
         Rectangle clientRectangle,

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/DarkModeAdapterFactory.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/DarkModeAdapterFactory.cs
@@ -5,8 +5,6 @@ namespace System.Windows.Forms.ButtonInternal;
 
 internal static class DarkModeAdapterFactory
 {
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
     public static ButtonBaseAdapter CreateFlatAdapter(ButtonBase control) =>
         Application.IsDarkModeEnabled
             ? new ButtonDarkModeAdapter(control)
@@ -21,6 +19,4 @@ internal static class DarkModeAdapterFactory
         Application.IsDarkModeEnabled
             ? new ButtonDarkModeAdapter(control)
             : new ButtonPopupAdapter(control);
-
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/RadioButtonBaseAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/RadioButtonBaseAdapter.cs
@@ -62,13 +62,13 @@ internal abstract class RadioButtonBaseAdapter : CheckableControlBaseAdapter
 
         if (!Control.Enabled)
         {
-            // If we are not in HighContrast mode OR we opted into the legacy behavior
+            // If we are not in contrast theme OR we opted into the legacy behavior
             if (!SystemInformation.HighContrast)
             {
                 border = ControlPaint.ContrastControlDark;
             }
 
-            // Otherwise we are in HighContrast mode
+            // Otherwise we are in a contrast theme
             field = SystemColors.Control;
         }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/CheckBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/CheckBox.cs
@@ -94,8 +94,6 @@ public partial class CheckBox : ButtonBase
         }
     }
 
-#pragma warning disable WFO5001
-
     private protected override bool OwnerDraw =>
             // We want NO owner draw ONLY when we're
             // * In Dark Mode
@@ -107,8 +105,6 @@ public partial class CheckBox : ButtonBase
                 || Appearance != Appearance.Button
                 || FlatStyle != FlatStyle.Standard)
                 && base.OwnerDraw;
-
-#pragma warning restore WFO5001
 
     [SRCategory(nameof(SR.CatPropertyChanged))]
     [SRDescription(nameof(SR.CheckBoxOnAppearanceChangedDescr))]

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/RadioButton.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/RadioButton.cs
@@ -171,7 +171,6 @@ public partial class RadioButton : ButtonBase
         }
     }
 
-#pragma warning disable WFO5001
     private protected override bool OwnerDraw =>
         // Order is key here - do NOT change!
         // We want NO owner draw ONLY when we're
@@ -184,7 +183,6 @@ public partial class RadioButton : ButtonBase
             || Appearance != Appearance.Button
             || FlatStyle != FlatStyle.Standard)
             && base.OwnerDraw;
-#pragma warning restore WFO5001
 
     /// <hideinheritance/>
     [Browsable(false)]

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
@@ -249,7 +249,6 @@ public partial class ComboBox : ListControl
         }
     }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     /// <summary>
     ///  The background color of this control. This is an ambient property and
     ///  will always return a non-null value.
@@ -273,7 +272,6 @@ public partial class ComboBox : ListControl
 
         set => base.BackColor = value;
     }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -2347,7 +2345,6 @@ public partial class ComboBox : ListControl
             _fromHandleCreate = false;
         }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         if (Application.IsDarkModeEnabled)
         {
             // Style the ComboBox Open-Button:
@@ -2359,7 +2356,6 @@ public partial class ComboBox : ListControl
             _ = PInvoke.GetComboBoxInfo(HWND, ref cInfo);
             PInvoke.SetWindowTheme(cInfo.hwndList, $"{DarkModeIdentifier}_{ExplorerThemeIdentifier}", null);
         }
-#pragma warning restore WFO5001
 
         if (_itemsCollection is not null)
         {
@@ -3677,7 +3673,6 @@ public partial class ComboBox : ListControl
 
                 break;
 
-#pragma warning disable WFO5001
             case PInvokeCore.WM_CTLCOLORSTATIC:
 
                 HWND hwndChild = (HWND)m.LParamInternal;
@@ -3713,7 +3708,6 @@ public partial class ComboBox : ListControl
 
                     return;
                 }
-#pragma warning restore WFO5001
 
                 break;
 
@@ -3812,7 +3806,6 @@ public partial class ComboBox : ListControl
                     using Graphics g = Graphics.FromHdcInternal((IntPtr)dc);
                     FlatComboBoxAdapter.DrawFlatCombo(this, g);
 
-#pragma warning disable WFO5001
                     // Special handling for disabled DropDownList in dark mode
                     if (Application.IsDarkModeEnabled && !Enabled && DropDownStyle == ComboBoxStyle.DropDownList)
                     {
@@ -3833,7 +3826,6 @@ public partial class ComboBox : ListControl
                             Color.FromArgb(180, 180, 180),
                             TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.EndEllipsis);
                     }
-#pragma warning restore WFO5001
 
                     return;
                 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBoxRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBoxRenderer.cs
@@ -15,13 +15,9 @@ public static class ComboBoxRenderer
     [ThreadStatic]
     private static VisualStyleRenderer? t_visualStyleRenderer;
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
     private static readonly VisualStyleElement s_comboBoxElement = Application.IsDarkModeEnabled
         ? VisualStyleElement.CreateElement($"{Control.DarkModeIdentifier}_{Control.ComboBoxButtonThemeIdentifier}::{Control.ComboboxClassIdentifier}", 1, 1)
         : VisualStyleElement.ComboBox.DropDownButton.Normal;
-
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     private static readonly VisualStyleElement s_textBoxElement = VisualStyleElement.TextBox.TextEdit.Normal;
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
@@ -1493,9 +1493,8 @@ public partial class DataGridView : Control, ISupportInitialize
     {
         get
         {
-#pragma warning disable WFO5001
             SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
+
             return base.CreateParams;
         }
     }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DateTimePicker/DateTimePicker.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DateTimePicker/DateTimePicker.cs
@@ -488,12 +488,10 @@ public partial class DateTimePicker : Control
     [EditorBrowsable(EditorBrowsableState.Never)]
     public override Color ForeColor
     {
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates.
         get => ShouldSerializeForeColor()
             || Application.IsDarkModeEnabled
                 ? base.ForeColor
                 : SystemColors.WindowText;
-#pragma warning restore WFO5001
 
         set => base.ForeColor = value;
     }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/GroupBox/GroupBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/GroupBox/GroupBox.cs
@@ -424,7 +424,7 @@ public partial class GroupBox : Control
             // We only pass in the text color if it is explicitly set, else we let the renderer use the color
             // specified by the theme. This is a temporary workaround till we find a good solution for the
             // "default theme color" issue.
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
             if (ShouldSerializeForeColor() || Application.IsDarkModeEnabled || !Enabled)
             {
                 Color textColor = Enabled ? ForeColor : TextRenderer.DisabledTextColor(BackColor);
@@ -448,7 +448,6 @@ public partial class GroupBox : Control
                     textFlags,
                     gbState);
             }
-#pragma warning restore WFO5001
         }
 
         base.OnPaint(e); // raise paint event

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Labels/Label.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Labels/Label.cs
@@ -243,9 +243,7 @@ public partial class Label : Control, IAutomationLiveRegion
     {
         get
         {
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
             CreateParams cp = base.CreateParams;
             cp.ClassName = PInvoke.WC_STATIC;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListBoxes/ListBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListBoxes/ListBox.cs
@@ -264,9 +264,7 @@ public partial class ListBox : ListControl
     {
         get
         {
-#pragma warning disable WFO5001
             SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
 
             CreateParams cp = base.CreateParams;
             cp.ClassName = PInvoke.WC_LISTBOX;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
@@ -627,9 +627,7 @@ public partial class ListView : Control
     {
         get
         {
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
             CreateParams cp = base.CreateParams;
 
@@ -4666,7 +4664,6 @@ public partial class ListView : Control
         BeginInvoke(ApplyDarkModeOnDemand);
     }
 
-#pragma warning disable WFO5001
     private void ApplyDarkModeOnDemand()
     {
         if (Application.IsDarkModeEnabled
@@ -4708,7 +4705,6 @@ public partial class ListView : Control
                 null);
         }
     }
-#pragma warning restore WFO5001
 
     protected override void OnHandleDestroyed(EventArgs e)
     {
@@ -4984,7 +4980,6 @@ public partial class ListView : Control
 
     protected void RealizeProperties()
     {
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         Color c = BackColor;
 
         if (c != SystemColors.Window || Application.IsDarkModeEnabled)
@@ -4998,7 +4993,6 @@ public partial class ListView : Control
         {
             PInvokeCore.SendMessage(this, PInvoke.LVM_SETTEXTCOLOR, (WPARAM)0, (LPARAM)c);
         }
-#pragma warning restore WFO5001
 
         // Realize state information
         if (_imageListLarge is not null)
@@ -6009,7 +6003,7 @@ public partial class ListView : Control
 
         // We need to set the text color when we are in dark mode,
         // so that the themed headers are actually readable.
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
         if (Application.IsDarkModeEnabled
             && !OwnerDraw
             && nmhdr->code == PInvoke.NM_CUSTOMDRAW)
@@ -6032,7 +6026,6 @@ public partial class ListView : Control
                 return false;
             }
         }
-#pragma warning restore WFO5001
 
         if (nmhdr->code == PInvoke.NM_CUSTOMDRAW && PInvoke.UiaClientsAreListening())
         {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/MonthCalendar/MonthCalendar.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/MonthCalendar/MonthCalendar.cs
@@ -188,7 +188,6 @@ public partial class MonthCalendar : Control
         }
     }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     [SRDescription(nameof(SR.MonthCalendarMonthBackColorDescr))]
     public override Color BackColor
     {
@@ -203,7 +202,6 @@ public partial class MonthCalendar : Control
         }
         set => base.BackColor = value;
     }
-#pragma warning restore WFO5001
 
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -284,9 +282,7 @@ public partial class MonthCalendar : Control
     {
         get
         {
-#pragma warning disable WFO5001
             SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
 
             CreateParams cp = base.CreateParams;
             cp.ClassName = PInvoke.MONTHCAL_CLASS;
@@ -408,7 +404,6 @@ public partial class MonthCalendar : Control
         }
     }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     [SRDescription(nameof(SR.MonthCalendarForeColorDescr))]
     public override Color ForeColor
     {
@@ -423,7 +418,6 @@ public partial class MonthCalendar : Control
         }
         set => base.ForeColor = value;
     }
-#pragma warning restore WFO5001
 
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PictureBox/PictureBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PictureBox/PictureBox.cs
@@ -193,9 +193,8 @@ public partial class PictureBox : Control, ISupportInitialize
     {
         get
         {
-#pragma warning disable WFO5001
             SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
+
             CreateParams cp = base.CreateParams;
 
             switch (_borderStyle)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ProgressBar/ProgressBar.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ProgressBar/ProgressBar.cs
@@ -45,9 +45,7 @@ public partial class ProgressBar : Control
     {
         get
         {
-#pragma warning disable WFO5001
             SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
 
             CreateParams cp = base.CreateParams;
             cp.ClassName = PInvoke.PROGRESS_CLASS;
@@ -80,13 +78,12 @@ public partial class ProgressBar : Control
         // If SystemColorMode is enabled, we need to disable the Visual Styles
         // so Windows allows setting Fore- and Background color.
         // There are more ideal ways imaginable, but this does the trick for now.
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
         if (Application.IsDarkModeEnabled)
         {
             // Disables Visual Styles for the ProgressBar.
             PInvoke.SetWindowTheme(HWND, " ", " ");
         }
-#pragma warning restore WFO5001
     }
 
     [Browsable(false)]

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/CategoryGridEntry.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/CategoryGridEntry.cs
@@ -121,7 +121,7 @@ internal sealed partial class CategoryGridEntry : GridEntry
             Rectangle focusRect = new(indent, rect.Y, labelWidth + 3, rect.Height - 1);
             if (SystemInformation.HighContrast && !OwnerGrid.HasCustomLineColor)
             {
-                // Line color is SystemColors.ControlDarkDark in high contrast mode.
+                // Line color is SystemColors.ControlDarkDark in a contrast theme scenario.
                 ControlPaint.DrawFocusRectangle(g, focusRect, SystemColors.ControlText, OwnerGrid.LineColor);
             }
             else

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/DropDownButton.DropDownButtonAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/DropDownButton.DropDownButtonAdapter.cs
@@ -66,7 +66,7 @@ internal sealed partial class DropDownButton : Button
         internal override void PaintUp(PaintEventArgs pevent, CheckState state)
         {
             base.PaintUp(pevent, state);
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
             if (!Application.RenderWithVisualStyles || Application.IsDarkModeEnabled)
             {
                 DDB_Draw3DBorder(pevent, Control.ClientRectangle, raised: true);
@@ -83,7 +83,6 @@ internal sealed partial class DropDownButton : Button
                     c, 1, ButtonBorderStyle.Solid,
                     c, 1, ButtonBorderStyle.None);
             }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         }
 
         internal override void DrawImageCore(Graphics graphics, Image image, Rectangle imageBounds, Point imageStart, LayoutData layout)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/DropDownButton.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/DropDownButton.cs
@@ -78,7 +78,6 @@ internal sealed partial class DropDownButton : Button
         }
     }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     protected override void OnPaint(PaintEventArgs pevent)
     {
         ComboBoxState state = ComboBoxState.Normal;
@@ -128,7 +127,7 @@ internal sealed partial class DropDownButton : Button
             RenderComboBoxButtonWithVisualStyles(pevent, state);
         }
     }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
     private void RenderComboBoxButtonWithVisualStyles(PaintEventArgs pevent, ComboBoxState state)
     {
         Rectangle dropDownButtonRect = new(0, 0, Width, Height);

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
@@ -191,7 +191,7 @@ internal sealed partial class PropertyGridView :
     ///   the selected row's <see cref="GridEntry"/>.
     ///  </para>
     /// </remarks>
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
     internal DropDownButton DropDownButton
     {
         get
@@ -282,7 +282,6 @@ internal sealed partial class PropertyGridView :
             return _dialogButton;
         }
     }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     /// <summary>
     ///  The common text box for editing values.

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
@@ -3426,7 +3426,6 @@ public partial class RichTextBox : TextBoxBase
     {
         switch (m.MsgInternal)
         {
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             case PInvokeCore.WM_PAINT:
 
                 // Important: We need to let to run the base
@@ -3462,7 +3461,6 @@ public partial class RichTextBox : TextBoxBase
                 }
 
                 break;
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
             case MessageId.WM_REFLECT_NOTIFY:
                 WmReflectNotify(ref m);

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Splitter/Splitter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Splitter/Splitter.cs
@@ -203,9 +203,7 @@ public partial class Splitter : Control
     {
         get
         {
-#pragma warning disable WFO5001
             SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
 
             CreateParams cp = base.CreateParams;
             cp.Style &= ~(int)WINDOW_STYLE.WS_BORDER;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabControl.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabControl.cs
@@ -271,9 +271,7 @@ public partial class TabControl : Control
     {
         get
         {
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
             CreateParams cp = base.CreateParams;
             cp.ClassName = PInvoke.WC_TABCONTROL;
@@ -1298,7 +1296,6 @@ public partial class TabControl : Control
         ApplyDarkModeOnDemand();
     }
 
-#pragma warning disable WFO5001
     private void ApplyDarkModeOnDemand()
     {
         // We need to avoid to apply the DarkMode theme twice on handle recreate.
@@ -1310,7 +1307,6 @@ public partial class TabControl : Control
 
         _suspendDarkModeChange = false;
     }
-#pragma warning restore WFO5001
 
     protected override void OnHandleDestroyed(EventArgs e)
     {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabPage.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabPage.cs
@@ -97,7 +97,7 @@ public partial class TabPage : Panel
         get
         {
             Color color = base.BackColor;
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
             if (color != DefaultBackColor)
             {
                 return color;
@@ -109,7 +109,6 @@ public partial class TabPage : Panel
             {
                 return Color.Transparent;
             }
-#pragma warning restore WFO5001
 
             return color;
         }
@@ -139,9 +138,7 @@ public partial class TabPage : Panel
     {
         get
         {
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
             return base.CreateParams;
         }
@@ -611,11 +608,9 @@ public partial class TabPage : Panel
             && UseVisualStyleBackColor
             && (ParentInternal is TabControl parent && parent.Appearance == TabAppearance.Normal))
         {
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             Color bkColor = (UseVisualStyleBackColor && !Application.IsDarkModeEnabled)
                 ? Color.Transparent
                 : BackColor;
-#pragma warning restore WFO5001
 
             Rectangle inflateRect = LayoutUtils.InflateRect(DisplayRectangle, Padding);
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TextBox/TextBoxBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TextBox/TextBoxBase.cs
@@ -269,7 +269,6 @@ public abstract partial class TextBoxBase : Control
         }
     }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     /// <summary>
     ///  Gets or sets the background color of the control.
     /// </summary>
@@ -298,7 +297,6 @@ public abstract partial class TextBoxBase : Control
 
         set => base.BackColor = value;
     }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -402,9 +400,7 @@ public abstract partial class TextBoxBase : Control
     {
         get
         {
-#pragma warning disable WFO5001
             SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
 
             CreateParams cp = base.CreateParams;
             cp.ClassName = PInvoke.WC_EDIT;
@@ -949,7 +945,6 @@ public abstract partial class TextBoxBase : Control
         }
     }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     private void EnsureReadonlyBackgroundColor(bool value)
     {
         // If we have no specifically defined back color, we set the back color in case we're in dark mode.
@@ -960,7 +955,6 @@ public abstract partial class TextBoxBase : Control
             Invalidate();
         }
     }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     [SRCategory(nameof(SR.CatPropertyChanged))]
     [SRDescription(nameof(SR.TextBoxBaseOnReadOnlyChangedDescr))]

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripRenderer.cs
@@ -69,9 +69,7 @@ public abstract class ToolStripRenderer
                 return s_disabledImageColorMatrix;
             }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             bool isDarkMode = Application.IsDarkModeEnabled;
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
             if (isDarkMode)
             {
@@ -1130,14 +1128,12 @@ public abstract class ToolStripRenderer
             if (Environment.OSVersion.Version >= new Version(10, 0, 22000)
                 && statusStrip.FindForm() is Form f)
             {
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
                 offset = f.FormCornerPreference switch
                 {
                     FormCornerPreference.Round => 4,
                     FormCornerPreference.RoundSmall => 3,
                     _ => 2
                 };
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             }
 
             return offset;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripSystemRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripSystemRenderer.cs
@@ -398,8 +398,8 @@ public class ToolStripSystemRenderer : ToolStripRenderer
     /// </summary>
     protected override void OnRenderButtonBackground(ToolStripItemRenderEventArgs e)
     {
-        // If system in high contrast mode and specific renderer override is defined, use that.
-        // For ToolStripSystemRenderer in High Contrast mode the RendererOverride property will be ToolStripHighContrastRenderer.
+        // If the user selected a contrast theme in the OS and a specific renderer-override is defined, use that.
+        // For ToolStripSystemRenderer in a contrast theme, the RendererOverride property will be ToolStripHighContrastRenderer.
         if (RendererOverride is not null)
         {
             base.OnRenderButtonBackground(e);
@@ -558,8 +558,8 @@ public class ToolStripSystemRenderer : ToolStripRenderer
     /// </summary>
     protected override void OnRenderSplitButtonBackground(ToolStripItemRenderEventArgs e)
     {
-        // If system in high contrast mode and specific renderer override is defined, use that.
-        // For ToolStripSystemRenderer in High Contrast mode the RendererOverride property will be ToolStripHighContrastRenderer.
+        // If the user selected a contrast theme in the OS and a specific renderer-override is defined, use that.
+        // For ToolStripSystemRenderer in a contrast theme, the RendererOverride property will be ToolStripHighContrastRenderer.
         if (RendererOverride is not null)
         {
             base.OnRenderSplitButtonBackground(e);

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripSystemRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripSystemRenderer.cs
@@ -70,12 +70,10 @@ public class ToolStripSystemRenderer : ToolStripRenderer
             }
 
             // Then check for dark mode
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             if (Application.IsDarkModeEnabled)
             {
                 return DarkModeRenderer;
             }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
             return null;
         }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolstripProfessionalRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolstripProfessionalRenderer.cs
@@ -297,10 +297,9 @@ public class ToolStripProfessionalRenderer : ToolStripRenderer
 
         if (buttonPressedOrSelected && !item.Pressed)
         {
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             using var brush = Application.IsDarkModeEnabled ?
                 Color.Silver.GetCachedSolidBrushScope() : ColorTable.ButtonSelectedBorder.GetCachedSolidBrushScope();
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
             g.FillRectangle(brush, item.SplitterBounds);
         }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TrackBar/TrackBar.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TrackBar/TrackBar.cs
@@ -144,9 +144,7 @@ public partial class TrackBar : Control, ISupportInitialize
     {
         get
         {
-#pragma warning disable WFO5001
             SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
 
             // If the user opts out of TrackBarModernRendering
             // then _autoDrawTicks will be set to true

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -291,7 +291,7 @@ public partial class TreeView : Control
 
                         // Reset the Checked state after setting the checkboxes (this was Everett behavior)
                         // The implementation of the TreeNode.Checked property has changed in Whidbey
-                        // So we need to explicit set the Checked state to false to keep the everett behavior.
+                        // So we need to explicit set the Checked state to false to keep the Everett behavior.
                         UpdateCheckedState(_root, false);
                         RecreateHandle();
                     }
@@ -304,15 +304,12 @@ public partial class TreeView : Control
     {
         get
         {
-#pragma warning disable WFO5001
             SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
 
             CreateParams cp = base.CreateParams;
             cp.ClassName = PInvoke.WC_TREEVIEW;
 
             // Keep the scrollbar if we are just updating styles...
-            //
             if (IsHandleCreated)
             {
                 int currentStyle = unchecked((int)((long)PInvokeCore.GetWindowLong(this, WINDOW_LONG_PTR_INDEX.GWL_STYLE)));
@@ -1882,7 +1879,7 @@ public partial class TreeView : Control
         }
 
         Color c = BackColor;
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
         if (c != SystemColors.Window || Application.IsDarkModeEnabled)
         {
             PInvokeCore.SendMessage(this, PInvoke.TVM_SETBKCOLOR, 0, c.ToWin32());
@@ -1894,7 +1891,6 @@ public partial class TreeView : Control
         {
             PInvokeCore.SendMessage(this, PInvoke.TVM_SETTEXTCOLOR, 0, c.ToWin32());
         }
-#pragma warning restore WFO5001
 
         // Put the LineColor into the native control only if set.
         if (_lineColor != Color.Empty)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.UpDownButtons.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.UpDownButtons.cs
@@ -264,7 +264,7 @@ public abstract partial class UpDownBase
         ///  Handles painting the buttons on the control.
         /// </summary>
         /// <param name="e">The paint event arguments.</param>
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
         protected override void OnPaint(PaintEventArgs e)
         {
             int half_height = ClientSize.Height / 2;
@@ -341,7 +341,6 @@ public abstract partial class UpDownBase
                     new Rectangle(0, half_height, _parent._defaultButtonsWidth, half_height),
                     HWNDInternal);
             }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
             if (half_height != (ClientSize.Height + 1) / 2)
             {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.cs
@@ -211,7 +211,6 @@ public abstract partial class UpDownBase : ContainerControl
     protected override AccessibleObject CreateAccessibilityInstance()
         => new UpDownBaseAccessibleObject(this);
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     protected override CreateParams CreateParams
     {
         get
@@ -237,7 +236,6 @@ public abstract partial class UpDownBase : ContainerControl
             return cp;
         }
     }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     /// <summary>
     ///  Deriving classes can override this to configure a default size for their control.

--- a/src/System.Windows.Forms/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Form.cs
@@ -6,7 +6,6 @@ using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Drawing;
 using System.Runtime.InteropServices;
-using System.Windows.Forms.Analyzers.Diagnostics;
 using System.Windows.Forms.Layout;
 using System.Windows.Forms.VisualStyles;
 using Windows.Win32.Graphics.Dwm;

--- a/src/System.Windows.Forms/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Form.cs
@@ -2261,7 +2261,6 @@ public partial class Form : ContainerControl
     [SRDescription(nameof(SR.FormCornerPreferenceDescr))]
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public FormCornerPreference FormCornerPreference
     {
         get => Properties.GetValueOrDefault(s_propFormCornerPreference, FormCornerPreference.Default);
@@ -2299,7 +2298,6 @@ public partial class Form : ContainerControl
     /// <param name="e">
     ///  An <see cref="EventArgs"/> that contains the event data, in this case empty.
     /// </param>
-    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     protected virtual void OnFormCornerPreferenceChanged(EventArgs e)
     {
         if (Events[s_formCornerPreferenceChanged] is EventHandler eventHandler)
@@ -2308,9 +2306,7 @@ public partial class Form : ContainerControl
         }
     }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     private unsafe void SetFormCornerPreferenceInternal(FormCornerPreference cornerPreference)
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     {
         DWM_WINDOW_CORNER_PREFERENCE dwmCornerPreference = cornerPreference switch
         {
@@ -2353,7 +2349,6 @@ public partial class Form : ContainerControl
     [SRDescription(nameof(SR.FormBorderColorDescr))]
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public Color FormBorderColor
     {
         get => Properties.GetValueOrDefault(s_propFormBorderColor, Color.Empty);
@@ -2381,7 +2376,6 @@ public partial class Form : ContainerControl
     /// <param name="e">
     ///  An <see cref="EventArgs"/> that contains the event data, in this case empty.
     /// </param>
-    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     protected virtual void OnFormBorderColorChanged(EventArgs e)
     {
         if (Events[s_formBorderColorChanged] is EventHandler eventHandler)
@@ -2415,7 +2409,6 @@ public partial class Form : ContainerControl
     [SRDescription(nameof(SR.FormCaptionBackColorDescr))]
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public Color FormCaptionBackColor
     {
         get => Properties.GetValueOrDefault(s_propFormCaptionBackColor, Color.Empty);
@@ -2444,7 +2437,6 @@ public partial class Form : ContainerControl
     /// <param name="e">
     ///  An <see cref="EventArgs"/> that contains the event data, in this case empty.
     /// </param>
-    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     protected virtual void OnFormCaptionBackColorChanged(EventArgs e)
     {
         if (Events[s_formCaptionBackColorChanged] is EventHandler eventHandler)
@@ -2478,7 +2470,6 @@ public partial class Form : ContainerControl
     [SRDescription(nameof(SR.FormCaptionTextColorDescr))]
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public Color FormCaptionTextColor
     {
         get => Properties.GetValueOrDefault(s_propFormCaptionTextColor, Color.Empty);
@@ -2507,7 +2498,6 @@ public partial class Form : ContainerControl
     /// <param name="e">
     ///  An <see cref="EventArgs"/> that contains the event data, in this case empty.
     /// </param>
-    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     protected virtual void OnFormCaptionTextColorChanged(EventArgs e)
     {
         if (Events[s_formCaptionTextColorChanged] is EventHandler eventHandler)
@@ -2686,7 +2676,6 @@ public partial class Form : ContainerControl
     /// </summary>
     [SRCategory(nameof(SR.CatAppearance))]
     [SRDescription(nameof(SR.FormBorderColorChangedDescr))]
-    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public event EventHandler? FormBorderColorChanged
     {
         add => Events.AddHandler(s_formBorderColorChanged, value);
@@ -2698,7 +2687,6 @@ public partial class Form : ContainerControl
     /// </summary>
     [SRCategory(nameof(SR.CatAppearance))]
     [SRDescription(nameof(SR.FormCaptionBackColorChangedDescr))]
-    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public event EventHandler? FormCaptionBackColorChanged
     {
         add => Events.AddHandler(s_formCaptionBackColorChanged, value);
@@ -2710,7 +2698,6 @@ public partial class Form : ContainerControl
     /// </summary>
     [SRCategory(nameof(SR.CatAppearance))]
     [SRDescription(nameof(SR.FormCaptionTextColorChangedDescr))]
-    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public event EventHandler? FormCaptionTextColorChanged
     {
         add => Events.AddHandler(s_formCaptionTextColorChanged, value);
@@ -2722,7 +2709,6 @@ public partial class Form : ContainerControl
     /// </summary>
     [SRCategory(nameof(SR.CatAppearance))]
     [SRDescription(nameof(SR.FormCornerPreferenceChangedDescr))]
-    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public event EventHandler? FormCornerPreferenceChanged
     {
         add => Events.AddHandler(s_formCornerPreferenceChanged, value);
@@ -4995,12 +4981,10 @@ public partial class Form : ContainerControl
                 SetFormAttributeColorInternal(DWMWINDOWATTRIBUTE.DWMWA_TEXT_COLOR, formCaptionTextColor.Value);
             }
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             if (Properties.TryGetValue(s_propFormCornerPreference, out FormCornerPreference? cornerPreference))
             {
                 SetFormCornerPreferenceInternal(cornerPreference.Value);
             }
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         }
     }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/FormCornerPreference.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/FormCornerPreference.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Windows.Forms.Analyzers.Diagnostics;
 using Windows.Win32.Graphics.Dwm;
 
 namespace System.Windows.Forms;
@@ -10,7 +9,6 @@ namespace System.Windows.Forms;
 ///  Specifies the corner preference for a <see cref="Form"/> which can be
 ///  set using the <see cref="Form.FormCornerPreference"/> property.
 /// </summary>
-[Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
 public enum FormCornerPreference
 {
     /// <summary>

--- a/src/System.Windows.Forms/System/Windows/Forms/MDI/MDIClient.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/MDI/MDIClient.cs
@@ -79,15 +79,13 @@ public sealed partial class MdiClient : Control
     {
         get
         {
-#pragma warning disable WFO5001
             SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
 
             CreateParams cp = base.CreateParams;
 
             cp.ClassName = "MDICLIENT";
 
-            // Note: Don't set the MDIS_ALLCHILDSTYLES CreatParams.Style bit, it prevents an MDI child form from getting
+            // Note: Don't set the MDIS_ALLCHILDSTYLES CreateParams.Style bit, it prevents an MDI child form from getting
             // activated when made visible (no WM_MDIACTIVATE sent to it), and forcing activation on it changes the
             // activation event sequence (MdiChildActivate/Enter/Focus/Activate/etc.).
             cp.Style |= (int)(WINDOW_STYLE.WS_VSCROLL | WINDOW_STYLE.WS_HSCROLL);

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint.cs
@@ -1870,7 +1870,6 @@ public static unsafe partial class ControlPaint
     public static void DrawScrollButton(Graphics graphics, Rectangle rectangle, ScrollButton button, ButtonState state)
         => DrawScrollButton(graphics, rectangle.X, rectangle.Y, rectangle.Width, rectangle.Height, button, state);
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     /// <summary>
     ///  Draws a button for a Win32 scroll bar in the given rectangle with the given state.
     /// </summary>

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint_ModernControlButtonRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint_ModernControlButtonRenderer.cs
@@ -14,7 +14,6 @@ public static unsafe partial class ControlPaint
     /// </summary>
     private const double ContentScaleFactor = 1.5;
 
-#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     /// <summary>
     ///  Draws a modern up/down button suitable for both light and dark modes.
     /// </summary>

--- a/src/System.Windows.Forms/System/Windows/Forms/Scrolling/ScrollBar.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Scrolling/ScrollBar.cs
@@ -114,9 +114,7 @@ public abstract partial class ScrollBar : Control
     {
         get
         {
-#pragma warning disable WFO5001
             SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
 
             CreateParams cp = base.CreateParams;
             cp.ClassName = PInvoke.WC_SCROLLBAR;

--- a/src/System.Windows.Forms/System/Windows/Forms/Scrolling/ScrollableControl.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Scrolling/ScrollableControl.cs
@@ -154,9 +154,7 @@ public partial class ScrollableControl : Control, IArrangedElement
     {
         get
         {
-#pragma warning disable WFO5001
             SetStyle(ControlStyles.ApplyThemingImplicitly, true);
-#pragma warning restore WFO5001
 
             CreateParams cp = base.CreateParams;
 

--- a/src/System.Windows.Forms/System/Windows/Forms/SystemColorMode.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/SystemColorMode.cs
@@ -1,11 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Windows.Forms.Analyzers.Diagnostics;
-
 namespace System.Windows.Forms;
 
-[Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
 public enum SystemColorMode
 {
     /// <summary>

--- a/src/test/integration/WinformsControlsTest/Program.cs
+++ b/src/test/integration/WinformsControlsTest/Program.cs
@@ -9,10 +9,7 @@ Thread.CurrentThread.SetApartmentState(ApartmentState.Unknown);
 Thread.CurrentThread.SetApartmentState(ApartmentState.STA);
 ApplicationConfiguration.Initialize();
 
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 Application.SetColorMode(SystemColorMode.Classic);
-#pragma warning restore WFO5001
-
 Application.SetUnhandledExceptionMode(UnhandledExceptionMode.ThrowException);
 Thread.CurrentThread.CurrentUICulture = Thread.CurrentThread.CurrentCulture;
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ApplicationTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ApplicationTests.cs
@@ -150,7 +150,7 @@ public class ApplicationTests
     }
 
 #pragma warning disable SYSLIB5002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
     [Fact]
     public void Application_SetColorMode_PlausibilityTests()
     {
@@ -177,7 +177,7 @@ public class ApplicationTests
         Assert.Equal(SystemColorMode.System, Application.ColorMode);
         Assert.False(SystemColors.UseAlternativeColorSet ^ systemColorMode == SystemColorMode.Dark);
     }
-#pragma warning restore WFO5001
+
 #pragma warning restore SYSLIB5002
 
     [WinFormsFact]


### PR DESCRIPTION
Fixes #13805 

* Removes the ExperimentalAttribute for all Dark Mode (SetColorMode) related APIs.
* Updates the docs for `Application.SetColorMode` to reflect latest developments.
* Removes #Pragma 5001

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13810)