### PR TITLE
Fix ToolStripStatusLabel text visibility in High Contrast mode with System RenderMode

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripLabel.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripLabel.cs
@@ -360,24 +360,25 @@ public partial class ToolStripLabel : ToolStripItem
                 {
                     font = _hoverLinkFont;
                     textColor = ActiveLinkColor;
-                    if (DisplayInformation.HighContrast)
-                    {
-                        g.FillRectangle(SystemBrushes.Highlight, textRect);
-                    }
                 }
                 else if (Selected)
                 {
                     font = _hoverLinkFont;
                     textColor = (LinkVisited) ? VisitedLinkColor : LinkColor;
-                    if (DisplayInformation.HighContrast)
-                    {
-                        g.FillRectangle(SystemBrushes.Highlight, textRect);
-                    }
                 }
                 else
                 {
                     font = _linkFont;
                     textColor = (LinkVisited) ? VisitedLinkColor : LinkColor;
+                }
+
+                if (Pressed || Selected)
+                {
+                    if (DisplayInformation.HighContrast)
+                    {
+                        g.FillRectangle(SystemBrushes.Highlight, textRect);
+                        textColor = SystemColors.HighlightText;
+                    }
                 }
             }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14098

## Proposed changes

- Modify PaintText() in ToolStripLabel class to make sure ToolStripStatusLabel text visibility in High Contrast mode with System RenderMode.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- ToolStripStatusLabel text visibility in High Contrast mode with System RenderMode.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

https://github.com/user-attachments/assets/a7a2ec47-0d30-458f-a261-904ed2e0e80e

### After

https://github.com/user-attachments/assets/953f39e1-9ab2-4fe7-9c2a-51daff8330a7


## Test methodology <!-- How did you ensure quality? -->

- Manually

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14110)