### PR TITLE
Adds ExpandColapse pattern to SplitButton

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripSplitButton.ToolStripSplitButtonExAccessibleObject.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripSplitButton.ToolStripSplitButtonExAccessibleObject.cs
@@ -24,9 +24,10 @@ public partial class ToolStripSplitButton
                 // If we don't set a default role for the accessible object
                 // it will be retrieved from Windows.
                 // And we don't have a 100% guarantee it will be correct, hence set it ourselves.
+                // SplitButton control type requires ExpandCollapse pattern support.
                 UIA_PROPERTY_ID.UIA_ControlTypePropertyId when
                     _owningToolStripSplitButton.AccessibleRole == AccessibleRole.Default
-                    => (VARIANT)(int)UIA_CONTROLTYPE_ID.UIA_ButtonControlTypeId,
+                    => (VARIANT)(int)UIA_CONTROLTYPE_ID.UIA_SplitButtonControlTypeId,
                 _ => base.GetPropertyValue(propertyID)
             };
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/ToolStripSplitButton.ToolStripSplitButtonAccessibleObjectTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/ToolStripSplitButton.ToolStripSplitButtonAccessibleObjectTests.cs
@@ -20,14 +20,14 @@ public class ToolStripSplitButton_ToolStripSplitButtonAccessibleObjectTests
     }
 
     [WinFormsFact]
-    public void ToolStripSplitButtonAccessibleObject_ControlType_IsButton_IfAccessibleRoleIsDefault()
+    public void ToolStripSplitButtonAccessibleObject_ControlType_IsSplitButton_IfAccessibleRoleIsDefault()
     {
         using ToolStripSplitButton toolStripSplitButton = new();
         // AccessibleRole is not set = Default
 
         var actual = (UIA_CONTROLTYPE_ID)(int)toolStripSplitButton.AccessibilityObject.GetPropertyValue(UIA_PROPERTY_ID.UIA_ControlTypePropertyId);
 
-        Assert.Equal(UIA_CONTROLTYPE_ID.UIA_ButtonControlTypeId, actual);
+        Assert.Equal(UIA_CONTROLTYPE_ID.UIA_SplitButtonControlTypeId, actual);
     }
 
     [WinFormsFact]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/ToolStripSplitButton.ToolStripSplitButtonExAccessibleObjectTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/ToolStripSplitButton.ToolStripSplitButtonExAccessibleObjectTests.cs
@@ -23,7 +23,7 @@ public class ToolStripSplitButton_ToolStripSplitButtonExAccessibleObjectTests
 
         ToolStripSplitButtonExAccessibleObject accessibleObject = new(toolStripSplitButton);
 
-        Assert.Equal(UIA_CONTROLTYPE_ID.UIA_ButtonControlTypeId, (UIA_CONTROLTYPE_ID)(int)accessibleObject.GetPropertyValue(UIA_PROPERTY_ID.UIA_ControlTypePropertyId));
+        Assert.Equal(UIA_CONTROLTYPE_ID.UIA_SplitButtonControlTypeId, (UIA_CONTROLTYPE_ID)(int)accessibleObject.GetPropertyValue(UIA_PROPERTY_ID.UIA_ControlTypePropertyId));
     }
 
     [WinFormsFact]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes [#4173](https://github.com/microsoft/winforms-designer/issues/4173)


## Proposed changes

- 
- 
- 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- 
- 
- 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- <!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14092)