### PR TITLE
[release/10.0] Fix 13829 Dark Mode: Button ForeColor ignored in Dark Mode when FlatStyle is Flat/Popup and Form.ForeColor Is set

### DIFF
--- a/src/System.Windows.Forms/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/PublicAPI.Unshipped.txt
@@ -1,5 +1,3 @@
-override System.Windows.Forms.ButtonBase.OnBackColorChanged(System.EventArgs! e) -> void
-override System.Windows.Forms.ButtonBase.OnForeColorChanged(System.EventArgs! e) -> void
 static System.Windows.Forms.Application.SetColorMode(System.Windows.Forms.SystemColorMode systemColorMode) -> void
 static System.Windows.Forms.TaskDialog.ShowDialogAsync(nint hwndOwner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
 static System.Windows.Forms.TaskDialog.ShowDialogAsync(System.Windows.Forms.IWin32Window! owner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonBase.cs
@@ -1202,30 +1202,6 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
         base.OnKeyDown(kevent);
     }
 
-    // These two properties are mainly used for ButtonDarkModeAdapter.
-    internal bool BackColorSet { get; set; }
-    internal bool ForeColorSet { get; set; }
-
-    protected override void OnForeColorChanged(EventArgs e)
-    {
-        base.OnForeColorChanged(e);
-        if (Application.IsDarkModeEnabled)
-        {
-            ForeColorSet = ShouldSerializeForeColor();
-            UpdateOwnerDraw();
-        }
-    }
-
-    protected override void OnBackColorChanged(EventArgs e)
-    {
-        base.OnBackColorChanged(e);
-        if (Application.IsDarkModeEnabled)
-        {
-            BackColorSet = ShouldSerializeBackColor();
-            UpdateOwnerDraw();
-        }
-    }
-
     /// <summary>
     ///  Raises the <see cref="OnKeyUp"/> event.
     /// </summary>

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/ButtonDarkModeAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/ButtonDarkModeAdapter.cs
@@ -29,7 +29,7 @@ internal class ButtonDarkModeAdapter : ButtonBaseAdapter
     {
         Color textColor;
 
-        if (Control.ForeColorSet)
+        if (Control.ForeColor != Forms.Control.DefaultForeColor)
         {
             textColor = new ColorOptions(deviceContext, Control.ForeColor, Control.BackColor)
             {
@@ -51,23 +51,23 @@ internal class ButtonDarkModeAdapter : ButtonBaseAdapter
 
     private Color GetButtonBackColor(PushButtonState state)
     {
-        Color textColor;
+        Color backColor;
 
-        if (Control.BackColorSet)
+        if (Control.BackColor != Forms.Control.DefaultBackColor)
         {
-            textColor = Control.BackColor;
+            backColor = Control.BackColor;
 
             if (IsHighContrastHighlighted())
             {
-                textColor = SystemColors.HighlightText;
+                backColor = SystemColors.HighlightText;
             }
         }
         else
         {
-            textColor = ButtonDarkModeRenderer.GetBackgroundColor(state, Control.IsDefault);
+            backColor = ButtonDarkModeRenderer.GetBackgroundColor(state, Control.IsDefault);
         }
 
-        return textColor;
+        return backColor;
     }
 
     internal override void PaintUp(PaintEventArgs e, CheckState state)


### PR DESCRIPTION
/backport [PR13834](https://github.com/dotnet/winforms/pull/13834) to release/10.0

Fixes #13829 

## Proposed changes

- 
- Remove BackColorSet, ForeColorSet. use DefaultForeColor,DefaultBackColor to decide whether we should use ButtonBase.BackColor or ButtonBase.ForeColor
- 

<!-- 

## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-

 -->


## Screenshots 
<!-- 
### Before
 -->


### After

<img width="569" height="316" alt="image" src="https://github.com/user-attachments/assets/a13b5cb6-5cca-40f7-9b11-e3b83095c48e" />
<img width="506" height="233" alt="image" src="https://github.com/user-attachments/assets/1ee0f2f9-5be3-46b7-8e39-3adb17e4010d" />
<img width="505" height="243" alt="image" src="https://github.com/user-attachments/assets/f9f043d2-91ff-407d-b240-03fc6d140c59" />
<img width="495" height="236" alt="image" src="https://github.com/user-attachments/assets/918395d0-711e-47fa-a760-db1f8389a19a" />


## Test methodology 

- 
- manual
- 
<!--
## Accessibility testing  


 ## Test environment(s) 
 -->
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13864)