### PR TITLE
[release/8.0] Allows DataGridView to start row/column on index 1 on Narrator

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -20,14 +20,14 @@ internal static partial class LocalAppContextSwitches
     internal const string ServicePointManagerCheckCrlSwitchName = "System.Windows.Forms.ServicePointManagerCheckCrl";
     internal const string TrackBarModernRenderingSwitchName = "System.Windows.Forms.TrackBarModernRendering";
     private const string DoNotCatchUnhandledExceptionsSwitchName = "System.Windows.Forms.DoNotCatchUnhandledExceptions";
-    internal const string DataGridViewUIAStartRowCountAtZeroSwitchName = "System.Windows.Forms.DataGridViewUIAStartRowCountAtZero";
+    internal const string DataGridViewUIAStartRowCountAtOneSwitchName = "System.Windows.Forms.DataGridViewUIAStartRowCountAtOne";
 
     private static int s_scaleTopLevelFormMinMaxSizeForDpi;
     private static int s_anchorLayoutV2;
     private static int s_servicePointManagerCheckCrl;
     private static int s_trackBarModernRendering;
     private static int s_doNotCatchUnhandledExceptions;
-    private static int s_dataGridViewUIAStartRowCountAtZero;
+    private static int s_dataGridViewUIAStartRowCountAtOne;
 
     private static FrameworkName? s_targetFrameworkName;
 
@@ -154,11 +154,9 @@ internal static partial class LocalAppContextSwitches
         get => GetCachedSwitchValue(ServicePointManagerCheckCrlSwitchName, ref s_servicePointManagerCheckCrl);
     }
 
-    public static bool DataGridViewUIAStartRowCountAtZero
+    public static bool DataGridViewUIAStartRowCountAtOne
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => GetCachedSwitchValue(DataGridViewUIAStartRowCountAtZeroSwitchName, ref s_dataGridViewUIAStartRowCountAtZero);
+        get => GetCachedSwitchValue(DataGridViewUIAStartRowCountAtOneSwitchName, ref s_dataGridViewUIAStartRowCountAtOne);
     }
-
-    internal static void SetDataGridViewUIAStartRowCountAtZero(bool value) => s_dataGridViewUIAStartRowCountAtZero = value ? 1 : 0;
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
@@ -114,7 +114,7 @@ public abstract partial class DataGridViewCell
 
         public override AccessibleRole Role => AccessibleRole.Cell;
 
-        private static int RowStartIndex => LocalAppContextSwitches.DataGridViewUIAStartRowCountAtZero ? 0 : 1;
+        private static int RowStartIndex => LocalAppContextSwitches.DataGridViewUIAStartRowCountAtOne ? 1 : 0;
 
         public override AccessibleStates State
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
@@ -133,7 +133,7 @@ public partial class DataGridViewRow
 
         public override AccessibleRole Role => AccessibleRole.Row;
 
-        private static int RowStartIndex => LocalAppContextSwitches.DataGridViewUIAStartRowCountAtZero ? 0 : 1;
+        private static int RowStartIndex => LocalAppContextSwitches.DataGridViewUIAStartRowCountAtOne ? 1 : 0;
 
         internal override int[] RuntimeId
             => _runtimeId ??= new int[]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellAccessibleObjectTests.cs
@@ -208,7 +208,6 @@ public class DataGridViewCellAccessibleObjectTests : DataGridViewCell
         Assert.Equal(expected, accessibleObject.Name);
     }
 
-    // Whether UIA row indexing is 1-based or 0-based, is controlled by the DataGridViewUIAStartRowCountAtZero switch
     [WinFormsFact]
     public void DataGridViewCellAccessibleObject_Name_ReturnExpected()
     {
@@ -220,13 +219,12 @@ public class DataGridViewCellAccessibleObjectTests : DataGridViewCell
         dataGridView.Rows.Add("3");
 
         AccessibleObject accessibleObject = dataGridView.Rows[2].Cells[0].AccessibilityObject;
-        string expected = string.Format(SR.DataGridView_AccDataGridViewCellName, column.HeaderText, 3);
+        string expected = string.Format(SR.DataGridView_AccDataGridViewCellName, column.HeaderText, 2);
 
         Assert.Equal(expected, accessibleObject.Name);
         Assert.False(dataGridView.IsHandleCreated);
     }
 
