### PR TITLE
Scale the Cursor editor according to DPI

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/CursorEditor.CursorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/CursorEditor.CursorUI.cs
@@ -19,7 +19,8 @@ public partial class CursorEditor
 
         public CursorUI()
         {
-            Height = 310;
+            Height = ScaleHelper.IsScalingRequired ? ScaleHelper.ScaleToInitialSystemDpi(310) : 310;
+
             ItemHeight = Math.Max(4 + Cursors.Default.Size.Height, Font.Height);
             DrawMode = DrawMode.OwnerDrawFixed;
             BorderStyle = BorderStyle.None;
@@ -64,13 +65,14 @@ public partial class CursorEditor
                 string? text = _cursorConverter.ConvertToString(cursor);
                 Font font = e.Font!;
                 using var brushText = e.ForeColor.GetCachedSolidBrushScope();
+                var cursorWidth = ScaleHelper.ScaleSmallIconToDpi(Icon.FromHandle(cursor.Handle), DeviceDpi).Size.Width;
 
                 e.DrawBackground();
-                e.Graphics.FillRectangle(SystemBrushes.Control, new Rectangle(e.Bounds.X + 2, e.Bounds.Y + 2, 32, e.Bounds.Height - 4));
-                e.Graphics.DrawRectangle(SystemPens.WindowText, new Rectangle(e.Bounds.X + 2, e.Bounds.Y + 2, 32 - 1, e.Bounds.Height - 4 - 1));
+                e.Graphics.FillRectangle(SystemBrushes.Control, new Rectangle(e.Bounds.X + 2, e.Bounds.Y + 2, cursorWidth, e.Bounds.Height - 4));
+                e.Graphics.DrawRectangle(SystemPens.WindowText, new Rectangle(e.Bounds.X + 2, e.Bounds.Y + 2, cursorWidth - 1, e.Bounds.Height - 4 - 1));
 
-                cursor.DrawStretched(e.Graphics, new Rectangle(e.Bounds.X + 2, e.Bounds.Y + 2, 32, e.Bounds.Height - 4));
-                e.Graphics.DrawString(text, font, brushText, e.Bounds.X + 36, e.Bounds.Y + (e.Bounds.Height - font.Height) / 2);
+                cursor.DrawStretched(e.Graphics, new Rectangle(e.Bounds.X + 2, e.Bounds.Y + 2, cursorWidth, e.Bounds.Height - 4));
+                e.Graphics.DrawString(text, font, brushText, e.Bounds.X + cursorWidth + 4, e.Bounds.Y + (e.Bounds.Height - font.Height) / 2);
             }
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9007


## Proposed changes

- Scale the Cursor Editor's Height as needed.
- Update the `OnDrawItem` method to draw the cursor using the scaled width instead of hard-coding it.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- On High DPI environment, cursor editor in propertyGrid can be scaled well

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
On High DPI environment, cursor editor in propertyGrid is not scaled well
![image](https://user-images.githubusercontent.com/26474449/233241549-b9a1d277-74cd-4448-95fb-6b011605cd63.png)

### After
On High DPI environment, cursor editor in propertyGrid can be scaled normally
<img width="2274" height="1329" alt="image" src="https://github.com/user-attachments/assets/8a39aff8-06ae-445d-9e40-ad1e0e6727ec" />

## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-rc.1.25418.105


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13830)