### PR TITLE
Fix incorrect logic in CharIsPrintable for UnicodeCategory exclusions

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ByteViewer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ByteViewer.cs
@@ -170,11 +170,11 @@ public class ByteViewer : TableLayoutPanel
     private static bool CharIsPrintable(char c)
     {
         UnicodeCategory uc = char.GetUnicodeCategory(c);
-        return uc is not UnicodeCategory.Control
+        return uc is not (UnicodeCategory.Control
             or UnicodeCategory.Format
             or UnicodeCategory.LineSeparator
             or UnicodeCategory.ParagraphSeparator
-            or UnicodeCategory.OtherNotAssigned;
+            or UnicodeCategory.OtherNotAssigned);
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14072

## Proposed changes

-  The original implementation of `CharIsPrintable` contains a semantic error in the combination of is not and or. As a result, it returns true for any character that is not `Control`, incorrectly classifying characters from `Format`, `LineSeparator`, `ParagraphSeparator`, and `OtherNotAssigned` as printable.
**Impact**: Zero-width spaces, line separators, paragraph separators, and unassigned code points are treated as printable, even though they render as invisible, garbled symbols, or empty spaces.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14079)