### PR TITLE
fix #13861 The custom ForeColor set on PrintPreviewControl is not rendered correctly

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -592,7 +592,7 @@ public partial class PrintPreviewControl : Control
 
     private void DrawMessage(Graphics g, Rectangle rect, bool isExceptionPrinting)
     {
-        Color brushColor = SystemColors.ControlText;
+        Color brushColor = ShouldSerializeForeColor() ? ForeColor : SystemColors.ControlText;
         if (SystemInformation.HighContrast && Parent is Control parent)
         {
             brushColor = parent.BackColor;

--- a/src/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -592,6 +592,7 @@ public partial class PrintPreviewControl : Control
 
     private void DrawMessage(Graphics g, Rectangle rect, bool isExceptionPrinting)
     {
+        // fix issue #13861 caused by pr #12368
         Color brushColor = ShouldSerializeForeColor() ? ForeColor : SystemColors.ControlText;
         if (SystemInformation.HighContrast && Parent is Control parent)
         {

--- a/src/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -592,7 +592,6 @@ public partial class PrintPreviewControl : Control
 
     private void DrawMessage(Graphics g, Rectangle rect, bool isExceptionPrinting)
     {
-        // fix issue #13861 caused by pr #12368
         Color brushColor = ShouldSerializeForeColor() ? ForeColor : SystemColors.ControlText;
         if (SystemInformation.HighContrast && Parent is Control parent)
         {


### PR DESCRIPTION
Fixes #13861 


## Proposed changes

-
- [pr #12368](https://github.com/dotnet/winforms/pull/12368) is to fix the High Contrast issue but omitted the case that a custom color is set.
- if ForeColor is set then use that color
- 

<!-- 

## Customer Impact

- 
- 

## Regression? 

- Yes / No
 -->
## Risk

- low




## Screenshots 

### Before

<img width="297" height="446" alt="image" src="https://github.com/user-attachments/assets/289be94d-f8d1-46bf-8d32-acb9539b61f0" />

### After

<img width="294" height="462" alt="image" src="https://github.com/user-attachments/assets/73c20cd7-482c-48aa-9686-cc2a7825c793" />


## Test methodology 

- 
- manual
- 

 <!-- 

## Test environment(s) 




 -->
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13863)