### PR TITLE
Fix visibility logic for addNewPanel in DesignBindingPicker to use _dataSourceProviderService

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignBindingPicker.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignBindingPicker.cs
@@ -419,10 +419,10 @@ namespace System.Windows.Forms.Design
             FillTree(initialSelectedItem);
 
             // Set initial state of the various sub-panels
-             _addNewPanel.Visible = (showDataSources
+            _addNewPanel.Visible = showDataSources
                 && _dataSourceProviderService is not null
-                && _dataSourceProviderService.SupportsAddNewDataSource);
-            _helpTextPanel.Visible = (showDataSources);
+                && _dataSourceProviderService.SupportsAddNewDataSource;
+            _helpTextPanel.Visible = showDataSources;
 
             // Set initial help text in help pane
             UpdateHelpText(null);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignBindingPicker.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignBindingPicker.cs
@@ -419,7 +419,9 @@ namespace System.Windows.Forms.Design
             FillTree(initialSelectedItem);
 
             // Set initial state of the various sub-panels
-            // addNewPanel.Visible = (showDataSources && dspSvc is not null && dspSvc.SupportsAddNewDataSource);
+             _addNewPanel.Visible = (showDataSources
+                && _dataSourceProviderService is not null
+                && _dataSourceProviderService.SupportsAddNewDataSource);
             _helpTextPanel.Visible = (showDataSources);
 
             // Set initial help text in help pane


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14132


## Proposed changes

- Re-enable the visibility logic for _addNewPanel in DesignBindingPicker 


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

-  Previously, the visibility logic for _addNewPanel was commented out(https://github.com/dotnet/winforms/pull/9677), causing the panel to remain always visible, regardless of whether adding new data sources was supported.
- This behavior diverged from .NET Framework, where visibility depends on the data source provider service and its capability to add new data sources.
- The incorrect logic could mislead developers by showing an option that is not actually supported at runtime.
- Restoring the original conditional logic ensures consistency with .NET Framework and improves design-time accuracy.

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

The "Add new Object Data Source" link & description shouldn't display in the DropDown panel for the DataSource & DisplayMember properties in the propertiGird

<img width="1081" height="642" alt="image" src="https://github.com/user-attachments/assets/3e45ac4c-97ed-4aa2-8f79-2861a09499da" />

### After
<img width="1587" height="793" alt="image" src="https://github.com/user-attachments/assets/9e95cd6b-8919-42b2-aefb-b01b59541e6d" />




## Test methodology <!-- How did you ensure quality? -->

-  Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-rc.3.25603.106


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14133)