### PR TITLE
Remove conditional for ConnectedPMEServiceName

### DIFF
--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -54,9 +54,7 @@ jobs:
       signType: $(_SignType)
       zipSources: false
       feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-      # Set ConnectedPMEServiceName for CI builds
-      ${{ if eq(variables['Build.Reason'], 'IndividualCI') }}:
-        ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
+      ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
     continueOnError: false
     condition: and(succeeded(), in(variables['_SignType'], 'real', 'test'))
   # NuGet's http cache lasts 30 minutes. If we're on a static machine, this may interfere with


### PR DESCRIPTION
Conditional causes build to fail if invoked manually. It works for automatically invoked CI builds.
This condition is not required.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13938)