### PR TITLE
Improve UIA Provider Cleanup Logic for Virtual ListView Items

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
@@ -5087,7 +5087,13 @@ public partial class ListView : Control
         }
     }
 
-    internal void NotifyUiaCreated(int index) => _uiaAccessedIndices.Add(index);
+    internal void NotifyUiaCreated(int index)
+    {
+        if (VirtualMode)
+        {
+            _uiaAccessedIndices.Add(index);
+        }
+    }
 
     internal override void ReleaseUiaProvider(HWND handle)
     {
@@ -5100,8 +5106,7 @@ public partial class ListView : Control
         {
             foreach (int index in _uiaAccessedIndices)
             {
-                var item = Items.GetItemByIndex(index);
-                item?.ReleaseUiaProvider();
+                Items.GetItemByIndex(index)?.ReleaseUiaProvider();
             }
 
             _uiaAccessedIndices.Clear();
@@ -5110,11 +5115,7 @@ public partial class ListView : Control
         {
             for (int i = 0; i < Items.Count; i++)
             {
-                var item = Items.GetItemByIndex(i);
-                if (item?.IsAccessibilityObjectCreated == true)
-                {
-                    item.ReleaseUiaProvider();
-                }
+                Items.GetItemByIndex(i)?.ReleaseUiaProvider();
             }
         }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListViewItem.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListViewItem.cs
@@ -265,11 +265,12 @@ public partial class ListViewItem : ICloneable, ISerializable
                 };
             }
 
+            owningListView.NotifyUiaCreated(this);
             return _accessibilityObject;
         }
     }
 
-    private bool IsAccessibilityObjectCreated => _accessibilityObject is not null;
+    internal bool IsAccessibilityObjectCreated => _accessibilityObject is not null;
 
     /// <summary>
     ///  The font that this item will be displayed in. If its value is null, it will be displayed

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListViewItem.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListViewItem.cs
@@ -265,7 +265,11 @@ public partial class ListViewItem : ICloneable, ISerializable
                 };
             }
 
-            owningListView.NotifyUiaCreated(this);
+            if (owningListView.VirtualMode)
+            {
+                owningListView.NotifyUiaCreated(Index);
+            }
+
             return _accessibilityObject;
         }
     }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListViewItem.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListViewItem.cs
@@ -265,16 +265,13 @@ public partial class ListViewItem : ICloneable, ISerializable
                 };
             }
 
-            if (owningListView.VirtualMode)
-            {
-                owningListView.NotifyUiaCreated(Index);
-            }
+            owningListView.NotifyUiaCreated(Index);
 
             return _accessibilityObject;
         }
     }
 
-    internal bool IsAccessibilityObjectCreated => _accessibilityObject is not null;
+    private bool IsAccessibilityObjectCreated => _accessibilityObject is not null;
 
     /// <summary>
     ///  The font that this item will be displayed in. If its value is null, it will be displayed


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13922

## Root Cause

When `ListView.VirtualMode = true`, the current implementation of ` ReleaseUiaProvider()` iterates over all indices (Items.Count) and calls `Items.GetItemByIndex()`.
This triggers `OnRetrieveVirtualItem` for every index, forcing creation of all virtual items even if they were never displayed or accessed.

**Result in:** 
Severe performance degradation for large virtual lists (e.g., tens of thousands of items).
High memory pressure due to unnecessary ListViewItem instantiation.
UI freeze during control disposal.

## Proposed changes

This PR improves the cleanup logic for UI Automation (UIA) providers in ListView when operating in `VirtualMode = true`. Specifically:

- Introduces a `_uiaAccessedIndices` tracking mechanism to record only the indices of items whose `AccessibilityObject` was created by UIA.
- Updates `ReleaseUiaProvider` to selectively release UIA providers only for accessed items, avoiding full traversal of `VirtualListSize` and improving performance.
- Ensures `NotifyUiaCreated` is called during `AccessibilityObject` creation to maintain accurate tracking.
- Prevents triggering `RetrieveVirtualItem` during cleanup, which previously caused unnecessary item creation and severe performance degradation in large virtual lists.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Improves performance and responsiveness when using ListView in virtual mode with large datasets

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
When closing the form containing the ListView (in virtual mode), followed by closing the main form, the application experienced a noticeable delay.

https://github.com/user-attachments/assets/b79ad779-7d4d-4bb8-925e-814ad2dbc58f

### After
When closing the form containing the ListView (in virtual mode), and subsequently closing the main form, the main form closes immediately with no noticeable delay.

https://github.com/user-attachments/assets/e5c03d7d-eec0-4580-bbe9-d44441631fc3


## Test methodology <!-- How did you ensure quality? -->

- Manually
 

## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-rc.1.25507.102

<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13953)