### PR TITLE
Fix 14062: Refactor StatusStrip DefaultPadding calculation and adjust GripWidth for improved layout consistency

### DIFF
--- a/src/System.Windows.Forms/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/PublicAPI.Unshipped.txt
@@ -1,4 +1,3 @@
-override System.Windows.Forms.StatusStrip.DisplayRectangle.get -> System.Drawing.Rectangle
 static System.Windows.Forms.Application.SetColorMode(System.Windows.Forms.SystemColorMode systemColorMode) -> void
 static System.Windows.Forms.TaskDialog.ShowDialogAsync(nint hwndOwner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!
 static System.Windows.Forms.TaskDialog.ShowDialogAsync(System.Windows.Forms.IWin32Window! owner, System.Windows.Forms.TaskDialogPage! page, System.Windows.Forms.TaskDialogStartupLocation startupLocation = System.Windows.Forms.TaskDialogStartupLocation.CenterOwner) -> System.Threading.Tasks.Task<System.Windows.Forms.TaskDialogButton!>!

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/StatusStrip.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/StatusStrip.cs
@@ -20,7 +20,7 @@ public partial class StatusStrip : ToolStrip
     private static readonly int s_stateSizingGrip = BitVector32.CreateMask();
     private static readonly int s_stateCalledSpringTableLayout = BitVector32.CreateMask(s_stateSizingGrip);
 
-    private const int GripWidth = 12;
+    private const int GripWidth = 15;
     private const int GripHeight = 22;
 
     private RightToLeftLayoutGrip? _rtlLayoutGrip;
@@ -72,14 +72,22 @@ public partial class StatusStrip : ToolStrip
         {
             if (Orientation == Orientation.Horizontal)
             {
-                return RightToLeft == RightToLeft.No ? new Padding(1, 0, 2, 0) : new Padding(2, 0, 1, 0);
+                int gripPaddingWidth = SizeGripBounds.Width < GripWidth + 2
+                    ? GripWidth + 2
+                    : SizeGripBounds.Width;
+                return RightToLeft == RightToLeft.No
+                    ? new Padding(1, 0, gripPaddingWidth, 0)
+                    : new Padding(gripPaddingWidth, 0, 1, 0);
             }
             else
             {
                 // vertical
                 // the difference in symmetry here is that the grip does not actually rotate, it remains the same height it
                 // was before, so the DisplayRectangle needs to shrink up by its height.
-                return new Padding(1, 3, 1, 0);
+                int gripPaddingHeight = SizeGripBounds.Height < DefaultSize.Height
+                    ? DefaultSize.Height
+                    : SizeGripBounds.Height;
+                return new Padding(1, 3, 1, gripPaddingHeight);
             }
         }
     }
@@ -307,49 +315,6 @@ public partial class StatusStrip : ToolStrip
         }
 
         return base.GetPreferredSizeCore(proposedSize);
-    }
-
-    /// <summary>
-    ///  Returns the client rect of the display area of the control.
-    ///  When SizingGrip is enabled, `DisplayRectangle` excludes the sizing grip width.
-    /// </summary>
-    public override Rectangle DisplayRectangle
-    {
-        get
-        {
-            Rectangle rect = base.DisplayRectangle;
-
-            if (!SizingGrip)
-            {
-                return rect;
-            }
-
-            Rectangle grip = SizeGripBounds;
-
-            if (grip.IsEmpty)
-            {
-                return rect;
-            }
-
-            int scaledGripWidth = grip.Width;
-
-            if (Orientation == Orientation.Horizontal)
-            {
-                // Reduce width to account for sizing grip
-                rect.Width = Math.Max(0, rect.Width - scaledGripWidth);
-                if (RightToLeft == RightToLeft.Yes)
-                {
-                    rect.X += scaledGripWidth;
-                }
-            }
-            else
-            {
-                // Reduce height to account for sizing grip (vertical orientation)
-                rect.Height = Math.Max(0, rect.Height - grip.Height);
-            }
-
-            return rect;
-        }
     }
 
     protected override void OnPaintBackground(PaintEventArgs e)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
