### PR TITLE
Fix Control.Dispose crash when dependent UserControl fails to load due to missing assembly

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Control.cs
@@ -4790,7 +4790,7 @@ public unsafe partial class Control :
         }
 
         // Unsubscribes from the Disposed event of the ContextMenuStrip.
-        if (ContextMenuStrip is ContextMenuStrip menu)
+        if (Properties?.TryGetValue(s_contextMenuStripProperty, out ContextMenuStrip? menu) == true)
         {
             menu.Disposed -= DetachContextMenuStrip;
         }
@@ -4816,10 +4816,10 @@ public unsafe partial class Control :
             SuspendLayout();
             try
             {
-                Properties.RemoveValue(s_ncAccessibilityProperty);
+                Properties?.RemoveValue(s_ncAccessibilityProperty);
 
                 DisposeAxControls();
-                Properties.GetValueOrDefault<ActiveXImpl>(s_activeXImplProperty)?.Dispose();
+                Properties?.GetValueOrDefault<ActiveXImpl>(s_activeXImplProperty)?.Dispose();
 
                 ResetBindings();
 


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13835

## Root Cause

When a control (e.g., MainObject) references another control (ExternalObject) from a separate assembly (ExternalAsm), and that assembly is missing at runtime, the constructor of MainObject fails. However, the .NET runtime still attempts to call `Dispose()` on the partially constructed control. Inside `Control.Dispose`, accessing `ContextMenuStrip` triggers a `NullReferenceException` because `Properties` is not initialized.

## Proposed changes

- Added a defensive null check around `ContextMenuStrip` access in `Control.Dispose()`
- Replaced direct property access with `Properties?.TryGetValue(...)` to ensure safe event unsubscription

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- This change ensures that `Control.Dispose()` can safely execute even when the control was never fully constructed.

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Run the attached project [net10Issue.zip](https://github.com/user-attachments/files/22095433/net10Issue.zip) using .NET 10 framework, crash with Exception thrown: 'System.NullReferenceException' in System.Windows.Forms.dll


https://github.com/user-attachments/assets/a7b5e494-0e72-48cb-944a-5b9c580f5fd6


### After

App exits successfully.

https://github.com/user-attachments/assets/1fe967cd-f68a-4897-b4e3-7990c010957a


## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-rc.1.25420.121


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13840)