### PR TITLE
Fix 12571 "DisplayMember" property cannot expand

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataMemberFieldEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataMemberFieldEditor.cs
@@ -27,12 +27,6 @@ internal class DataMemberFieldEditor : UITypeEditor
         }
 
         object? dataSource = property.GetValue(instance);
-
-        if (dataSource is null )
-        {
-            return value;
-        }
-
         _designBindingPicker ??= new();
 
         DesignBinding oldSelection = new DesignBinding(dataSource, (string?)value);
@@ -47,12 +41,7 @@ internal class DataMemberFieldEditor : UITypeEditor
             initialSelectedItem: oldSelection
         );
 
-        if (newSelection is null)
-        {
-            return value;
-        }
-
-        return newSelection.DataMember;
+        return dataSource is null || newSelection is null ? value : newSelection.DataMember;
     }
 
     public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext? context) => UITypeEditorEditStyle.DropDown;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12571


## Proposed changes

- When DataSource is null, do not return value immediately but return after the `designBindingPicker` is created.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The dropdown list of the `DisplayMember` property of the `PropertyGrid` can be expanded when DataSource is null

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
There no "Open" button for the "DiaplayMember" property and cannot not expand the dropdown list in the PropertyGrid control

![Image](https://github.com/user-attachments/assets/37f2a1b7-602e-4c0a-b8fe-6421ebe08f23)


### After
The dropdown list of the `DisplayMember` property can be expanded when DataSource is null

https://github.com/user-attachments/assets/5016f6e7-3f1f-4616-8bd0-b34cd2edfdb9


## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-beta.25418.105


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13833)