### PR TITLE
Analyzer projects should get assembly versions which iterate with the patch version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,17 +26,6 @@
     <EnablePackageValidation>false</EnablePackageValidation>
   </PropertyGroup>
 
-  <!--
-    Set assembly version to align with major and minor version, as for the patches and revisions should be manually
-    updated per assembly if it is serviced.
-
-    Note, any components that aren't exposed as references in the targeting pack (like analyzers/generators) those should rev
-    so that they can exist SxS, as the compiler relies on different version to change assembly version for caching purposes.
-    -->
-  <PropertyGroup Condition="'$(IsAnalyzerProject)' != 'true'">
-    <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
-  </PropertyGroup>
-
   <!-- SDK flipped to 'true' by default https://github.com/dotnet/sdk/pull/12720 -->
   <PropertyGroup>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -43,6 +43,17 @@
 	<RedistTargetFrameworkName>$(NetCurrent)</RedistTargetFrameworkName>
   </PropertyGroup>
 
+  <!--
+    Set assembly version to align with major and minor version, as for the patches and revisions should be manually
+    updated per assembly if it is serviced.
+
+    Note, any components that aren't exposed as references in the targeting pack (like analyzers/generators) those should rev
+    so that they can exist SxS, as the compiler relies on different version to change assembly version for caching purposes.
+    -->
+  <PropertyGroup Condition="'$(IsAnalyzerProject)' != 'true'">
+    <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
+  </PropertyGroup>
+
   <Target Name="InstrumentModulesNoBuild" BeforeTargets="RunTests" Condition="'$(IsTestProject)' == 'true'">
     <Coverlet.MSbuild.Tasks.InstrumentationTask
       Condition="'$(CollectCoverage)' == 'true'"


### PR DESCRIPTION
This was placed in the wrong spot in the repo, and so analyzer projects were getting 10.0.0. They should get 10.0.1.0, 10.0.2.0...
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13892)