-    // Whether UIA row indexing is 1-based or 0-based, is controlled by the DataGridViewUIAStartRowCountAtZero switch
     [WinFormsFact]
     public void DataGridViewCellAccessibleObject_Name_ReturnExpected_IfOneRowHidden()
     {
@@ -239,13 +237,12 @@ public class DataGridViewCellAccessibleObjectTests : DataGridViewCell
         dataGridView.Rows[0].Visible = false;
 
         AccessibleObject accessibleObject = dataGridView.Rows[2].Cells[0].AccessibilityObject;
-        string expected = string.Format(SR.DataGridView_AccDataGridViewCellName, column.HeaderText, 2);
+        string expected = string.Format(SR.DataGridView_AccDataGridViewCellName, column.HeaderText, 1);
 
         Assert.Equal(expected, accessibleObject.Name);
         Assert.False(dataGridView.IsHandleCreated);
     }
 
-    // Whether UIA row indexing is 1-based or 0-based, is controlled by the DataGridViewUIAStartRowCountAtZero switch
     [WinFormsFact]
     public void DataGridViewCellAccessibleObject_Name_ReturnExpected_IfTwoRowsHidden()
     {
@@ -259,7 +256,7 @@ public class DataGridViewCellAccessibleObjectTests : DataGridViewCell
         dataGridView.Rows[1].Visible = false;
 
         AccessibleObject accessibleObject = dataGridView.Rows[2].Cells[0].AccessibilityObject;
-        string expected = string.Format(SR.DataGridView_AccDataGridViewCellName, column.HeaderText, 1);
+        string expected = string.Format(SR.DataGridView_AccDataGridViewCellName, column.HeaderText, 0);
 
         Assert.Equal(expected, accessibleObject.Name);
         Assert.False(dataGridView.IsHandleCreated);
@@ -1440,17 +1437,17 @@ public class DataGridViewCellAccessibleObjectTests : DataGridViewCell
     [WinFormsFact]
     public void DataGridView_SwitchConfigured_AdjustsCellRowStartIndices()
     {
-        LocalAppContextSwitches.SetDataGridViewUIAStartRowCountAtZero(true);
+        AppContext.SetSwitch(LocalAppContextSwitches.DataGridViewUIAStartRowCountAtOneSwitchName, true);
 
         using DataGridView dataGridView = new();
         dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
         dataGridView.Rows.Add(new DataGridViewRow());
 
-        Assert.Equal($"{string.Format(SR.DataGridView_AccRowName, 0)}, Not sorted.", dataGridView.Rows[0].Cells[0].AccessibilityObject.Name);
-
-        LocalAppContextSwitches.SetDataGridViewUIAStartRowCountAtZero(false);
-
         Assert.Equal($"{string.Format(SR.DataGridView_AccRowName, 1)}, Not sorted.", dataGridView.Rows[0].Cells[0].AccessibilityObject.Name);
+
+        AppContext.SetSwitch(LocalAppContextSwitches.DataGridViewUIAStartRowCountAtOneSwitchName, false);
+
+        Assert.Equal($"{string.Format(SR.DataGridView_AccRowName, 0)}, Not sorted.", dataGridView.Rows[0].Cells[0].AccessibilityObject.Name);
     }
 
     private class SubDataGridViewCell : DataGridViewCell

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowAccessibleObjectTests.cs
@@ -72,7 +72,6 @@ public class DataGridViewRowAccessibleObjectTests : DataGridViewRow
         Assert.Equal(string.Format(SR.DataGridView_AccRowName, -1), accessibilityObject.Name);
     }
 
-    // Whether UIA row indexing is 1-based or 0-based, is controlled by the DataGridViewUIAStartRowCountAtZero switch
     [Fact]
     public void DataGridViewRowAccessibleObject_Name_Get_ReturnsExpected()
     {
@@ -86,13 +85,12 @@ public class DataGridViewRowAccessibleObjectTests : DataGridViewRow
         AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
         AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
 
-        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 1), accessibleObject1.Name);
-        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 2), accessibleObject2.Name);
-        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 3), accessibleObject3.Name);
+        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 0), accessibleObject1.Name);
+        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 1), accessibleObject2.Name);
+        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 2), accessibleObject3.Name);
         Assert.False(dataGridView.IsHandleCreated);
     }
 
