### PR TITLE
Fix 13976: Enhance TreeNode.UpdateImage() to support inherited image keys and selected image rendering

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -26,6 +26,7 @@ internal static partial class LocalAppContextSwitches
     internal const string EnableMsoComponentManagerSwitchName = "Switch.System.Windows.Forms.EnableMsoComponentManager";
     internal const string TreeNodeCollectionAddRangeRespectsSortOrderSwitchName = "System.Windows.Forms.TreeNodeCollectionAddRangeRespectsSortOrder";
     internal const string MoveTreeViewTextLocationOnePixelSwitchName = "System.Windows.Forms.TreeView.MoveTreeViewTextLocationOnePixel";
+    internal const string PreserveUnassignedTreeNodeImagesSwitchName = "System.Windows.Forms.TreeView.PreserveUnassignedTreeNodeImages";
 
     private static int s_scaleTopLevelFormMinMaxSizeForDpi;
     private static int s_anchorLayoutV2;
@@ -39,6 +40,7 @@ internal static partial class LocalAppContextSwitches
     private static int s_treeNodeCollectionAddRangeRespectsSortOrder;
 
     private static int s_moveTreeViewTextLocationOnePixel;
+    private static int s_preserveUnassignedTreeNodeImages;
 
     private static FrameworkName? s_targetFrameworkName;
 
@@ -230,5 +232,14 @@ internal static partial class LocalAppContextSwitches
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => GetCachedSwitchValue(MoveTreeViewTextLocationOnePixelSwitchName, ref s_moveTreeViewTextLocationOnePixel);
+    }
+
+    /// <summary>
+    ///  Indicates whether keep the node image that has not set an image when the ImageList changes dynamically.
+    /// </summary>
+    public static bool PreserveUnassignedTreeNodeImages
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetCachedSwitchValue(PreserveUnassignedTreeNodeImagesSwitchName, ref s_preserveUnassignedTreeNodeImages);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -235,7 +235,7 @@ internal static partial class LocalAppContextSwitches
     }
 
     /// <summary>
