### PR TITLE
Fixes #13901. Properly displays PropertyGrid` color and cursor dropdowns when using Dark Mode

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorUI.cs
@@ -274,7 +274,14 @@ public partial class ColorEditor
 
             _editor.PaintValue(value, graphics, new Rectangle(die.Bounds.X + 2, die.Bounds.Y + 2, 22, die.Bounds.Height - 4));
             graphics.DrawRectangle(SystemPens.WindowText, new Rectangle(die.Bounds.X + 2, die.Bounds.Y + 2, 22 - 1, die.Bounds.Height - 4 - 1));
-            Brush foreBrush = new SolidBrush(die.ForeColor);
+
+            Color textColor = die.ForeColor;
+            if (Application.IsDarkModeEnabled && die.State.HasFlag(DrawItemState.Selected))
+            {
+                textColor = SystemColors.ControlText;
+            }
+
+            Brush foreBrush = new SolidBrush(textColor);
             graphics.DrawString(value.Name, font, foreBrush, die.Bounds.X + 26, die.Bounds.Y);
             foreBrush.Dispose();
         }

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/CursorEditor.CursorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/CursorEditor.CursorUI.cs
@@ -64,7 +64,14 @@ public partial class CursorEditor
                 Cursor cursor = (Cursor)Items[e.Index];
                 string? text = _cursorConverter.ConvertToString(cursor);
                 Font font = e.Font!;
-                using var brushText = e.ForeColor.GetCachedSolidBrushScope();
+
+                Color textColor = e.ForeColor;
+                if (Application.IsDarkModeEnabled && e.State.HasFlag(DrawItemState.Selected))
+                {
+                    textColor = SystemColors.ControlText;
+                }
+
+                using var brushText = textColor.GetCachedSolidBrushScope();
                 var cursorWidth = ScaleHelper.ScaleSmallIconToDpi(Icon.FromHandle(cursor.Handle), DeviceDpi).Size.Width;
 
                 e.DrawBackground();


### PR DESCRIPTION
Fixes #13901

## Root Cause

`ColorEditor.ColorUI` and `CursorEditor.CursorUI` use owner-draw ListBoxes with custom `OnDrawItem` handlers that use `DrawItemEventArgs.ForeColor` for text rendering. In Dark Mode, this property returns dark text color for selected items, creating poor contrast against the bright blue selection background.

## Proposed changes

- Modified `ColorEditor.ColorUI.OnListDrawItem()` to use `SystemColors.ControlText` for selected item text in Dark Mode
- Modified `CursorEditor.CursorUI.OnDrawItem()` to use `SystemColors.ControlText` for selected item text in Dark Mode

## Customer Impact

Users can now properly read selected items in `PropertyGrid` color and cursor dropdowns when using Dark Mode.

## Regression?

No

## Risk

Minimal

## Screenshots

### Before
<img width="507" height="778" alt="Screenshot 2025-10-09 210129" src="https://github.com/user-attachments/assets/b30b6d0c-349e-43e2-97f9-1b10c0bc56f8" />


### After

<img width="637" height="872" alt="Screenshot 2025-10-09 204857" src="https://github.com/user-attachments/assets/40d32355-5eaf-42c7-9ba8-10fb4cbf67e7" />
<img width="642" height="863" alt="Screenshot 2025-10-09 204806" src="https://github.com/user-attachments/assets/7f6aadce-f2b4-4084-8ce2-2b2593317e9a" />
<img width="643" height="876" alt="Screenshot 2025-10-09 204840" src="https://github.com/user-attachments/assets/fb869e2c-e3a5-4e26-9032-73f348915935" />

## Test methodology

Manual testing

## Test environment(s)

- 10.0.100-rc.1.25420.111

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13950)