### PR TITLE
Updating LocProject.json as per the generated file by OneLocBuild

### DIFF
--- a/eng/Localize/LocProject.json
+++ b/eng/Localize/LocProject.json
@@ -229,7 +229,11 @@
                          "LanguageSet":  "VS_Main_Languages",
                          "CloneLanguageSet":  "WiX_CloneLanguages",
                          "LocItems":  [
-
+                                          {
+                                            "SourceFile":  ".\\WindowsDesktopLocalization\\Wix5Bundle\\theme\\1033\\bundle.wxl",
+                                            "CopyOption":  "LCIDOnPath",
+                                            "OutputPath":  ".\\WindowsDesktopLocalization\\Wix5Bundle\\theme\\"
+                                          }
                                       ],
                          "LssFiles":  [
                                           "P210WxlSchemaV4.lss"
@@ -243,19 +247,6 @@
                                       ],
                          "LssFiles":  [
                                           ".\\eng\\common\\loc\\P22DotNetHtmlLocalization.lss"
-                                      ]
-                     },
-                     {
-                         "CloneLanguageSet":  "WiX_CloneLanguages",
-                         "LocItems":  [
-                                          {
-                                            "SourceFile": ".\\WindowsDesktopLocalization\\Wix5Bundle\\theme\\1033\\bundle.wxl",
-                                            "CopyOption": "LCIDOnPath",
-                                            "OutputPath": ".\\WindowsDesktopLocalization\\Wix5Bundle\\theme\\"
-                                          }
-                                      ],
-                         "LssFiles":  [
-                                          "P210WxlSchemaV4.lss"
                                       ]
                      }
                  ]


### PR DESCRIPTION
**Issue**: As part of CI build, OneLocBuild task generates LocProject.json and compares it with the contents of this file which is checked in to the repo. If there is a mismatch, the task fails.

As part of [WixV5 localization changes](https://github.com/dotnet/winforms/pull/13923), we updated LocProject.json with .wxl file entry, but it caused a mismatch as the the task expects file entry to be added in an existing node rather than a new node.

**Fix**: Added the .wxl file entry in the expected place 