### PR TITLE
[release/10.0] Refactor StatusStrip DefaultPadding calculation and adjust GripWidth for improved layout consistency

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/StatusStrip.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/StatusStrip.cs
@@ -20,7 +20,7 @@ public partial class StatusStrip : ToolStrip
     private static readonly int s_stateSizingGrip = BitVector32.CreateMask();
     private static readonly int s_stateCalledSpringTableLayout = BitVector32.CreateMask(s_stateSizingGrip);
 
-    private const int GripWidth = 12;
+    private const int GripWidth = 15;
     private const int GripHeight = 22;
 
     private RightToLeftLayoutGrip? _rtlLayoutGrip;
@@ -72,14 +72,22 @@ public partial class StatusStrip : ToolStrip
         {
             if (Orientation == Orientation.Horizontal)
             {
-                return RightToLeft == RightToLeft.No ? new Padding(1, 0, 14, 0) : new Padding(14, 0, 1, 0);
+                int gripPaddingWidth = SizeGripBounds.Width < GripWidth + 2
+                    ? GripWidth + 2
+                    : SizeGripBounds.Width;
+                return RightToLeft == RightToLeft.No
+                    ? new Padding(1, 0, gripPaddingWidth, 0)
+                    : new Padding(gripPaddingWidth, 0, 1, 0);
             }
             else
             {
                 // vertical
                 // the difference in symmetry here is that the grip does not actually rotate, it remains the same height it
                 // was before, so the DisplayRectangle needs to shrink up by its height.
-                return new Padding(1, 3, 1, DefaultSize.Height);
+                int gripPaddingHeight = SizeGripBounds.Height < DefaultSize.Height
+                    ? DefaultSize.Height
+                    : SizeGripBounds.Height;
+                return new Padding(1, 3, 1, gripPaddingHeight);
             }
         }
     }

