### PR TITLE
Add hover visual effect for Popup button

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/PopupButtonDarkModeRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/PopupButtonDarkModeRenderer.cs
@@ -141,10 +141,10 @@ internal class PopupButtonDarkModeRenderer : ButtonDarkModeRendererBase
 
             if (state == PushButtonState.Pressed)
             {
-                // In pressed state, invert the 3D effect: brighter highlight bottom/right, deeper shadow top/left
-                topLeftOuter = DefaultColors.ShadowDarkColor;       // deeper shadow
+                // In pressed state, brighter all borders to simulate the button being pressed.
+                topLeftOuter = DefaultColors.HighlightBrightColor;       // brighter highlight
                 bottomRightOuter = DefaultColors.HighlightBrightColor; // brighter highlight
-                topLeftInner = DefaultColors.ShadowDarkColor;   // deeper shadow
+                topLeftInner = DefaultColors.HighlightBrightColor;   // deeper shadow
                 bottomRightInner = DefaultColors.HighlightBrightColor; // brighter highlight
             }
             else if (state == PushButtonState.Disabled)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/PopupButtonDarkModeRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/PopupButtonDarkModeRenderer.cs
@@ -141,9 +141,9 @@ internal class PopupButtonDarkModeRenderer : ButtonDarkModeRendererBase
 
             if (state == PushButtonState.Pressed)
             {
-                // In pressed state, invert the 3D effect: highlight bottom/right, shadow top/left
-                topLeftOuter = DefaultColors.ShadowColor;       // shadow
-                bottomRightOuter = DefaultColors.HighlightColor; // highlight
+                // In pressed state, invert the 3D effect: brighter highlight bottom/right, deeper shadow top/left
+                topLeftOuter = DefaultColors.ShadowDarkColor;       // deeper shadow
+                bottomRightOuter = DefaultColors.HighlightBrightColor; // brighter highlight
                 topLeftInner = DefaultColors.ShadowDarkColor;   // deeper shadow
                 bottomRightInner = DefaultColors.HighlightBrightColor; // brighter highlight
             }
@@ -155,9 +155,17 @@ internal class PopupButtonDarkModeRenderer : ButtonDarkModeRendererBase
                 topLeftInner = DefaultColors.DisabledBorderMidColor;
                 bottomRightInner = DefaultColors.DisabledBorderMidColor;
             }
+            else if (state == PushButtonState.Hot)
+            {
+                // In hover state, invert the 3D effect: highlight bottom/right, shadow top/left
+                topLeftOuter = DefaultColors.ShadowColor;       // shadow
+                bottomRightOuter = DefaultColors.HighlightColor; // highlight
+                topLeftInner = DefaultColors.ShadowColor;   // shadow
+                bottomRightInner = DefaultColors.HighlightColor; // highlight
+            }
             else
             {
-                // Normal/hot: highlight top/left, shadow bottom/right
+                // Normal: highlight top/left, shadow bottom/right
                 topLeftOuter = DefaultColors.HighlightColor;     // highlight
                 bottomRightOuter = DefaultColors.ShadowColor;     // shadow
                 topLeftInner = DefaultColors.HighlightBrightColor; // brighter highlight


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13882


## Proposed changes

- Distinguish between the normal state and hover state of the Popup button, and add a visual effect of about to be pressed to the hover state

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- In Dark mode, Popup buttons also have normal visual feedback

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Hover on the button:

https://github.com/user-attachments/assets/806d3394-e423-4730-9dea-9cc7347afb25


Press the button:

https://github.com/user-attachments/assets/20f1e111-263d-40aa-8b13-2af5a98f7f3a


### After
Hover on the button:

https://github.com/user-attachments/assets/e28b7592-97b4-42cd-8956-7502c885ab73


Press the button:


https://github.com/user-attachments/assets/ee484946-61ca-4854-8146-de845848ee76



## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net  10.0.0-rc.1.25468.102


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13891)