### PR TITLE
Fixing/clarifying XML comments for ScreenCaptureMode and VB's ColorMode.

### DIFF
--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/ApplyApplicationDefaultsEventArgs.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/ApplyApplicationDefaultsEventArgs.vb
@@ -27,8 +27,9 @@ Namespace Microsoft.VisualBasic.ApplicationServices
         End Sub
 
         ''' <summary>
-        '''  Setting this property inside the event handler determines the
-        '''  <see cref="Application.ColorMode"/> for the application.
+        '''  Setting this property inside the event handler determines the application's
+        '''  <see cref="Application.ColorMode"/>. Use this property to control whether the application
+        '''  uses dark mode, classic mode, or system default for its lifecycle.
         ''' </summary>
         Public Property ColorMode As SystemColorMode
 

--- a/src/System.Windows.Forms/System/Windows/Forms/ScreenCaptureMode.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/ScreenCaptureMode.cs
@@ -4,27 +4,25 @@
 namespace System.Windows.Forms;
 
 /// <summary>
-///  Enumeration defining the behavior when a form or control is captured in a screenshot.
+///  Enumeration defining the behavior when a form is attempted to be captured in a screen capture (clipboard, image file),
+///  in a screen sharing video conference scenario, a video recording or the alike.
 /// </summary>
 public enum ScreenCaptureMode
 {
     /// <summary>
-    ///  The form or control can be captured normally in screenshots. Default.
+    ///  The form can be captured normally in screen captures.
+    ///  Default setting.
     /// </summary>
     Allow = 0,
 
     /// <summary>
-    ///  The form or control appears blacked out in screenshots.
+    ///  Only the form's content is hidden in screenshots.
+    ///  The form's borders and title bar remain visible.
     /// </summary>
     HideContent = 1,
 
     /// <summary>
-    ///  The form or control appears blurred in screenshots.
+    ///  The whole form is invisible in screenshots.
     /// </summary>
-    /// <remarks>
-    ///  <para>
-    ///   Using this option requires Windows 10 version 2004 or higher.
-    ///  </para>
-    /// </remarks>
     HideWindow = 2
 }


### PR DESCRIPTION
Fixes a couple of issues in XML comments for the ScreenCaptionMode and clarifies the usage of the ColorMode property in VB's `ApplyApplicationDefaultEventArg`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14074)