### PR TITLE
Fix 13963: Ensure ScaleSmallIconToDpi Always Returns a New Icon to Prevent Resource Mismanagement

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
@@ -429,7 +429,7 @@ internal static partial class ScaleHelper
         int width = PInvoke.GetCurrentSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXSMICON, (uint)dpi);
         int height = PInvoke.GetCurrentSystemMetrics(SYSTEM_METRICS_INDEX.SM_CYSMICON, (uint)dpi);
 
-        return (icon.Width == width && icon.Height == height) ? icon : new(icon, width, height);
+        return new Icon(icon, width, height);
     }
 
     /// <summary>


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13963

## Root Cause
The issue was introduced in PR https://github.com/dotnet/winforms/pull/13787/files, which changed the `Form.UpdateWindowIcon` implementation from `_smallIcon = new Icon(icon, SystemInformation.SmallIconSize);`  to  `_smallIcon = ScaleHelper.ScaleSmallIconToDpi(icon, dpi);`

The problem arises because `ScaleSmallIconToDpi` returns the original icon instance when its size already matches the target DPI. This caused` _smallIcon` and the external icon to reference the same object. When `UpdateWindowIcon` later disposed `_smallIcon`, it unintentionally disposed the original icon as well, leading to `ObjectDisposedException` when the original icon was reused.

## Proposed changes

-  Update `ScaleSmallIconToDpi` to always return a new Icon instance, even when the original icon already matches the target DPI size.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Apps that reuse the same Icon for multiple forms may throw `ObjectDisposedException` after closing a form, because the original icon gets disposed. This fix ensures the original icon remains valid and reusable, preventing these exceptions and improving reliability.

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
With the demo code, 
```
    public partial class Form1 : Form
    {
        private Icon ico;

        public Form1()
        {
            InitializeComponent();
            ico = new Icon("D:\\TestWinformIcon\\exception.size32.ico");  // change the path on your machine
        }

        private void button1_Click(object sender, EventArgs e)
        {
            var form = new Form2();
            form.Icon = ico;
            form.Show();
            form.Close();
        }

        private void button2_Click(object sender, EventArgs e)
        {
            MessageBox.Show(ico.Handle.ToString());
        }
    }
```
Click button1 and then click button2, exception dialog pops.

<img width="877" height="1163" alt="Image" src="https://github.com/user-attachments/assets/ece5f080-c58a-4ba6-940b-4a144bd373bc" />

### After
Click button1 and then click button2, the _ico.Handle displays normally.

<img width="876" height="546" alt="image" src="https://github.com/user-attachments/assets/c6e1242d-75a1-4f35-9c39-d8c5856b9010" />


## Test methodology <!-- How did you ensure quality? -->

-  Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-rc.1.25405.103

<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13971)