### PR TITLE
Add ConnectedPMEServiceName for MicroBuild signing in CI builds

### DIFF
--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -54,6 +54,9 @@ jobs:
       signType: $(_SignType)
       zipSources: false
       feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+      # Set ConnectedPMEServiceName for CI builds
+      ${{ if eq(variables['Build.Reason'], 'IndividualCI') }}:
+        ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
     continueOnError: false
     condition: and(succeeded(), in(variables['_SignType'], 'real', 'test'))
   # NuGet's http cache lasts 30 minutes. If we're on a static machine, this may interfere with


### PR DESCRIPTION
Added ConnectedPMEServiceName for MicroBuild signing in CI builds

Reference: https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/46279/Real-signing-with-PME-Enforcement
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13926)