-    ///  Indicates whether keep the node image that has not set an image when the ImageList changes dynamically.
+    ///  Indicates whether to keep the node image that has not set an image when the ImageList changes dynamically.
     /// </summary>
     public static bool PreserveUnassignedTreeNodeImages
     {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeNode.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeNode.cs
@@ -2205,74 +2205,65 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
 
         if (treeView.ImageList is { } imageList)
         {
-            string effectiveImageKey = ImageKey;
-
-            // If the current node does not set ImageKey, try inheriting TreeView's ImageKey
-            if (string.IsNullOrEmpty(effectiveImageKey))
+            if (AppContextSwitches.PreserveUnassignedTreeNodeImages)
             {
-                effectiveImageKey = treeView.ImageKey;
-            }
-
-            // If the current node has an ImageKey set, prefer using the valid ImageKey
-            if (!string.IsNullOrEmpty(effectiveImageKey) && imageList.Images.ContainsKey(effectiveImageKey))
-            {
-                imageIndex = imageList.Images.IndexOfKey(effectiveImageKey);
-            }
-            else if (ImageIndexer.ActualIndex >= 0 && ImageIndexer.ActualIndex < imageList.Images.Count)
-            {
-                // Otherwise use the node's own ImageIndex
-                imageIndex = ImageIndexer.ActualIndex;
-            }
-            else if (treeView.ImageIndexer.ActualIndex >= 0 && treeView.ImageIndexer.ActualIndex < imageList.Images.Count)
-            {
-                // Then try using TreeView's ImageIndex
-                imageIndex = treeView.ImageIndexer.ActualIndex;
+                imageIndex = GetEffectiveImageIndex(treeView, imageList, ImageKey);
+                selectedImageIndex = GetEffectiveImageIndex(treeView, imageList, SelectedImageKey);
             }
             else
             {
-                // Fallback to default image
-                imageIndex = 0;
-            }
-
-            // Resolve the effective SelectedImageKey for the node
-            // If the node's SelectedImageKey is not set, it will be using "Default", fallback to TreeView's SelectedImageKey
-            string effectiveSelectedImageKey = SelectedImageKey;
-            if (string.IsNullOrEmpty(effectiveSelectedImageKey))
-            {
-                effectiveSelectedImageKey = treeView.SelectedImageKey;
-            }
-
-            // Determine selected image index based on effective SelectedImageKey
-            if (!string.IsNullOrEmpty(effectiveSelectedImageKey) && imageList.Images.ContainsKey(effectiveSelectedImageKey))
-            {
-                selectedImageIndex = imageList.Images.IndexOfKey(effectiveSelectedImageKey);
-            }
-            else if (SelectedImageIndexer.ActualIndex >= 0 && SelectedImageIndexer.ActualIndex < imageList.Images.Count)
-            {
-                // If SelectedImageKey is invalid, fallback to node's SelectedImageIndex
-                selectedImageIndex = SelectedImageIndexer.ActualIndex;
-            }
-            else if (treeView.SelectedImageIndexer.ActualIndex >= 0 && treeView.SelectedImageIndexer.ActualIndex < imageList.Images.Count)
-            {
-                // If node's SelectedImageIndex is invalid, fallback to TreeView's SelectedImageIndex
-                selectedImageIndex = treeView.SelectedImageIndexer.ActualIndex;
-            }
-            else
-            {
-                // Final fallback to index 0
-                selectedImageIndex = 0;
+                imageIndex = Math.Clamp(ImageIndexer.ActualIndex, 0, imageList.Images.Count - 1);
             }
         }
 
         TVITEMW item = new()
         {
-            mask = TVITEM_MASK.TVIF_HANDLE | TVITEM_MASK.TVIF_IMAGE | TVITEM_MASK.TVIF_SELECTEDIMAGE,
+            mask = TVITEM_MASK.TVIF_HANDLE | TVITEM_MASK.TVIF_IMAGE,
             hItem = HTREEITEM,
-            iImage = imageIndex,
-            iSelectedImage = selectedImageIndex
+            iImage = imageIndex
         };
 
+        if (AppContextSwitches.PreserveUnassignedTreeNodeImages)
+        {
+            item.mask |= TVITEM_MASK.TVIF_SELECTEDIMAGE;
+            item.iSelectedImage = selectedImageIndex;
+        }
+
         PInvokeCore.SendMessage(treeView, PInvoke.TVM_SETITEMW, 0, ref item);
+    }
+
+    private unsafe int GetEffectiveImageIndex(TreeView treeView, ImageList imageList, string effectiveImageKey)
+    {
+        int imageIndex;
+
+        // If the current node does not set ImageKey, try inheriting TreeView's ImageKey
+        if (string.IsNullOrEmpty(effectiveImageKey))
+        {
+            effectiveImageKey = treeView.ImageKey;
+        }
+
+        // If the current node has an ImageKey set, prefer using the valid ImageKey
+        if (!string.IsNullOrEmpty(effectiveImageKey) && imageList.Images.ContainsKey(effectiveImageKey))
+        {
+            imageIndex = imageList.Images.IndexOfKey(effectiveImageKey);
+        }
+        else if (ImageIndexer.ActualIndex >= 0 && ImageIndexer.ActualIndex < imageList.Images.Count)
+        {
+            // Otherwise use the node's own ImageIndex
+            imageIndex = ImageIndexer.ActualIndex;
+        }
+        else if (treeView.ImageIndexer.ActualIndex >= 0 && treeView.ImageIndexer.ActualIndex < imageList.Images.Count)
+        {
+            // Then try using TreeView's ImageIndex
+            imageIndex = treeView.ImageIndexer.ActualIndex;
+        }
+        else
+        {
+            // Fallback to default image
+            imageIndex = 0;
+        }
+
+        return imageIndex;
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeNode.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeNode.cs
@@ -2208,7 +2208,6 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
             if (AppContextSwitches.PreserveUnassignedTreeNodeImages)
             {
                 imageIndex = GetEffectiveImageIndex(
-                    treeView,
                     imageList,
                     ImageKey,
                     ImageIndexer,
@@ -2216,7 +2215,6 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
                     treeView.ImageIndexer);
 
                 selectedImageIndex = GetEffectiveImageIndex(
-                    treeView,
                     imageList,
                     SelectedImageKey,
                     SelectedImageIndexer,
@@ -2245,8 +2243,7 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
         PInvokeCore.SendMessage(treeView, PInvoke.TVM_SETITEMW, 0, ref item);
     }
 
-    private int GetEffectiveImageIndex(
-        TreeView treeView,
+    private static int GetEffectiveImageIndex(
         ImageList imageList,
         string effectiveImageKey,
         ImageList.Indexer nodeImageIndexer,

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeNode.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeNode.cs
@@ -2193,7 +2193,7 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
             => actualIndex is ImageList.Indexer.NoneIndex or ImageList.Indexer.DefaultIndex;
     }
 
-    internal unsafe void UpdateImage()
+    internal void UpdateImage()
     {
         if (TreeView is not { IsDisposed: false } treeView)
         {
@@ -2207,8 +2207,21 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
         {
             if (AppContextSwitches.PreserveUnassignedTreeNodeImages)
             {
-                imageIndex = GetEffectiveImageIndex(treeView, imageList, ImageKey);
-                selectedImageIndex = GetEffectiveImageIndex(treeView, imageList, SelectedImageKey);
+                imageIndex = GetEffectiveImageIndex(
+                    treeView,
+                    imageList,
+                    ImageKey,
+                    ImageIndexer,
+                    treeView.ImageKey,
+                    treeView.ImageIndexer);
+
+                selectedImageIndex = GetEffectiveImageIndex(
+                    treeView,
+                    imageList,
+                    SelectedImageKey,
+                    SelectedImageIndexer,
+                    treeView.SelectedImageKey,
+                    treeView.SelectedImageIndexer);
             }
             else
             {
@@ -2232,30 +2245,37 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
         PInvokeCore.SendMessage(treeView, PInvoke.TVM_SETITEMW, 0, ref item);
     }
 
-    private unsafe int GetEffectiveImageIndex(TreeView treeView, ImageList imageList, string effectiveImageKey)
+    private int GetEffectiveImageIndex(
+        TreeView treeView,
+        ImageList imageList,
+        string effectiveImageKey,
+        ImageList.Indexer nodeImageIndexer,
+        string treeViewEffectiveImageKey,
+        ImageList.Indexer treeViewImageIndexer)
     {
         int imageIndex;
 
-        // If the current node does not set ImageKey, try inheriting TreeView's ImageKey
+        // If the current node does not set a key, try inheriting the TreeView key.
         if (string.IsNullOrEmpty(effectiveImageKey))
         {
-            effectiveImageKey = treeView.ImageKey;
+            effectiveImageKey = treeViewEffectiveImageKey;
         }
 
-        // If the current node has an ImageKey set, prefer using the valid ImageKey
+        // If the current node (or inherited TreeView) has a key set, prefer using
+        // the corresponding image when it exists in the ImageList.
         if (!string.IsNullOrEmpty(effectiveImageKey) && imageList.Images.ContainsKey(effectiveImageKey))
         {
             imageIndex = imageList.Images.IndexOfKey(effectiveImageKey);
         }
-        else if (ImageIndexer.ActualIndex >= 0 && ImageIndexer.ActualIndex < imageList.Images.Count)
+        else if (nodeImageIndexer.ActualIndex >= 0 && nodeImageIndexer.ActualIndex < imageList.Images.Count)
         {
-            // Otherwise use the node's own ImageIndex
-            imageIndex = ImageIndexer.ActualIndex;
+            // Otherwise use the node's own index.
+            imageIndex = nodeImageIndexer.ActualIndex;
         }
-        else if (treeView.ImageIndexer.ActualIndex >= 0 && treeView.ImageIndexer.ActualIndex < imageList.Images.Count)
+        else if (treeViewImageIndexer.ActualIndex >= 0 && treeViewImageIndexer.ActualIndex < imageList.Images.Count)
         {
-            // Then try using TreeView's ImageIndex
-            imageIndex = treeView.ImageIndexer.ActualIndex;
+            // Then try using the TreeView's index.
+            imageIndex = treeViewImageIndexer.ActualIndex;
         }
         else
         {

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/TreeNodeTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/TreeNodeTests.cs
@@ -3569,6 +3569,142 @@ public class TreeNodeTests
         Assert.Equal("Key", node.SelectedImageKey);
     }
 
+    [WinFormsFact]
+    public void TreeNode_UpdateImage_PreserveUnassigned_UsesTreeViewSelectedImageKey()
+    {
+        const string SwitchName = "System.Windows.Forms.TreeView.PreserveUnassignedTreeNodeImages";
+        AppContext.TryGetSwitch(SwitchName, out bool originalValue);
+        AppContext.SetSwitch(SwitchName, true);
+
+        try
+        {
+            using Bitmap image1 = new(10, 10);
+            using Bitmap image2 = new(10, 10);
+            using ImageList imageList = new();
+            imageList.Images.Add("Image1", image1);
+            imageList.Images.Add("Image2", image2);
+
+            using TreeView control = new()
+            {
+                ImageList = imageList,
+                ImageKey = "Image1",
+                SelectedImageKey = "Image2"
+            };
+
+            TreeNode node = new();
+            control.Nodes.Add(node);
+
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+
+            node.UpdateImage();
+
+            TVITEMW item = new()
+            {
+                mask = TVITEM_MASK.TVIF_HANDLE | TVITEM_MASK.TVIF_SELECTEDIMAGE,
+                hItem = node.HTREEITEM
+            };
+
+            Assert.Equal(1, (int)PInvokeCore.SendMessage(control, PInvoke.TVM_GETITEMW, 0, ref item));
+            Assert.Equal(1, item.iSelectedImage);
+        }
+        finally
+        {
+            AppContext.SetSwitch(SwitchName, originalValue);
+        }
+    }
+
+    [WinFormsFact]
+    public void TreeNode_UpdateImage_PreserveUnassigned_UsesNodeSelectedImageIndex()
+    {
+        const string SwitchName = "System.Windows.Forms.TreeView.PreserveUnassignedTreeNodeImages";
+        AppContext.TryGetSwitch(SwitchName, out bool originalValue);
+        AppContext.SetSwitch(SwitchName, true);
+
+        try
+        {
+            using Bitmap image1 = new(10, 10);
+            using Bitmap image2 = new(10, 10);
+            using ImageList imageList = new();
+            imageList.Images.Add("Image1", image1);
+            imageList.Images.Add("Image2", image2);
+
+            using TreeView control = new()
+            {
+                ImageList = imageList
+            };
+
+            TreeNode node = new()
+            {
+                ImageIndex = 0,
+                SelectedImageIndex = 1,
+                SelectedImageKey = "NoSuchImage"
+            };
+
+            control.Nodes.Add(node);
+
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+
+            node.UpdateImage();
+
+            TVITEMW item = new()
+            {
+                mask = TVITEM_MASK.TVIF_HANDLE | TVITEM_MASK.TVIF_SELECTEDIMAGE,
+                hItem = node.HTREEITEM
+            };
+
+            Assert.Equal(1, (int)PInvokeCore.SendMessage(control, PInvoke.TVM_GETITEMW, 0, ref item));
+            Assert.Equal(1, item.iSelectedImage);
+        }
+        finally
+        {
+            AppContext.SetSwitch(SwitchName, originalValue);
+        }
+    }
+
+    [WinFormsFact]
+    public unsafe void TreeNode_UpdateImage_PreserveUnassigned_UsesTreeViewSelectedImageIndex()
+    {
+        const string SwitchName = "System.Windows.Forms.TreeView.PreserveUnassignedTreeNodeImages";
+        AppContext.TryGetSwitch(SwitchName, out bool originalValue);
+        AppContext.SetSwitch(SwitchName, true);
+
+        try
+        {
+            using Bitmap image1 = new(10, 10);
+            using Bitmap image2 = new(10, 10);
+            using ImageList imageList = new();
+            imageList.Images.Add(image1);
+            imageList.Images.Add(image2);
+
+            using TreeView control = new()
+            {
+                ImageList = imageList,
+                ImageIndex = 0,
+                SelectedImageIndex = 1
+            };
+
+            TreeNode node = new();
+            control.Nodes.Add(node);
+
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+
+            node.UpdateImage();
+
+            TVITEMW item = new()
+            {
+                mask = TVITEM_MASK.TVIF_HANDLE | TVITEM_MASK.TVIF_SELECTEDIMAGE,
+                hItem = node.HTREEITEM
+            };
+
+            Assert.Equal(1, (int)PInvokeCore.SendMessage(control, PInvoke.TVM_GETITEMW, 0, ref item));
+            Assert.Equal(1, item.iSelectedImage);
+        }
+        finally
+        {
+            AppContext.SetSwitch(SwitchName, originalValue);
+        }
+    }
+
     [WinFormsTheory]
     [InlineData(-1, -1)]
     [InlineData(0, 0)]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/TreeNodeTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/TreeNodeTests.cs
@@ -3636,8 +3636,7 @@ public class TreeNodeTests
             TreeNode node = new()
             {
                 ImageIndex = 0,
-                SelectedImageIndex = 1,
-                SelectedImageKey = "NoSuchImage"
+                SelectedImageIndex = 1
             };
 
             control.Nodes.Add(node);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13976


## Proposed changes

- Add switch `PreserveUnassignedTreeNodeImages` to do following change 
   - Update `TreeNode.UpdateImage()` by adding logic to resolve `ImageKey` and `SelectedImageKey` from `TreeView` when not explicitly set on the node.
   - Improved fallback handling for both image and selected image index:
      - Priority: ImageKey → ImageIndex → TreeView.ImageKey → TreeView.ImageIndex → default (0) 
      - Same logic applied to `SelectedImageKey` and `SelectedImageIndex`
   - Prevented setting `iSelectedImage` when no valid image is available, allowing native fallback to `iImage`
   - Ensured `TVITEMW.mask` includes `TVIF_SELECTEDIMAGE` only when applicable

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- After this fix, when the TreeView’s ImageList changes, TreeNodes without explicitly set images will continue to display their original default image—if it still exists. If the default image has been removed, they will fall back to showing the first image in the new ImageList.

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

Example project: [TreeViewImageBug-master.zip](https://github.com/user-attachments/files/23050854/TreeViewImageBug-master.zip)

### Before
TreeNodes without an image set are changed to the first image if the ImageList is changed.

https://github.com/user-attachments/assets/8fb895cc-94f2-4cee-8429-f62f50ab82e4

### After
TreeNodes without an image set are changed to the first image only when the original image is removed

https://github.com/user-attachments/assets/dbfce213-c2f4-46e7-8b78-306ddd779b8b

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

-  .net  10.0.0-rc.1.25405.103


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/13981)