### PR TITLE
fix #13873 [DarkMode]: TabControl doesn't render tab titles correctly when SizeMode = Fixed

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabControl.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabControl.cs
@@ -767,7 +767,18 @@ public partial class TabControl : Control
             SourceGenerated.EnumValidator.Validate(value);
 
             _sizeMode = value;
-            RecreateHandle();
+
+            if (Application.IsDarkModeEnabled)
+            {
+                if (IsHandleCreated)
+                {
+                    RecreateHandle();
+                }
+            }
+            else
+            {
+                RecreateHandle();
+            }
         }
     }
 


### PR DESCRIPTION


Fixes #13873 


## Proposed changes

- 
- when TabSizeMode is set and if it's dark mode and handle is created then RecreateHandle
- 

<!-- 

## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-

 -->


## Screenshots 

### Before

<img width="316" height="205" alt="image" src="https://github.com/user-attachments/assets/54252c26-d759-442d-9d74-6faa79395191" />


### After

<img width="294" height="235" alt="image" src="https://github.com/user-attachments/assets/4cade051-17a9-4f39-9f37-898423a8d61c" />


## Test methodology 

- 
- manual
- 
<!-- 
## Accessibility testing  




 

## Test environment(s) 

 -->


