### PR TITLE
Place the TabPanel as a child of the TabItem

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabControl.TabControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabControl.TabControlAccessibleObject.cs
@@ -117,7 +117,9 @@ public partial class TabControl
 
             return direction switch
             {
-                NavigateDirection.NavigateDirection_FirstChild => owner.SelectedTab?.AccessibilityObject,
+                NavigateDirection.NavigateDirection_FirstChild => owner.TabPages.Count > 0
+                    ? owner.TabPages[0].TabAccessibilityObject
+                    : null,
                 NavigateDirection.NavigateDirection_LastChild => owner.TabPages.Count > 0
                     ? owner.TabPages[^1].TabAccessibilityObject
                     : null,

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabPage.TabAccessibleObject.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabPage.TabAccessibleObject.cs
@@ -95,12 +95,24 @@ public partial class TabPage
                 return null;
             }
 
+            int index = OwningTabControl.TabPages.IndexOf(_owningTabPage);
+
             return direction switch
             {
                 NavigateDirection.NavigateDirection_Parent => OwningTabControl.AccessibilityObject,
-                NavigateDirection.NavigateDirection_NextSibling => OwningTabControl.AccessibilityObject.GetChild(GetChildId() + 1),
-                NavigateDirection.NavigateDirection_PreviousSibling => OwningTabControl.AccessibilityObject.GetChild(GetChildId() - 1),
-                _ => null
+                NavigateDirection.NavigateDirection_FirstChild =>
+                    index == OwningTabControl.SelectedIndex
+                        ? _owningTabPage.AccessibilityObject // Panel
+                        : null,
+                NavigateDirection.NavigateDirection_NextSibling =>
+                    index < OwningTabControl.TabPages.Count - 1
+                        ? OwningTabControl.TabPages[index + 1].TabAccessibilityObject
+                        : null,
+                NavigateDirection.NavigateDirection_PreviousSibling =>
+                    index > 0
+                        ? OwningTabControl.TabPages[index - 1].TabAccessibilityObject
+                        : null,
+                _ => base.FragmentNavigate(direction)
             };
         }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabPage.TabPageAccessibleObject.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabPage.TabPageAccessibleObject.cs
@@ -11,14 +11,19 @@ public partial class TabPage
 {
     internal sealed class TabPageAccessibleObject : ControlAccessibleObject
     {
-        public TabPageAccessibleObject(TabPage owningTabPage) : base(owningTabPage) { }
+        private readonly TabPage _owningTabPage;
+
+        public TabPageAccessibleObject(TabPage owningTabPage) : base(owningTabPage)
+        {
+            _owningTabPage = owningTabPage;
+        }
 
         internal override Rectangle BoundingRectangle => this.IsOwnerHandleCreated(out TabPage? owner) ?
             owner.GetPageRectangle() : Rectangle.Empty;
 
         public override AccessibleStates State => SystemIAccessible.TryGetState(GetChildId());
 
-        internal override IRawElementProviderFragmentRoot.Interface? FragmentRoot => OwningTabControl?.AccessibilityObject;
+        internal override IRawElementProviderFragmentRoot.Interface? FragmentRoot => _owningTabPage?.TabAccessibilityObject;
 
         private TabControl? OwningTabControl =>
             this.TryGetOwnerAs(out TabPage? owningTabPage) ? owningTabPage.ParentInternal as TabControl : null;
@@ -52,9 +57,7 @@ public partial class TabPage
 
             return direction switch
             {
-                NavigateDirection.NavigateDirection_Parent => OwningTabControl?.AccessibilityObject,
-                NavigateDirection.NavigateDirection_NextSibling => GetNextSibling(),
-                NavigateDirection.NavigateDirection_PreviousSibling => null,
+                NavigateDirection.NavigateDirection_Parent => _owningTabPage?.TabAccessibilityObject,
                 _ => base.FragmentNavigate(direction)
             };
         }
@@ -78,15 +81,5 @@ public partial class TabPage
                 UIA_PATTERN_ID.UIA_ValuePatternId => false,
                 _ => base.IsPatternSupported(patternId)
             };
-
-        private TabAccessibleObject? GetNextSibling()
-        {
-            if (!this.TryGetOwnerAs(out TabPage? owningTabPage) || OwningTabControl is null || owningTabPage != OwningTabControl.SelectedTab)
-            {
-                return null;
-            }
-
-            return OwningTabControl.TabPages.Count > 0 ? OwningTabControl.TabPages[0].TabAccessibilityObject : null;
-        }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10408


## Proposed changes

- **TabControlAccessibleObject**
  - Removed logic that exposed TabPage Panel as a direct child of TabControl.
  - FragmentNavigate now only returns TabItem objects for FirstChild and LastChild. 
- **TabAccessibleObject**
  - Added logic to expose TabPage Panel as FirstChild when the tab is selected.
  - Maintains sibling navigation for other tab items.
- **TabPageAccessibleObject**
  - Updated Parent and FragmentRoot to point to the corresponding TabItem instead of TabControl.
  - Removed any logic that previously treated the panel as a sibling of tab items.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

-  **Improved Accessibility Compliance**: The new structure aligns with UIA best practices, making the hierarchy intuitive for assistive technologies.
- **Better Screen Reader Experience**: Users will now hear the correct relationship between a tab item and its content, improving usability for visually impaired users.
- **Reduced Automation Errors**: Automated tests and AI tools will no longer encounter ambiguous sibling relationships between tab items and panels.
- **Consistent Tree Representation**: Tools like Inspect and UIA Verify will display a predictable and logical structure, reducing developer confusion and debugging time.

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

In the .net project,  TreeWalker only obtain the panel. Example project [WinFormsApp71.zip](https://github.com/user-attachments/files/22924609/WinFormsApp71.zip)

<img width="2019" height="927" alt="image" src="https://github.com/user-attachments/assets/b64041c6-843b-44c6-b804-671c9d38c3e4" />

### After
In the .net project,  TreeWalker can obtain the tabitem
<img width="2164" height="726" alt="image" src="https://github.com/user-attachments/assets/09117d51-3a2a-4946-8f3e-c42c6c42f552" />


## Test methodology <!-- How did you ensure quality? -->

-  Manually
- Accessibility tools

## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-rc.1.25468.102

<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13964)