### PR TITLE
Move LinkLabel text region dispose back to EnsureRun

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Control.cs
@@ -5908,6 +5908,8 @@ public unsafe partial class Control :
         }
         else if (IsHandleCreated)
         {
+            Debug.Assert(region.GetPointer() != null);
+
             using Graphics graphics = CreateGraphicsInternal();
             using RegionScope regionHandle = region.GetRegionScope(graphics);
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Labels/LinkLabel.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Labels/LinkLabel.cs
@@ -515,6 +515,9 @@ public partial class LinkLabel : Label, IButtonControl
             return _textRegion;
         }
 
+        _textRegion?.Dispose();
+        _textRegion = null;
+
         string text = Text;
 
         if (text.Length == 0)
@@ -723,8 +726,6 @@ public partial class LinkLabel : Label, IButtonControl
     private void InvalidateTextLayout()
     {
         _textLayoutValid = false;
-        _textRegion?.Dispose();
-        _textRegion = null;
     }
 
     private bool LinkInText(int start, int length) => start >= 0 && start < Text.Length && length > 0;


### PR DESCRIPTION
Disposing in `InvalidateLayout` would break in some workflows when accessing the `Links` `VisualRegion` as it is shared. This got mistakenly moved in #10448.

Fixes #13973

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13978)