### PR TITLE
Fix Analyzer Assembly Versioning for Official Builds

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,6 +6,19 @@
   <Import Project="$(RepositoryEngineeringDir)versioning.targets" />
   <Import Project="$(RepositoryEngineeringDir)Test.targets" Condition="'$(IsTestProject)' == 'true' "/>
 
+  <!-- 
+    Analyzer projects require incremental versioning for proper side-by-side loading.
+    Use build number from Arcade SDK when available (official builds), otherwise use timestamp for local builds.
+    -->
+  <PropertyGroup Condition="'$(IsAnalyzerProject)' == 'true'">
+    <!-- For official builds, extract build number from OfficialBuildId (format: yyyyMMdd.buildNumber) -->
+    <_AnalyzerBuildNumber Condition="'$(OfficialBuildId)' != '' and $(OfficialBuildId.Contains('.'))" >$(OfficialBuildId.Split('.')[1])</_AnalyzerBuildNumber>
+    <!-- For local builds, generate a build number from days since 2020-01-01 (keeps it under 65535) -->
+    <_AnalyzerBuildNumber Condition="'$(_AnalyzerBuildNumber)' == ''">$([MSBuild]::Subtract($([System.DateTime]::Now.Subtract($([System.DateTime]::new(2020,1,1))).Days), 0))</_AnalyzerBuildNumber>
+    <!-- Override the AssemblyVersion for analyzer projects: Major.Minor.BuildNumber.0 -->
+    <AssemblyVersion>$(MajorVersion).$(MinorVersion).$(_AnalyzerBuildNumber).0</AssemblyVersion>
+  </PropertyGroup>
+
   <!-- CA1416 Validate platform compatibility. Do not apply to netstandard as it does not have the attribute. -->
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.Versioning.SupportedOSPlatform" Condition="!$(TargetFramework.StartsWith('netstandard'))">

--- a/src/System.Windows.Forms.Analyzers.VisualBasic/System.Windows.Forms.Analyzers.VisualBasic.vbproj
+++ b/src/System.Windows.Forms.Analyzers.VisualBasic/System.Windows.Forms.Analyzers.VisualBasic.vbproj
@@ -7,6 +7,7 @@
     <RootNamespace></RootNamespace>
     <LangVersion>15.5</LangVersion>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <IsAnalyzerProject>true</IsAnalyzerProject>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Problem
During a recent servicing build, analyzer projects failed with version conflicts because they were excluded from standard versioning but had no alternative versioning strategy. This left analyzer assemblies with default `10.0.0.0` versions, causing build failures since Roslyn requires unique assembly versions for proper analyzer caching and side-by-side execution.

## Solution
Implemented incremental versioning for all 5 analyzer projects in `Directory.Build.targets`. For official builds, the solution extracts the build number from Arcade SDK's `OfficialBuildId` (e.g., `20250917.123` → `10.0.123.0`). For local builds, it uses days since 2020-01-01 as the build number, ensuring unique versions while staying under .NET's 65535 component limit. Also fixed missing `IsAnalyzerProject` property in the Visual Basic analyzer project.

## Result (Pending)
Analyzer assemblies now receive proper incremental versions (`10.0.[BuildNumber].0`), resolving servicing build failures while maintaining seamless local development. The solution leverages existing Arcade infrastructure and follows Microsoft's best practices for analyzer side-by-side loading.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13879)