-    // Whether UIA row indexing is 1-based or 0-based, is controlled by the DataGridViewUIAStartRowCountAtZero switch
     [Fact]
     public void DataGridViewRowAccessibleObject_Name_Get_ReturnsExpected_IfFirstRowHidden()
     {
@@ -108,12 +106,11 @@ public class DataGridViewRowAccessibleObjectTests : DataGridViewRow
         AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
 
         Assert.Equal(string.Format(SR.DataGridView_AccRowName, -1), accessibleObject1.Name);
-        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 1), accessibleObject2.Name);
-        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 2), accessibleObject3.Name);
+        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 0), accessibleObject2.Name);
+        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 1), accessibleObject3.Name);
         Assert.False(dataGridView.IsHandleCreated);
     }
 
-    // Whether UIA row indexing is 1-based or 0-based, is controlled by the DataGridViewUIAStartRowCountAtZero switch
     [Fact]
     public void DataGridViewRowAccessibleObject_Name_Get_ReturnsExpected_IfSecondRowHidden()
     {
@@ -128,13 +125,12 @@ public class DataGridViewRowAccessibleObjectTests : DataGridViewRow
         AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
         AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
 
-        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 1), accessibleObject1.Name);
+        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 0), accessibleObject1.Name);
         Assert.Equal(string.Format(SR.DataGridView_AccRowName, -1), accessibleObject2.Name);
-        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 2), accessibleObject3.Name);
+        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 1), accessibleObject3.Name);
         Assert.False(dataGridView.IsHandleCreated);
     }
 
-    // Whether UIA row indexing is 1-based or 0-based, is controlled by the DataGridViewUIAStartRowCountAtZero switch
     [Fact]
     public void DataGridViewRowAccessibleObject_Name_Get_ReturnsExpected_IfLastRowHidden()
     {
@@ -149,8 +145,8 @@ public class DataGridViewRowAccessibleObjectTests : DataGridViewRow
         AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
         AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
 
-        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 1), accessibleObject1.Name);
-        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 2), accessibleObject2.Name);
+        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 0), accessibleObject1.Name);
+        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 1), accessibleObject2.Name);
         Assert.Equal(string.Format(SR.DataGridView_AccRowName, -1), accessibleObject3.Name);
         Assert.False(dataGridView.IsHandleCreated);
     }
@@ -2388,17 +2384,17 @@ public class DataGridViewRowAccessibleObjectTests : DataGridViewRow
     [WinFormsFact]
     public void DataGridView_SwitchConfigured_AdjustsRowStartIndices()
     {
-        LocalAppContextSwitches.SetDataGridViewUIAStartRowCountAtZero(true); 
+        AppContext.SetSwitch(LocalAppContextSwitches.DataGridViewUIAStartRowCountAtOneSwitchName, true);
 
         using DataGridView dataGridView = new();
         dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
         dataGridView.Rows.Add(new DataGridViewRow());
 
-        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 0), dataGridView.Rows[0].AccessibilityObject.Name);
-
-        LocalAppContextSwitches.SetDataGridViewUIAStartRowCountAtZero(false);
-
         Assert.Equal(string.Format(SR.DataGridView_AccRowName, 1), dataGridView.Rows[0].AccessibilityObject.Name);
+
+        AppContext.SetSwitch(LocalAppContextSwitches.DataGridViewUIAStartRowCountAtOneSwitchName, false);
+
+        Assert.Equal(string.Format(SR.DataGridView_AccRowName, 0), dataGridView.Rows[0].AccessibilityObject.Name);
     }
 
     private class SubDataGridViewCell : DataGridViewCell


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

 Backport  #10243 to release/8.0

Fixes https://github.com/dotnet/winforms/issues/13994

## Proposed changes

- Creates a new switch `System.Windows.Forms.DataGridViewUIAStartRowCountAtOne` that allows developers to configure their application to make the starting index of rows/cells in DataGridView to be read by Narrator from 1, instead of 0;
- Adds checks on rows and cells of DataGridView to see if the switch is true. If true, starting index of rows/cells will be 1, instead of 0.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Developers will be able to configure their WinForms DataGridView rows/cells to be read by Narrator from index 1, instead of 0.

## Regression? 

- No

## Risk

- Low

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Unit tests
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14003)