@@ -728,11 +728,6 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
         {
             Rectangle rect = base.DisplayRectangle;
 
-            if (this is StatusStrip)
-            {
-                return rect;
-            }
-
             if ((LayoutEngine is ToolStripSplitStackLayout) && (GripStyle == ToolStripGripStyle.Visible))
             {
                 if (Orientation == Orientation.Horizontal)

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/StatusStripTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/StatusStripTests.cs
@@ -59,20 +59,20 @@ public partial class StatusStripTests
         Assert.Equal(Padding.Empty, control.DefaultMargin);
         Assert.Equal(Size.Empty, control.DefaultMaximumSize);
         Assert.Equal(Size.Empty, control.DefaultMinimumSize);
-        Assert.Equal(new Padding(1, 0, 14, 0), control.DefaultPadding);
+        Assert.Equal(new Padding(1, 0, 17, 0), control.DefaultPadding);
         Assert.Equal(new Size(200, 22), control.DefaultSize);
         Assert.False(control.DefaultShowItemToolTips);
         Assert.False(control.DesignMode);
         Assert.Empty(control.DisplayedItems);
         Assert.Same(control.DisplayedItems, control.DisplayedItems);
-        Assert.Equal(new Rectangle(1, 0, 173, 22), control.DisplayRectangle);
+        Assert.Equal(new Rectangle(1, 0, 182, 22), control.DisplayRectangle);
         Assert.Equal(DockStyle.Bottom, control.Dock);
         Assert.NotNull(control.DockPadding);
         Assert.Same(control.DockPadding, control.DockPadding);
         Assert.Equal(0, control.DockPadding.Top);
         Assert.Equal(0, control.DockPadding.Bottom);
         Assert.Equal(1, control.DockPadding.Left);
-        Assert.Equal(14, control.DockPadding.Right);
+        Assert.Equal(17, control.DockPadding.Right);
         Assert.True(control.DoubleBuffered);
         Assert.True(control.Enabled);
         Assert.NotNull(control.Events);
@@ -108,13 +108,13 @@ public partial class StatusStripTests
         Assert.Equal(Point.Empty, control.Location);
         Assert.Equal(Padding.Empty, control.Margin);
         Assert.Equal(Size.Empty, control.MaximumSize);
-        Assert.Equal(new Size(173, 22), control.MaxItemSize);
+        Assert.Equal(new Size(182, 22), control.MaxItemSize);
         Assert.Equal(Size.Empty, control.MinimumSize);
         Assert.Equal(Orientation.Horizontal, control.Orientation);
         Assert.NotNull(control.OverflowButton);
         Assert.Same(control.OverflowButton, control.OverflowButton);
         Assert.Same(control, control.OverflowButton.GetCurrentParent());
-        Assert.Equal(new Padding(1, 0, 14, 0), control.Padding);
+        Assert.Equal(new Padding(1, 0, 17, 0), control.Padding);
         Assert.Null(control.Parent);
         Assert.True(control.PreferredSize.Width > 0);
         Assert.True(control.PreferredSize.Height > 0);
@@ -136,7 +136,7 @@ public partial class StatusStripTests
         Assert.Null(control.Site);
         Assert.Equal(new Size(200, 22), control.Size);
         Assert.True(control.SizingGrip);
-        Assert.Equal(new Rectangle(188, 0, 12, 22), control.SizeGripBounds);
+        Assert.Equal(new Rectangle(185, 0, 15, 22), control.SizeGripBounds);
         Assert.True(control.Stretch);
         Assert.Equal(0, control.TabIndex);
         Assert.False(control.TabStop);
@@ -202,21 +202,21 @@ public partial class StatusStripTests
 
     public static IEnumerable<object[]> DefaultPadding_Get_TestData()
     {
-        yield return new object[] { ToolStripLayoutStyle.Flow, RightToLeft.Yes, new Padding(14, 0, 1, 0) };
-        yield return new object[] { ToolStripLayoutStyle.Flow, RightToLeft.No, new Padding(1, 0, 14, 0) };
-        yield return new object[] { ToolStripLayoutStyle.Flow, RightToLeft.Inherit, new Padding(1, 0, 14, 0) };
+        yield return new object[] { ToolStripLayoutStyle.Flow, RightToLeft.Yes, new Padding(17, 0, 1, 0) };
+        yield return new object[] { ToolStripLayoutStyle.Flow, RightToLeft.No, new Padding(1, 0, 17, 0) };
+        yield return new object[] { ToolStripLayoutStyle.Flow, RightToLeft.Inherit, new Padding(1, 0, 17, 0) };
 
-        yield return new object[] { ToolStripLayoutStyle.HorizontalStackWithOverflow, RightToLeft.Yes, new Padding(14, 0, 1, 0) };
-        yield return new object[] { ToolStripLayoutStyle.HorizontalStackWithOverflow, RightToLeft.No, new Padding(1, 0, 14, 0) };
-        yield return new object[] { ToolStripLayoutStyle.HorizontalStackWithOverflow, RightToLeft.Inherit, new Padding(1, 0, 14, 0) };
+        yield return new object[] { ToolStripLayoutStyle.HorizontalStackWithOverflow, RightToLeft.Yes, new Padding(17, 0, 1, 0) };
+        yield return new object[] { ToolStripLayoutStyle.HorizontalStackWithOverflow, RightToLeft.No, new Padding(1, 0, 17, 0) };
+        yield return new object[] { ToolStripLayoutStyle.HorizontalStackWithOverflow, RightToLeft.Inherit, new Padding(1, 0, 17, 0) };
 
-        yield return new object[] { ToolStripLayoutStyle.StackWithOverflow, RightToLeft.Yes, new Padding(14, 0, 1, 0) };
-        yield return new object[] { ToolStripLayoutStyle.StackWithOverflow, RightToLeft.No, new Padding(1, 0, 14, 0) };
-        yield return new object[] { ToolStripLayoutStyle.StackWithOverflow, RightToLeft.Inherit, new Padding(1, 0, 14, 0) };
+        yield return new object[] { ToolStripLayoutStyle.StackWithOverflow, RightToLeft.Yes, new Padding(17, 0, 1, 0) };
+        yield return new object[] { ToolStripLayoutStyle.StackWithOverflow, RightToLeft.No, new Padding(1, 0, 17, 0) };
+        yield return new object[] { ToolStripLayoutStyle.StackWithOverflow, RightToLeft.Inherit, new Padding(1, 0, 17, 0) };
 
-        yield return new object[] { ToolStripLayoutStyle.Table, RightToLeft.Yes, new Padding(14, 0, 1, 0) };
-        yield return new object[] { ToolStripLayoutStyle.Table, RightToLeft.No, new Padding(1, 0, 14, 0) };
-        yield return new object[] { ToolStripLayoutStyle.Table, RightToLeft.Inherit, new Padding(1, 0, 14, 0) };
+        yield return new object[] { ToolStripLayoutStyle.Table, RightToLeft.Yes, new Padding(17, 0, 1, 0) };
+        yield return new object[] { ToolStripLayoutStyle.Table, RightToLeft.No, new Padding(1, 0, 17, 0) };
+        yield return new object[] { ToolStripLayoutStyle.Table, RightToLeft.Inherit, new Padding(1, 0, 17, 0) };
 
         yield return new object[] { ToolStripLayoutStyle.VerticalStackWithOverflow, RightToLeft.Yes, new Padding(1, 3, 1, 22) };
         yield return new object[] { ToolStripLayoutStyle.VerticalStackWithOverflow, RightToLeft.No, new Padding(1, 3, 1, 22) };
@@ -396,7 +396,7 @@ public partial class StatusStripTests
     public static IEnumerable<object[]> Padding_Set_TestData()
     {
         yield return new object[] { default(Padding), default(Padding), 1, 1 };
-        yield return new object[] { new Padding(1, 0, 14, 0), new Padding(1, 0, 14, 0), 0, 0 };
+        yield return new object[] { new Padding(1, 0, 17, 0), new Padding(1, 0, 17, 0), 0, 0 };
         yield return new object[] { new Padding(1, 2, 3, 4), new Padding(1, 2, 3, 4), 1, 1 };
         yield return new object[] { new Padding(1), new Padding(1), 1, 1 };
         yield return new object[] { new Padding(-1, -2, -3, -4), Padding.Empty, 1, 2 };
@@ -620,9 +620,9 @@ public partial class StatusStripTests
     {
         foreach (ToolStripLayoutStyle layoutStyle in Enum.GetValues(typeof(ToolStripLayoutStyle)))
         {
-            yield return new object[] { true, layoutStyle, RightToLeft.Yes, new Rectangle(0, 0, 12, 22) };
-            yield return new object[] { true, layoutStyle, RightToLeft.No, new Rectangle(188, 0, 12, 22) };
-            yield return new object[] { true, layoutStyle, RightToLeft.Inherit, new Rectangle(188, 0, 12, 22) };
+            yield return new object[] { true, layoutStyle, RightToLeft.Yes, new Rectangle(0, 0, 15, 22) };
+            yield return new object[] { true, layoutStyle, RightToLeft.No, new Rectangle(185, 0, 15, 22) };
+            yield return new object[] { true, layoutStyle, RightToLeft.Inherit, new Rectangle(185, 0, 15, 22) };
             yield return new object[] { false, layoutStyle, RightToLeft.Yes, Rectangle.Empty };
             yield return new object[] { false, layoutStyle, RightToLeft.No, Rectangle.Empty };
             yield return new object[] { false, layoutStyle, RightToLeft.Inherit, Rectangle.Empty };
@@ -646,9 +646,9 @@ public partial class StatusStripTests
     {
         foreach (ToolStripLayoutStyle layoutStyle in Enum.GetValues(typeof(ToolStripLayoutStyle)))
         {
-            yield return new object[] { true, layoutStyle, RightToLeft.Yes, new Rectangle(0, 10, 12, 22) };
-            yield return new object[] { true, layoutStyle, RightToLeft.No, new Rectangle(198, 10, 12, 22) };
-            yield return new object[] { true, layoutStyle, RightToLeft.Inherit, new Rectangle(198, 10, 12, 22) };
+            yield return new object[] { true, layoutStyle, RightToLeft.Yes, new Rectangle(0, 10, 15, 22) };
+            yield return new object[] { true, layoutStyle, RightToLeft.No, new Rectangle(195, 10, 15, 22) };
+            yield return new object[] { true, layoutStyle, RightToLeft.Inherit, new Rectangle(195, 10, 15, 22) };
             yield return new object[] { false, layoutStyle, RightToLeft.Yes, Rectangle.Empty };
             yield return new object[] { false, layoutStyle, RightToLeft.No, Rectangle.Empty };
             yield return new object[] { false, layoutStyle, RightToLeft.Inherit, Rectangle.Empty };
@@ -673,9 +673,9 @@ public partial class StatusStripTests
     {
         foreach (ToolStripLayoutStyle layoutStyle in Enum.GetValues(typeof(ToolStripLayoutStyle)))
         {
-            yield return new object[] { true, layoutStyle, RightToLeft.Yes, new Rectangle(0, 0, 12, 12) };
-            yield return new object[] { true, layoutStyle, RightToLeft.No, new Rectangle(178, 0, 12, 12) };
-            yield return new object[] { true, layoutStyle, RightToLeft.Inherit, new Rectangle(178, 0, 12, 12) };
+            yield return new object[] { true, layoutStyle, RightToLeft.Yes, new Rectangle(0, 0, 15, 12) };
+            yield return new object[] { true, layoutStyle, RightToLeft.No, new Rectangle(175, 0, 15, 12) };
+            yield return new object[] { true, layoutStyle, RightToLeft.Inherit, new Rectangle(175, 0, 15, 12) };
             yield return new object[] { false, layoutStyle, RightToLeft.Yes, Rectangle.Empty };
             yield return new object[] { false, layoutStyle, RightToLeft.No, Rectangle.Empty };
             yield return new object[] { false, layoutStyle, RightToLeft.Inherit, Rectangle.Empty };


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14062 


## Proposed changes

- **GripWidth Adjustment**
    - Changed GripWidth from 12 to 15 to improve visual balance and reduce unnecessary space.
- **Refactored DefaultPadding Logic**
    - Previous implementation used hardcoded values: Padding(1, 0, 14, 0) or Padding(1, 3, 1, DefaultSize.Height).
    - New implementation dynamically calculates padding based on `SizingGripBounds.Width` and GripWidth for horizontal orientation, and adjusts for height differences in vertical orientation.
- **Update unit test and add StatusStrip to DemoConsole** 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Prevents labels and items from being pushed out of view due to fixed padding values.

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

The right label is missing when the first ToolStripStatusLabel has Spring = True

<img width="1411" height="879" alt="image" src="https://github.com/user-attachments/assets/6c8b5b7e-298b-4cf3-8636-c610592648fa" />


### After
The right-side label is displayed in full.

https://github.com/user-attachments/assets/df379b10-b683-4533-b23d-f6bca6ab850f


## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

-  10.0.0-rc.3.25569.110


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14068)