### PR TITLE
Optimize OnDrawItem to prevent GDI resource exhaustion by caching scaled icon size

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/CursorEditor.CursorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/CursorEditor.CursorUI.cs
@@ -67,7 +67,7 @@ public partial class CursorEditor
                 string? text = _cursorConverter.ConvertToString(cursor);
                 Font font = e.Font!;
                 using var brushText = e.ForeColor.GetCachedSolidBrushScope();
-                var cursorWidth = GetCursorWidthForDpi(cursor, DeviceDpi);
+                int cursorWidth = GetCursorWidthForDpi(cursor, DeviceDpi);
 
                 e.DrawBackground();
                 e.Graphics.FillRectangle(SystemBrushes.Control, new Rectangle(e.Bounds.X + 2, e.Bounds.Y + 2, cursorWidth, e.Bounds.Height - 4));
@@ -80,8 +80,8 @@ public partial class CursorEditor
 
         private int GetCursorWidthForDpi(Cursor cursor, int dpi)
         {
-            var key = (cursor, dpi);
-            if (_cursorWidthCache.TryGetValue(key, out var cursorWidth))
+            (Cursor cursor, int dpi) key = (cursor, dpi);
+            if (_cursorWidthCache.TryGetValue(key, out int cursorWidth))
             {
                 return cursorWidth;
             }


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14122

## Root Cause

The exception:  `An object could not be created, possibly due to a lack of memory, but most likely due to invalid input`
was triggered because of how `OnDrawItem` handled icon creation in a high-frequency drawing path:

Repeated GDI object creation in hot path
Each call to OnDrawItem executed:
- Icon.FromHandle(cursor.Handle)
- Clone()
- ScaleSmallIconToDpi(...)

This pattern allocates multiple unmanaged GDI resources per draw cycle. Under heavy redraw (scrolling, hover, DPI changes), these allocations accumulate quickly, exhausting GDI handles.

## Proposed changes

- Introduced a caching mechanism for scaled icon width based on (Cursor, DPI) to minimize redundant object creation.
- Ensured ScaleSmallIconToDpi is still called as required, but only during cache population rather than every draw.
- Added proper disposal of temporary Icon objects during cache initialization.
- Cleared the cache in the End method to release resources when the control lifecycle ends.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Eliminates random crashes caused by GDI handle exhaustion in owner-drawn controls.


## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
When using a PropertyGrid to edit properties of type Cursor, resizing the Cursor UITypeEditor drop-down window causes the application to stop responding or crash.

https://github.com/user-attachments/assets/99575f6d-244d-44da-9166-af0b6295fc47


### After

https://github.com/user-attachments/assets/be1f6d59-448a-414e-9da2-064f2b3f61f5



## Test methodology <!-- How did you ensure quality? -->

-  Manual testing


## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-rc.3.25603.106


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14123)