### PR TITLE
Fix issue 14071: ComboBox.ObjectCollection.CopyTo(Array destination, int index) copies Entry object, not inner item

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.ObjectCollection.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.ObjectCollection.cs
@@ -287,7 +287,7 @@ public partial class ComboBox
 
             for (int i = 0; i < count; i++)
             {
-                destination.SetValue(InnerList[i], i + index);
+                destination.SetValue(InnerList[i].Item, i + index);
             }
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14071 

## Proposed changes

- Refactored the CopyTo methods to ensure correct item copying and type safety.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Copying ComboBox items to an array or using a collection wrapper will not throw an InvalidCastException exception.

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

https://github.com/user-attachments/assets/c03043ca-133c-49a3-90f9-11a0cd5ba1e1


### After

https://github.com/user-attachments/assets/b0c911d7-eecc-4838-a54b-9a9959efff25


## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- 10.0.100-rc.2.25502.107


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14075)