### PR TITLE
Makes PropertyGrid for CoboBox show "(none)" when DataSource is null …

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataSourceConverter.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataSourceConverter.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+using System.Globalization;
+
+namespace System.Windows.Forms.Design;
+
+internal class DataSourceConverter : ReferenceConverter
+{
+    public DataSourceConverter() : base(typeof(IListSource))
+    {
+    }
+
+    public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
+    {
+        if (destinationType == typeof(string) && value is null)
+        {
+            return SR.None_lc.ToString();
+        }
+
+        return base.ConvertTo(context, culture, value, destinationType);
+    }
+}

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataSourceConverterTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataSourceConverterTests.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.Design.Tests;
+
+public class DataSourceConverterTests
+{
+    private readonly DataSourceConverter _converter = new();
+
+    [Fact]
+    public void ConvertTo_NullValueToString_ReturnsNoneLowercase() =>
+        (_converter.ConvertTo(context: null, culture: null, value: null, destinationType: typeof(string)) as string).Should().Be("(none)");
+
+    [Fact]
+    public void ConvertTo_NonNullValueToString_CallsBase() =>
+        _converter.ConvertTo(context: null, culture: null, value: new(), destinationType: typeof(string)).Should().NotBe("(none)");
+
+    [Fact]
+    public void ConvertTo_NullValueToNonString_ThrowsNotSupportedException()
+    {
+        Action act = () => _converter.ConvertTo(context: null, culture: null, value: null, destinationType: typeof(int));
+
+        act.Should().Throw<NotSupportedException>();
+    }
+
+    [Theory]
+    [InlineData("en-US")]
+    [InlineData("fr-FR")]
+    [InlineData("de-DE")]
+    public void ConvertTo_NullValueWithDifferentCultures_ReturnsNoneLowercase(string cultureName) =>
+        (_converter.ConvertTo(context: null, culture: new(cultureName), value: null, destinationType: typeof(string)) as string).Should().Be("(none)");
+}

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListControl/ListControl.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListControl/ListControl.cs
@@ -44,6 +44,7 @@ public abstract class ListControl : Control
     [RefreshProperties(RefreshProperties.Repaint)]
     [AttributeProvider(typeof(IListSource))]
     [SRDescription(nameof(SR.ListControlDataSourceDescr))]
+    [TypeConverter("System.Windows.Forms.Design.DataSourceConverter, System.Windows.Forms.Design")]
     public object? DataSource
     {
         get => _dataSource;


### PR DESCRIPTION
Fixes #12570

## Root Cause

The `ComboBox.DataSource` property was missing a `TypeConverter` to handle null value display in `PropertyGrid`. When `DataSource` is null, `PropertyGrid` shows empty/blank instead of "(none)" text, breaking consistency with .NET Framework behavior and other similar properties like `DisplayMember` and `ValueMember`.

## Proposed changes

- Created `DataSourceConverter` class that inherits from `ReferenceConverter` and converts null values to "(none)" for string display
- Applied `TypeConverter` attribute to `ComboBox.DataSource` property to use the new converter
- Added comprehensive unit tests to verify converter behavior across different cultures and scenarios

## Customer Impact

Restores .NET Framework parity for PropertyGrid display. Developers using `PropertyGrid` to inspect `ComboBox` properties will now see consistent "(none)" text when `DataSource` is null, improving design-time experience.

## Regression?

No. This is a missing feature/behavior that existed in .NET Framework but was lost in .NET Core migration.

## Risk

Minimal.

## Screenshots

### Before
<img width="377" height="477" alt="before" src="https://github.com/user-attachments/assets/7560f3e8-35c3-49f3-9f32-6b45469e820c" />

### After  
<img width="374" height="470" alt="after" src="https://github.com/user-attachments/assets/83a3d5a0-549f-482a-af8e-d6e5f13ce945" />

## Test methodology

- Unit tests for `DataSourceConverter` covering null conversion, culture handling, and edge cases
- Manual testing with `PropertyGrid` and `ComboBox` to verify "(none)" display

## Test environment(s)

- 10.0.100-alpha.1.24573.1

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13860)