### PR TITLE
Fix GDI+ crash in FillRectangle with AntiAlias and 24bppRgb

### DIFF
--- a/src/System.Drawing.Common/src/Resources/Strings.resx
+++ b/src/System.Drawing.Common/src/Resources/Strings.resx
@@ -425,4 +425,7 @@
   <data name="IconCouldNotBeExtracted" xml:space="preserve">
     <value>The file path could not be opened or did not contain valid data.</value>
   </data>
+  <data name="ArgumentException_GdiPlus_AntiAlias24bppRgbBounds" xml:space="preserve">
+    <value>Drawing operation exceeds the bounds of the image. This is a known GDI+ limitation with AntiAlias smoothing mode and Format24bppRgb pixel format.</value>
+  </data>
 </root>

--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -1226,10 +1226,29 @@ public sealed unsafe partial class Graphics : MarshalByRefObject, IDisposable, I
         // on a 24bppRgb bitmap, causing an AccessViolationException (or ExecutionEngineException in .NET 9+).
         // We validate the parameters here to prevent the crash.
         if (SmoothingMode == Drawing2D.SmoothingMode.AntiAlias &&
-            _backingImage is { PixelFormat: PixelFormat.Format24bppRgb } &&
-            (x < 0 || y < 0 || x + width > _backingImage.Width || y + height > _backingImage.Height))
+            _backingImage is { PixelFormat: PixelFormat.Format24bppRgb })
         {
-            throw new ArgumentException(SR.ArgumentException_GdiPlus_AntiAlias24bppRgbBounds);
+            float left = x;
+            float right = x + width;
+            float top = y;
+            float bottom = y + height;
+
+            if (width < 0)
+            {
+                left = right;
+                right = x;
+            }
+
+            if (height < 0)
+            {
+                top = bottom;
+                bottom = y;
+            }
+
+            if (left < 0 || top < 0 || right > _backingImage.Width || bottom > _backingImage.Height)
+            {
+                throw new ArgumentException(SR.ArgumentException_GdiPlus_AntiAlias24bppRgbBounds);
+            }
         }
 
         CheckErrorStatus(PInvokeGdiPlus.GdipFillRectangle(

--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -1225,11 +1225,11 @@ public sealed unsafe partial class Graphics : MarshalByRefObject, IDisposable, I
         // GDI+ has a bug where it writes out of bounds when using AntiAlias smoothing mode
         // on a 24bppRgb bitmap, causing an AccessViolationException (or ExecutionEngineException in .NET 9+).
         // We validate the parameters here to prevent the crash.
-        if (SmoothingMode == System.Drawing.Drawing2D.SmoothingMode.AntiAlias &&
+        if (SmoothingMode == Drawing2D.SmoothingMode.AntiAlias &&
             _backingImage is { PixelFormat: PixelFormat.Format24bppRgb } &&
             (x < 0 || y < 0 || x + width > _backingImage.Width || y + height > _backingImage.Height))
         {
-            throw new ArgumentException("Drawing operation exceeds the bounds of the image. This is a known GDI+ limitation with AntiAlias smoothing mode and Format24bppRgb pixel format.");
+            throw new ArgumentException(SR.ArgumentException_GdiPlus_AntiAlias24bppRgbBounds);
         }
 
         CheckErrorStatus(PInvokeGdiPlus.GdipFillRectangle(

--- a/src/System.Drawing.Common/tests/System/Drawing/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/GraphicsTests.cs
@@ -3002,5 +3002,19 @@ public partial class GraphicsTests
         graphics.FillRoundedRectangle(Brushes.Green, new RectangleF(0, 0, 10, 10), new(2, 2));
         VerifyBitmapNotEmpty(bitmap);
     }
+
+    [Fact]
+    public void FillRectangle_AntiAlias_24bppRgb_OutOfBounds_ThrowsArgumentException()
+    {
+        using Bitmap bmp = new(256, 256, PixelFormat.Format24bppRgb);
+        using Graphics graphics = Graphics.FromImage(bmp);
+        graphics.SmoothingMode = SmoothingMode.AntiAlias;
+
+        // This combination causes a crash in GDI+ on .NET 9+ (ExecutionEngineException)
+        // and AccessViolationException on .NET 8.
+        // We expect our fix to throw ArgumentException instead.
+        Assert.Throws<ArgumentException>(() =>
+            graphics.FillRectangle(Brushes.Green, new RectangleF(190.5f, 180.5f, 100, 100)));
+    }
 #endif
 }

--- a/src/System.Drawing.Common/tests/System/Drawing/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/GraphicsTests.cs
@@ -3009,6 +3009,8 @@ public partial class GraphicsTests
     [InlineData(10, -10, 100, 100)]        // Out of bounds (top)
     [InlineData(200, 10, 100, 100)]        // Out of bounds (right)
     [InlineData(10, 200, 100, 100)]        // Out of bounds (bottom)
+    [InlineData(10, 10, -100, 100)]        // Out of bounds (negative width extending left)
+    [InlineData(10, 10, 100, -100)]        // Out of bounds (negative height extending top)
     public void FillRectangle_AntiAlias_24bppRgb_OutOfBounds_ThrowsArgumentException(float x, float y, float width, float height)
     {
         using Bitmap bmp = new(256, 256, PixelFormat.Format24bppRgb);
@@ -3025,6 +3027,7 @@ public partial class GraphicsTests
     [Theory]
     [InlineData(0, 0, 100, 100)]           // Within bounds
     [InlineData(156, 156, 100, 100)]       // Exactly on bounds (256 - 100 = 156)
+    [InlineData(100, 100, -50, -50)]       // Within bounds (negative width/height)
     public void FillRectangle_AntiAlias_24bppRgb_WithinBounds_Success(float x, float y, float width, float height)
     {
         using Bitmap bmp = new(256, 256, PixelFormat.Format24bppRgb);


### PR DESCRIPTION
Fixes #14113

## Description
This PR addresses a crash (AccessViolationException in .NET 8, ExecutionEngineException in .NET 9+) that occurs when calling \Graphics.FillRectangle\ with a specific combination of parameters:
- \PixelFormat.Format24bppRgb\
- \SmoothingMode.AntiAlias\
- Drawing outside the bitmap bounds

This is a known GDI+ bug where it writes out of bounds. In .NET 9, the runtime treats this memory corruption as fatal and terminates the process.

## Fix
Added parameter validation in \Graphics.FillRectangle\ to detect this specific unsafe combination and throw a managed \ArgumentException\ instead of allowing the process to crash.

## Regression
This is a fix for a crash that became fatal in .NET 9 due to stricter runtime exception handling.

## Testing
Verified with a reproduction app that previously crashed the process and now correctly throws an ArgumentException.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14115)