--- a/src/test/integration/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/test/integration/DesignSurface/DemoConsole/MainForm.cs
@@ -291,7 +291,7 @@ public partial class MainForm : Form
                     break;
                 case 5:
                     {
-                        rootComponent = surface.CreateRootComponent<Form>(new Size(800, 600));
+                        rootComponent = surface.CreateRootComponent<Form>(new Size(900, 600));
                         rootComponent.BackColor = Color.Orange;
                         rootComponent.Text = "Root Component hosted by the DesignSurface N.5";
 
@@ -309,6 +309,24 @@ public partial class MainForm : Form
                         DataGridViewComboBoxColumn comboBoxColumn = surface.CreateComponent<DataGridViewComboBoxColumn>();
                         comboBoxColumn.HeaderText = "Column1";
                         dataGridView.Columns.AddRange([comboBoxColumn]);
+
+                        StatusStrip statusStrip1 = surface.CreateControl<StatusStrip>(new Size(400, 50), new Point(500, 0));
+                        ToolStripStatusLabel toolStripStatusLabel1 = surface.CreateComponent<ToolStripStatusLabel>();
+                        ToolStripStatusLabel toolStripStatusLabel2 = surface.CreateComponent<ToolStripStatusLabel>();
+                        statusStrip1.Dock = DockStyle.Right;
+                        statusStrip1.AutoSize = true;
+                        statusStrip1.SizingGrip = true;
+
+                        toolStripStatusLabel1.Name = "toolStripStatusLabel1";
+                        toolStripStatusLabel1.Size = new Size(667, 17);
+                        toolStripStatusLabel1.Spring = true;
+                        toolStripStatusLabel1.Text = "toolStripStatusLabel1";
+
+                        toolStripStatusLabel2.Name = "toolStripStatusLabel2";
+                        toolStripStatusLabel2.Size = new Size(118, 17);
+                        toolStripStatusLabel2.Text = "toolStripStatusLabel2";
+
+                        statusStrip1.Items.AddRange([toolStripStatusLabel1, toolStripStatusLabel2]);
                     }
 
                     break;

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/StatusStrip.StatusStripAccessibleObjectTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/StatusStrip.StatusStripAccessibleObjectTests.cs
@@ -738,8 +738,8 @@ public class StatusStrip_StatusStripAccessibleObjectTests
     {
         Size horizontalOverflowSize = new(70, 30);
         Size horizontalOverflowGripSize = new(80, 30);
-        Size verticalOverflowSize = new(80, 55);
-        Size verticalOverflowGripSize = new(80, 65);
+        Size verticalOverflowSize = new(80, 77);
+        Size verticalOverflowGripSize = new(80, 87);
         Size bothOverflowSize = new(70, 25);
 
         yield return new object[] { ToolStripGripStyle.Visible, ToolStripLayoutStyle.HorizontalStackWithOverflow, null, horizontalOverflowGripSize };
@@ -777,8 +777,8 @@ public class StatusStrip_StatusStripAccessibleObjectTests
     {
         Size horizontalOverflowSize = new(70, 30);
         Size horizontalOverflowGripSize = new(80, 30);
-        Size verticalOverflowSize = new(30, 55);
-        Size verticalOverflowGripSize = new(30, 65);
+        Size verticalOverflowSize = new(30, 77);
+        Size verticalOverflowGripSize = new(30, 87);
         Size bothOverflowSize = new(70, 30);
 
         yield return new object[] { ToolStripGripStyle.Visible, ToolStripLayoutStyle.HorizontalStackWithOverflow, null, horizontalOverflowGripSize };
@@ -820,8 +820,8 @@ public class StatusStrip_StatusStripAccessibleObjectTests
     {
         Size horizontalOverflowSize = new(70, 30);
         Size horizontalOverflowGripSize = new(80, 30);
-        Size verticalOverflowSize = new(60, 60);
-        Size verticalOverflowGripSize = new(70, 70);
+        Size verticalOverflowSize = new(60, 82);
+        Size verticalOverflowGripSize = new(70, 92);
 
         yield return new object[] { ToolStripGripStyle.Visible, ToolStripLayoutStyle.HorizontalStackWithOverflow, null, horizontalOverflowGripSize };
         yield return new object[] { ToolStripGripStyle.Hidden, ToolStripLayoutStyle.HorizontalStackWithOverflow, null, horizontalOverflowSize };
@@ -933,7 +933,7 @@ public class StatusStrip_StatusStripAccessibleObjectTests
             return new ToolStripStatusLabel()
             {
                 AutoSize = false,
-                Size = new Size(50, 25)
+                Size = new Size(40, 25)
             };
         }
     }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/StatusStripTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/StatusStripTests.cs
@@ -59,20 +59,20 @@ public partial class StatusStripTests
         Assert.Equal(Padding.Empty, control.DefaultMargin);
         Assert.Equal(Size.Empty, control.DefaultMaximumSize);
         Assert.Equal(Size.Empty, control.DefaultMinimumSize);
-        Assert.Equal(new Padding(1, 0, 14, 0), control.DefaultPadding);
+        Assert.Equal(new Padding(1, 0, 17, 0), control.DefaultPadding);
         Assert.Equal(new Size(200, 22), control.DefaultSize);
         Assert.False(control.DefaultShowItemToolTips);
         Assert.False(control.DesignMode);
         Assert.Empty(control.DisplayedItems);
         Assert.Same(control.DisplayedItems, control.DisplayedItems);
-        Assert.Equal(new Rectangle(1, 0, 185, 22), control.DisplayRectangle);
+        Assert.Equal(new Rectangle(1, 0, 182, 22), control.DisplayRectangle);
         Assert.Equal(DockStyle.Bottom, control.Dock);
         Assert.NotNull(control.DockPadding);
         Assert.Same(control.DockPadding, control.DockPadding);
         Assert.Equal(0, control.DockPadding.Top);
         Assert.Equal(0, control.DockPadding.Bottom);
         Assert.Equal(1, control.DockPadding.Left);
-        Assert.Equal(14, control.DockPadding.Right);
+        Assert.Equal(17, control.DockPadding.Right);
         Assert.True(control.DoubleBuffered);
         Assert.True(control.Enabled);
         Assert.NotNull(control.Events);
@@ -108,13 +108,13 @@ public partial class StatusStripTests
         Assert.Equal(Point.Empty, control.Location);
         Assert.Equal(Padding.Empty, control.Margin);
         Assert.Equal(Size.Empty, control.MaximumSize);
-        Assert.Equal(new Size(185, 22), control.MaxItemSize);
+        Assert.Equal(new Size(182, 22), control.MaxItemSize);
         Assert.Equal(Size.Empty, control.MinimumSize);
         Assert.Equal(Orientation.Horizontal, control.Orientation);
         Assert.NotNull(control.OverflowButton);
         Assert.Same(control.OverflowButton, control.OverflowButton);
         Assert.Same(control, control.OverflowButton.GetCurrentParent());
-        Assert.Equal(new Padding(1, 0, 14, 0), control.Padding);
+        Assert.Equal(new Padding(1, 0, 17, 0), control.Padding);
         Assert.Null(control.Parent);
         Assert.True(control.PreferredSize.Width > 0);
         Assert.True(control.PreferredSize.Height > 0);
@@ -136,7 +136,7 @@ public partial class StatusStripTests
         Assert.Null(control.Site);
         Assert.Equal(new Size(200, 22), control.Size);
         Assert.True(control.SizingGrip);
-        Assert.Equal(new Rectangle(188, 0, 12, 22), control.SizeGripBounds);
+        Assert.Equal(new Rectangle(185, 0, 15, 22), control.SizeGripBounds);
         Assert.True(control.Stretch);
         Assert.Equal(0, control.TabIndex);
         Assert.False(control.TabStop);
@@ -202,21 +202,21 @@ public partial class StatusStripTests
 
     public static IEnumerable<object[]> DefaultPadding_Get_TestData()
     {
-        yield return new object[] { ToolStripLayoutStyle.Flow, RightToLeft.Yes, new Padding(14, 0, 1, 0) };
-        yield return new object[] { ToolStripLayoutStyle.Flow, RightToLeft.No, new Padding(1, 0, 14, 0) };
-        yield return new object[] { ToolStripLayoutStyle.Flow, RightToLeft.Inherit, new Padding(1, 0, 14, 0) };
+        yield return new object[] { ToolStripLayoutStyle.Flow, RightToLeft.Yes, new Padding(17, 0, 1, 0) };
+        yield return new object[] { ToolStripLayoutStyle.Flow, RightToLeft.No, new Padding(1, 0, 17, 0) };
+        yield return new object[] { ToolStripLayoutStyle.Flow, RightToLeft.Inherit, new Padding(1, 0, 17, 0) };
 
-        yield return new object[] { ToolStripLayoutStyle.HorizontalStackWithOverflow, RightToLeft.Yes, new Padding(14, 0, 1, 0) };
-        yield return new object[] { ToolStripLayoutStyle.HorizontalStackWithOverflow, RightToLeft.No, new Padding(1, 0, 14, 0) };
-        yield return new object[] { ToolStripLayoutStyle.HorizontalStackWithOverflow, RightToLeft.Inherit, new Padding(1, 0, 14, 0) };
+        yield return new object[] { ToolStripLayoutStyle.HorizontalStackWithOverflow, RightToLeft.Yes, new Padding(17, 0, 1, 0) };
+        yield return new object[] { ToolStripLayoutStyle.HorizontalStackWithOverflow, RightToLeft.No, new Padding(1, 0, 17, 0) };
+        yield return new object[] { ToolStripLayoutStyle.HorizontalStackWithOverflow, RightToLeft.Inherit, new Padding(1, 0, 17, 0) };
 
-        yield return new object[] { ToolStripLayoutStyle.StackWithOverflow, RightToLeft.Yes, new Padding(14, 0, 1, 0) };
-        yield return new object[] { ToolStripLayoutStyle.StackWithOverflow, RightToLeft.No, new Padding(1, 0, 14, 0) };
-        yield return new object[] { ToolStripLayoutStyle.StackWithOverflow, RightToLeft.Inherit, new Padding(1, 0, 14, 0) };
+        yield return new object[] { ToolStripLayoutStyle.StackWithOverflow, RightToLeft.Yes, new Padding(17, 0, 1, 0) };
+        yield return new object[] { ToolStripLayoutStyle.StackWithOverflow, RightToLeft.No, new Padding(1, 0, 17, 0) };
+        yield return new object[] { ToolStripLayoutStyle.StackWithOverflow, RightToLeft.Inherit, new Padding(1, 0, 17, 0) };
 
-        yield return new object[] { ToolStripLayoutStyle.Table, RightToLeft.Yes, new Padding(14, 0, 1, 0) };
-        yield return new object[] { ToolStripLayoutStyle.Table, RightToLeft.No, new Padding(1, 0, 14, 0) };
-        yield return new object[] { ToolStripLayoutStyle.Table, RightToLeft.Inherit, new Padding(1, 0, 14, 0) };
+        yield return new object[] { ToolStripLayoutStyle.Table, RightToLeft.Yes, new Padding(17, 0, 1, 0) };
+        yield return new object[] { ToolStripLayoutStyle.Table, RightToLeft.No, new Padding(1, 0, 17, 0) };
+        yield return new object[] { ToolStripLayoutStyle.Table, RightToLeft.Inherit, new Padding(1, 0, 17, 0) };
 
         yield return new object[] { ToolStripLayoutStyle.VerticalStackWithOverflow, RightToLeft.Yes, new Padding(1, 3, 1, 22) };
         yield return new object[] { ToolStripLayoutStyle.VerticalStackWithOverflow, RightToLeft.No, new Padding(1, 3, 1, 22) };
@@ -396,7 +396,7 @@ public partial class StatusStripTests
     public static IEnumerable<object[]> Padding_Set_TestData()
     {
         yield return new object[] { default(Padding), default(Padding), 1, 1 };
-        yield return new object[] { new Padding(1, 0, 14, 0), new Padding(1, 0, 14, 0), 0, 0 };
+        yield return new object[] { new Padding(1, 0, 17, 0), new Padding(1, 0, 17, 0), 0, 0 };
         yield return new object[] { new Padding(1, 2, 3, 4), new Padding(1, 2, 3, 4), 1, 1 };
         yield return new object[] { new Padding(1), new Padding(1), 1, 1 };
         yield return new object[] { new Padding(-1, -2, -3, -4), Padding.Empty, 1, 2 };
@@ -620,9 +620,9 @@ public partial class StatusStripTests
     {
         foreach (ToolStripLayoutStyle layoutStyle in Enum.GetValues(typeof(ToolStripLayoutStyle)))
         {
-            yield return new object[] { true, layoutStyle, RightToLeft.Yes, new Rectangle(0, 0, 12, 22) };
-            yield return new object[] { true, layoutStyle, RightToLeft.No, new Rectangle(188, 0, 12, 22) };
-            yield return new object[] { true, layoutStyle, RightToLeft.Inherit, new Rectangle(188, 0, 12, 22) };
+            yield return new object[] { true, layoutStyle, RightToLeft.Yes, new Rectangle(0, 0, 15, 22) };
+            yield return new object[] { true, layoutStyle, RightToLeft.No, new Rectangle(185, 0, 15, 22) };
+            yield return new object[] { true, layoutStyle, RightToLeft.Inherit, new Rectangle(185, 0, 15, 22) };
             yield return new object[] { false, layoutStyle, RightToLeft.Yes, Rectangle.Empty };
             yield return new object[] { false, layoutStyle, RightToLeft.No, Rectangle.Empty };
             yield return new object[] { false, layoutStyle, RightToLeft.Inherit, Rectangle.Empty };
@@ -646,9 +646,9 @@ public partial class StatusStripTests
     {
         foreach (ToolStripLayoutStyle layoutStyle in Enum.GetValues(typeof(ToolStripLayoutStyle)))
         {
-            yield return new object[] { true, layoutStyle, RightToLeft.Yes, new Rectangle(0, 10, 12, 22) };
-            yield return new object[] { true, layoutStyle, RightToLeft.No, new Rectangle(198, 10, 12, 22) };
-            yield return new object[] { true, layoutStyle, RightToLeft.Inherit, new Rectangle(198, 10, 12, 22) };
+            yield return new object[] { true, layoutStyle, RightToLeft.Yes, new Rectangle(0, 10, 15, 22) };
+            yield return new object[] { true, layoutStyle, RightToLeft.No, new Rectangle(195, 10, 15, 22) };
+            yield return new object[] { true, layoutStyle, RightToLeft.Inherit, new Rectangle(195, 10, 15, 22) };
             yield return new object[] { false, layoutStyle, RightToLeft.Yes, Rectangle.Empty };
             yield return new object[] { false, layoutStyle, RightToLeft.No, Rectangle.Empty };
             yield return new object[] { false, layoutStyle, RightToLeft.Inherit, Rectangle.Empty };
@@ -673,9 +673,9 @@ public partial class StatusStripTests
     {
         foreach (ToolStripLayoutStyle layoutStyle in Enum.GetValues(typeof(ToolStripLayoutStyle)))
         {
-            yield return new object[] { true, layoutStyle, RightToLeft.Yes, new Rectangle(0, 0, 12, 12) };
-            yield return new object[] { true, layoutStyle, RightToLeft.No, new Rectangle(178, 0, 12, 12) };
-            yield return new object[] { true, layoutStyle, RightToLeft.Inherit, new Rectangle(178, 0, 12, 12) };
+            yield return new object[] { true, layoutStyle, RightToLeft.Yes, new Rectangle(0, 0, 15, 12) };
+            yield return new object[] { true, layoutStyle, RightToLeft.No, new Rectangle(175, 0, 15, 12) };
+            yield return new object[] { true, layoutStyle, RightToLeft.Inherit, new Rectangle(175, 0, 15, 12) };
             yield return new object[] { false, layoutStyle, RightToLeft.Yes, Rectangle.Empty };
             yield return new object[] { false, layoutStyle, RightToLeft.No, Rectangle.Empty };
             yield return new object[] { false, layoutStyle, RightToLeft.Inherit, Rectangle.Empty };


### PR DESCRIPTION
Backport https://github.com/dotnet/winforms/pull/14068 to release/10.0

Fixes  #14062 

## Proposed changes

- **GripWidth Adjustment**
    - Changed GripWidth from 12 to 15 to improve visual balance and reduce unnecessary space.
- **Refactored DefaultPadding Logic**
    - Previous implementation used hardcoded values: Padding(1, 0, 14, 0) or Padding(1, 3, 1, DefaultSize.Height).
    - New implementation dynamically calculates padding based on `SizingGripBounds.Width` and GripWidth for horizontal orientation, and adjusts for height differences in vertical orientation.
- **Update unit test and add StatusStrip in DemoConsole** 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Prevents labels and items from being pushed out of view due to fixed padding values.

## Regression? 

- Yes- regression PR https://github.com/dotnet/winforms/pull/13620

## Risk

- Low

## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Unit tests