### PR TITLE
fix #13813 : Dark Mode: The ForeColor & BackColor properties are not working for the controls

### DIFF
--- a/src/System.Windows.Forms/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
+override System.Windows.Forms.ButtonBase.OnBackColorChanged(System.EventArgs! e) -> void
+override System.Windows.Forms.ButtonBase.OnForeColorChanged(System.EventArgs! e) -> void
 static System.Windows.Forms.Application.SetColorMode(System.Windows.Forms.SystemColorMode systemColorMode) -> void
 static System.Windows.Forms.TaskDialog.ShowDialogAsync(nint hwndOwner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
 static System.Windows.Forms.TaskDialog.ShowDialogAsync(System.Windows.Forms.IWin32Window! owner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/Button.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/Button.cs
@@ -170,6 +170,8 @@ public partial class Button : ButtonBase, IButtonControl
                 // ...the user wants to opt out of implicit DarkMode rendering.
                 && DarkModeRequestState is true
 
+                && !ForeColorSet
+                && !BackColorSet
                 // And all of this only counts for FlatStyle.Standard. For the
                 // rest, we're using specific renderers anyway, which check
                 // themselves on demand, if they need to apply Light- or DarkMode.

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/Button.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/Button.cs
@@ -170,8 +170,6 @@ public partial class Button : ButtonBase, IButtonControl
                 // ...the user wants to opt out of implicit DarkMode rendering.
                 && DarkModeRequestState is true
 
-                && !ForeColorSet
-                && !BackColorSet
                 // And all of this only counts for FlatStyle.Standard. For the
                 // rest, we're using specific renderers anyway, which check
                 // themselves on demand, if they need to apply Light- or DarkMode.

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonBase.cs
@@ -1202,6 +1202,23 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
         base.OnKeyDown(kevent);
     }
 
+    internal bool BackColorSet { get; set; }
+    internal bool ForeColorSet { get; set; }
+
+    protected override void OnForeColorChanged(EventArgs e)
+    {
+        base.OnForeColorChanged(e);
+        ForeColorSet = ShouldSerializeForeColor();
+        UpdateOwnerDraw();
+    }
+
+    protected override void OnBackColorChanged(EventArgs e)
+    {
+        base.OnBackColorChanged(e);
+        BackColorSet = ShouldSerializeBackColor();
+        UpdateOwnerDraw();
+    }
+
     /// <summary>
     ///  Raises the <see cref="OnKeyUp"/> event.
     /// </summary>

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/ButtonDarkModeAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/ButtonDarkModeAdapter.cs
@@ -93,7 +93,7 @@ internal class ButtonDarkModeAdapter : ButtonBaseAdapter
                 Control.Parent?.BackColor ?? Control.BackColor,
                 GetButtonBackColor(pushButtonState),
                 _ => PaintImage(e, layout),
-                (_, textColor1, drawFocus) => PaintField(
+                () => PaintField(
                     e,
                     layout,
                     PaintDarkModeRender(e).Calculate(),
@@ -131,7 +131,7 @@ internal class ButtonDarkModeAdapter : ButtonBaseAdapter
                 Control.Parent?.BackColor ?? Control.BackColor,
                 GetButtonBackColor(PushButtonState.Pressed),
                 _ => PaintImage(e, layout),
-                (_, textColor, drawFocus) => PaintField(
+                () => PaintField(
                     e,
                     layout,
                     PaintDarkModeRender(e).Calculate(),
@@ -169,7 +169,7 @@ internal class ButtonDarkModeAdapter : ButtonBaseAdapter
                 Control.Parent?.BackColor ?? Control.BackColor,
                 GetButtonBackColor(PushButtonState.Hot),
                 _ => PaintImage(e, layout),
-                (_, textColor, drawFocus) => PaintField(
+                () => PaintField(
                     e,
                     layout,
                     PaintDarkModeRender(e).Calculate(),

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/ButtonDarkModeAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/ButtonDarkModeAdapter.cs
@@ -25,6 +25,51 @@ internal class ButtonDarkModeAdapter : ButtonBaseAdapter
     private ButtonDarkModeRendererBase ButtonDarkModeRenderer =>
         _buttonDarkModeRenderer;
 
+    private Color GetButtonTextColor(IDeviceContext deviceContext, PushButtonState state)
+    {
+        Color textColor;
+
+        if (Control.ForeColorSet)
+        {
+            textColor = new ColorOptions(deviceContext, Control.ForeColor, Control.BackColor)
+            {
+                Enabled = Control.Enabled
+            }.Calculate().WindowText;
+
+            if (IsHighContrastHighlighted())
+            {
+                textColor = SystemColors.HighlightText;
+            }
+        }
+        else
+        {
+            textColor = ButtonDarkModeRenderer.GetTextColor(state, Control.IsDefault);
+        }
+
+        return textColor;
+    }
+
+    private Color GetButtonBackColor(PushButtonState state)
+    {
+        Color textColor;
+
+        if (Control.BackColorSet)
+        {
+            textColor = Control.BackColor;
+
+            if (IsHighContrastHighlighted())
+            {
+                textColor = SystemColors.HighlightText;
+            }
+        }
+        else
+        {
+            textColor = ButtonDarkModeRenderer.GetBackgroundColor(state, Control.IsDefault);
+        }
+
+        return textColor;
+    }
+
     internal override void PaintUp(PaintEventArgs e, CheckState state)
     {
         try
@@ -36,21 +81,23 @@ internal class ButtonDarkModeAdapter : ButtonBaseAdapter
 
             LayoutData layout = CommonLayout().Layout();
 
+            PushButtonState pushButtonState = ToPushButtonState(state, Control.Enabled);
             ButtonDarkModeRenderer.RenderButton(
                 g,
                 Control.ClientRectangle,
                 Control.FlatStyle,
-                ToPushButtonState(state, Control.Enabled),
+                pushButtonState,
                 Control.IsDefault,
                 Control.Focused,
                 Control.ShowFocusCues,
                 Control.Parent?.BackColor ?? Control.BackColor,
+                GetButtonBackColor(pushButtonState),
                 _ => PaintImage(e, layout),
-                (_, textColor, drawFocus) => PaintField(
+                (_, textColor1, drawFocus) => PaintField(
                     e,
                     layout,
                     PaintDarkModeRender(e).Calculate(),
-                    textColor,
+                    GetButtonTextColor(e, pushButtonState),
                     drawFocus: false)
             );
 
@@ -82,12 +129,13 @@ internal class ButtonDarkModeAdapter : ButtonBaseAdapter
                 Control.Focused,
                 Control.ShowFocusCues,
                 Control.Parent?.BackColor ?? Control.BackColor,
+                GetButtonBackColor(PushButtonState.Pressed),
                 _ => PaintImage(e, layout),
                 (_, textColor, drawFocus) => PaintField(
                     e,
                     layout,
                     PaintDarkModeRender(e).Calculate(),
-                    textColor,
+                    GetButtonTextColor(e, PushButtonState.Pressed),
                     drawFocus: false)
             );
 
@@ -119,12 +167,13 @@ internal class ButtonDarkModeAdapter : ButtonBaseAdapter
                 Control.Focused,
                 Control.ShowFocusCues,
                 Control.Parent?.BackColor ?? Control.BackColor,
+                GetButtonBackColor(PushButtonState.Hot),
                 _ => PaintImage(e, layout),
                 (_, textColor, drawFocus) => PaintField(
                     e,
                     layout,
                     PaintDarkModeRender(e).Calculate(),
-                    textColor,
+                    GetButtonTextColor(e, PushButtonState.Hot),
                     drawFocus: false)
             );
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/ButtonDarkModeRendererBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/ButtonDarkModeRendererBase.cs
@@ -37,6 +37,7 @@ internal abstract partial class ButtonDarkModeRendererBase : IButtonRenderer
         bool focused,
         bool showFocusCues,
         Color parentBackgroundColor,
+        Color backColor,
         Action<Rectangle> paintImage,
         Action<Rectangle, Color, bool> paintField)
     {
@@ -60,7 +61,7 @@ internal abstract partial class ButtonDarkModeRendererBase : IButtonRenderer
                 height: bounds.Height - padding.Vertical);
 
             // Draw button background and get content bounds
-            Rectangle contentBounds = DrawButtonBackground(graphics, paddedBounds, state, isDefault);
+            Rectangle contentBounds = DrawButtonBackground(graphics, paddedBounds, state, isDefault, backColor);
 
             // Paint image and field using the provided delegates
             paintImage(contentBounds);
@@ -78,9 +79,11 @@ internal abstract partial class ButtonDarkModeRendererBase : IButtonRenderer
         }
     }
 
-    public abstract Rectangle DrawButtonBackground(Graphics graphics, Rectangle bounds, PushButtonState state, bool isDefault);
+    public abstract Rectangle DrawButtonBackground(Graphics graphics, Rectangle bounds, PushButtonState state, bool isDefault, Color backColor);
 
     public abstract void DrawFocusIndicator(Graphics graphics, Rectangle contentBounds, bool isDefault);
 
     public abstract Color GetTextColor(PushButtonState state, bool isDefault);
+
+    public abstract Color GetBackgroundColor(PushButtonState state, bool isDefault);
 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/ButtonDarkModeRendererBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/ButtonDarkModeRendererBase.cs
@@ -39,7 +39,7 @@ internal abstract partial class ButtonDarkModeRendererBase : IButtonRenderer
         Color parentBackgroundColor,
         Color backColor,
         Action<Rectangle> paintImage,
-        Action<Rectangle, Color, bool> paintField)
+        Action paintField)
     {
         ArgumentNullException.ThrowIfNull(graphics);
         ArgumentNullException.ThrowIfNull(paintImage);
@@ -66,10 +66,7 @@ internal abstract partial class ButtonDarkModeRendererBase : IButtonRenderer
             // Paint image and field using the provided delegates
             paintImage(contentBounds);
 
-            paintField(
-                contentBounds,
-                GetTextColor(state, isDefault),
-                false);
+            paintField();
 
             if (focused && showFocusCues)
             {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/FlatButtonDarkModeRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/FlatButtonDarkModeRenderer.cs
@@ -23,10 +23,10 @@ internal sealed class FlatButtonDarkModeRenderer : ButtonDarkModeRendererBase
     private protected override Padding PaddingCore { get; } = new(0);
 
     public override Rectangle DrawButtonBackground(
-        Graphics graphics, Rectangle bounds, PushButtonState state, bool isDefault)
+        Graphics graphics, Rectangle bounds, PushButtonState state, bool isDefault, Color backColor)
     {
         // fill background
-        using var back = GetBackgroundColor(state, isDefault).GetCachedSolidBrushScope();
+        using var back = backColor.GetCachedSolidBrushScope();
         graphics.FillRectangle(back, bounds);
 
         // draw border identical to Win32
@@ -58,7 +58,7 @@ internal sealed class FlatButtonDarkModeRenderer : ButtonDarkModeRendererBase
                 ? DefaultColors.AcceptButtonTextColor
                 : DefaultColors.NormalTextColor;
 
-    private static Color GetBackgroundColor(PushButtonState state, bool isDefault) =>
+    public override Color GetBackgroundColor(PushButtonState state, bool isDefault) =>
         isDefault
             ? state switch
             {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/IButtonRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/IButtonRenderer.cs
@@ -50,7 +50,7 @@ internal partial interface IButtonRenderer
         Color parentBackgroundColor,
         Color backColor,
         Action<Rectangle> paintImage,
-        Action<Rectangle, Color, bool> paintField);
+        Action paintField);
 
     /// <summary>
     ///  Draws button background with appropriate styling.

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/IButtonRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/IButtonRenderer.cs
@@ -48,6 +48,7 @@ internal partial interface IButtonRenderer
         bool focused,
         bool showFocusCues,
         Color parentBackgroundColor,
+        Color backColor,
         Action<Rectangle> paintImage,
         Action<Rectangle, Color, bool> paintField);
 
@@ -59,7 +60,7 @@ internal partial interface IButtonRenderer
     /// <param name="state">State of the button (normal, hot, pressed, disabled)</param>
     /// <param name="isDefault">True if button is the default button</param>
     /// <returns>The content bounds (area inside the button for text/image)</returns>
-    Rectangle DrawButtonBackground(Graphics graphics, Rectangle bounds, PushButtonState state, bool isDefault);
+    Rectangle DrawButtonBackground(Graphics graphics, Rectangle bounds, PushButtonState state, bool isDefault, Color backColor);
 
     /// <summary>
     ///  Draws focus indicator appropriate for this style.

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/PopupButtonDarkModeRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/PopupButtonDarkModeRenderer.cs
@@ -30,7 +30,7 @@ internal class PopupButtonDarkModeRenderer : ButtonDarkModeRendererBase
     /// <summary>
     ///  Draws button background with popup styling, including subtle 3D effect.
     /// </summary>
-    public override Rectangle DrawButtonBackground(Graphics graphics, Rectangle bounds, PushButtonState state, bool isDefault)
+    public override Rectangle DrawButtonBackground(Graphics graphics, Rectangle bounds, PushButtonState state, bool isDefault, Color backColor)
     {
         // Use padding from ButtonDarkModeRenderer
         Padding padding = PaddingCore;
@@ -44,9 +44,6 @@ internal class PopupButtonDarkModeRenderer : ButtonDarkModeRendererBase
         {
             contentBounds.Offset(ContentOffset, ContentOffset);
         }
-
-        // Get appropriate background color based on state
-        Color backColor = GetBackgroundColor(state, isDefault);
 
         // Create path for rounded corners
         using GraphicsPath path = CreateRoundedRectanglePath(paddedBounds, ButtonCornerRadius);
@@ -101,7 +98,7 @@ internal class PopupButtonDarkModeRenderer : ButtonDarkModeRendererBase
     /// <summary>
     ///  Gets the background color appropriate for the button state and type.
     /// </summary>
-    private static Color GetBackgroundColor(PushButtonState state, bool isDefault) =>
+    public override Color GetBackgroundColor(PushButtonState state, bool isDefault) =>
         isDefault
             ? state switch
             {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/SystemButtonDarkModeRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/SystemButtonDarkModeRenderer.cs
@@ -30,15 +30,12 @@ internal class SystemButtonDarkModeRenderer : ButtonDarkModeRendererBase
     /// <summary>
     ///  Draws button background with system styling (larger rounded corners).
     /// </summary>
-    public override Rectangle DrawButtonBackground(Graphics graphics, Rectangle bounds, PushButtonState state, bool isDefault)
+    public override Rectangle DrawButtonBackground(Graphics graphics, Rectangle bounds, PushButtonState state, bool isDefault, Color backColor)
     {
         // Shrink for DarkBorderGap and FocusBorderThickness
         Rectangle fillBounds = Rectangle.Inflate(bounds, -SystemStylePadding, -SystemStylePadding);
 
         using GraphicsPath fillPath = CreateRoundedRectanglePath(fillBounds, CornerRadius - DarkBorderGapThickness);
-
-        // Get appropriate background color based on state
-        Color backColor = GetBackgroundColor(state, isDefault);
 
         // Fill the background using cached brush
         using var brush = backColor.GetCachedSolidBrushScope();
@@ -82,7 +79,7 @@ internal class SystemButtonDarkModeRenderer : ButtonDarkModeRendererBase
     /// <summary>
     ///  Gets the background color appropriate for the button state and type.
     /// </summary>
-    private static Color GetBackgroundColor(PushButtonState state, bool isDefault) =>
+    public override Color GetBackgroundColor(PushButtonState state, bool isDefault) =>
         // For default button in System style, use a darker version of the background color
         isDefault
             ? state switch
@@ -114,7 +111,7 @@ internal class SystemButtonDarkModeRenderer : ButtonDarkModeRendererBase
     /// <summary>
     ///  Draws the button border based on the current state, using anti-aliasing and an additional inner border.
     /// </summary>
-    public static void DrawButtonBorder(
+    public void DrawButtonBorder(
         Graphics graphics,
         Rectangle bounds,
         PushButtonState state,


### PR DESCRIPTION
Fixes #13813

## Proposed changes

Add code to see if BackColor or ForeColor is specified in dark mode, if so then use the specified color, if not then let the renderer decide the color.  

<!-- 

## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-

 -->

## Screenshots 

### Before

<img width="589" height="574" alt="image" src="https://github.com/user-attachments/assets/b5c2281e-937f-4e44-8841-552d22fceed7" />


### After
<img width="590" height="571" alt="image" src="https://github.com/user-attachments/assets/9604e7ce-1d69-4b63-a0e1-b57938f9752d" />

<!-- 


## Test methodology 

- 
- 
- 

## Accessibility testing  



## Test environment(s) 

-->
