### PR TITLE
Remove audit sources from NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -75,8 +75,4 @@
   <disabledPackageSources>
     <clear />
   </disabledPackageSources>
-  <auditSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </auditSources>
 </configuration>


### PR DESCRIPTION
The api.nuget.org source will clash with the CFSClean network isolation policy and the same data is provided by AzDO now.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13958)