### PR TITLE
Switch test runner to global.json

### DIFF
--- a/dotnet.config
+++ b/dotnet.config
@@ -1,2 +1,0 @@
-[dotnet.test.runner]
-name = "Microsoft.Testing.Platform"

--- a/global.json
+++ b/global.json
@@ -20,6 +20,9 @@
       ]
     }
   },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.25457.103",
     "Microsoft.DotNet.CMake.Sdk": "11.0.0-beta.25457.103",


### PR DESCRIPTION
If https://github.com/dotnet/sdk/pull/50673 gets merged, the insertion of SDK with that change will require the change in this PR.

FYI @LeafShi1 @JeremyKuhne