### PR TITLE
Add AppContext switch to mirror Owner.TopMost for modal dialogs (restore .NET Framework‑like behavior)

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -26,7 +26,7 @@ internal static partial class LocalAppContextSwitches
     internal const string EnableMsoComponentManagerSwitchName = "Switch.System.Windows.Forms.EnableMsoComponentManager";
     internal const string TreeNodeCollectionAddRangeRespectsSortOrderSwitchName = "System.Windows.Forms.TreeNodeCollectionAddRangeRespectsSortOrder";
     internal const string MoveTreeViewTextLocationOnePixelSwitchName = "System.Windows.Forms.TreeView.MoveTreeViewTextLocationOnePixel";
-    internal const string MirrorTopMostForModalDialogsSwitchName = "System.Windows.Forms.TreeView.MirrorTopMostForModalDialogs";
+    internal const string MirrorTopMostForModalDialogsSwitchName = "System.Windows.Forms.MirrorTopMostForModalDialogs";
 
     private static int s_scaleTopLevelFormMinMaxSizeForDpi;
     private static int s_anchorLayoutV2;

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -26,6 +26,7 @@ internal static partial class LocalAppContextSwitches
     internal const string EnableMsoComponentManagerSwitchName = "Switch.System.Windows.Forms.EnableMsoComponentManager";
     internal const string TreeNodeCollectionAddRangeRespectsSortOrderSwitchName = "System.Windows.Forms.TreeNodeCollectionAddRangeRespectsSortOrder";
     internal const string MoveTreeViewTextLocationOnePixelSwitchName = "System.Windows.Forms.TreeView.MoveTreeViewTextLocationOnePixel";
+    internal const string MirrorTopMostForModalDialogsSwitchName = "System.Windows.Forms.TreeView.MirrorTopMostForModalDialogs";
 
     private static int s_scaleTopLevelFormMinMaxSizeForDpi;
     private static int s_anchorLayoutV2;
@@ -37,6 +38,7 @@ internal static partial class LocalAppContextSwitches
     private static int s_noClientNotifications;
     private static int s_enableMsoComponentManager;
     private static int s_treeNodeCollectionAddRangeRespectsSortOrder;
+    private static int s_mirrorTopMostForModalDialogs;
 
     private static int s_moveTreeViewTextLocationOnePixel;
 
@@ -220,6 +222,18 @@ internal static partial class LocalAppContextSwitches
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => GetCachedSwitchValue(TreeNodeCollectionAddRangeRespectsSortOrderSwitchName, ref s_treeNodeCollectionAddRangeRespectsSortOrder);
+    }
+
+    /// <summary>
+    ///  When true, ShowDialog will temporarily set the dialog as TopMost if its owner is TopMost.
+    ///  This prevents the dialog from being covered by the owner during the modal session.
+    ///  The original TopMost state is restored after closing.
+    ///  Default is false. Set to true for .NET Framework-compatible behavior.
+    /// </summary>
+    public static bool MirrorTopMostForModalDialogs
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetCachedSwitchValue(MirrorTopMostForModalDialogsSwitchName, ref s_mirrorTopMostForModalDialogs);
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Form.cs
@@ -5830,8 +5830,8 @@ public partial class Form : ContainerControl
             }
         }
 
-            return DialogResult;
-        }
+        return DialogResult;
+    }
 
     /// <summary>
     ///  Shows the form as a modal dialog box asynchronously.

--- a/src/System.Windows.Forms/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Form.cs
@@ -5824,7 +5824,7 @@ public partial class Form : ContainerControl
             Properties.RemoveValue(s_propDialogOwner);
             GC.KeepAlive(ownerHwnd.Wrapper);
 
-            if (mirrored && TopMost != originalTopMost)
+            if (mirrored)
             {
                 TopMost = originalTopMost;
             }

--- a/src/System.Windows.Forms/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Form.cs
@@ -5718,6 +5718,9 @@ public partial class Form : ContainerControl
 
         Form? oldOwner = OwnerInternal;
 
+        bool originalTopMost = TopMost;
+        bool mirrored = false;
+
         try
         {
             SetState(States.Modal, true);
@@ -5755,6 +5758,12 @@ public partial class Form : ContainerControl
                 if (owner is Form form && owner != oldOwner)
                 {
                     Owner = form;
+
+                    if (AppContextSwitches.MirrorTopMostForModalDialogs && TopLevel && !IsMdiChild && Owner.TopMost && !TopMost)
+                    {
+                        TopMost = true;
+                        mirrored = true;
+                    }
                 }
                 else
                 {
@@ -5814,10 +5823,15 @@ public partial class Form : ContainerControl
             Owner = oldOwner;
             Properties.RemoveValue(s_propDialogOwner);
             GC.KeepAlive(ownerHwnd.Wrapper);
+
+            if (mirrored && TopMost != originalTopMost)
+            {
+                TopMost = originalTopMost;
+            }
         }
 
-        return DialogResult;
-    }
+            return DialogResult;
+        }
 
     /// <summary>
     ///  Shows the form as a modal dialog box asynchronously.


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14101


## Proposed changes

-  Add an  switch `System.Windows.Forms.MirrorTopMostForModalDialogs`.
When enabled, `ShowDialog` will temporarily set the dialog as `TopMost` if its owner is `TopMost`, and restore the original state after closing.
Default is false to keep current behavior.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- With the switch off: No change, modern .NET behavior remains.
- With the switch on: Modal dialogs owned by `TopMost` forms will stay above the owner during the modal session, matching .NET Framework behavior.

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

If the owner is TopMost and the dialog is not, the dialog can be pushed behind the owner during the modal session.
<img width="1643" height="772" alt="Image" src="https://github.com/user-attachments/assets/0c70c1a9-a4a5-45d2-80da-a1e10c2176fa" />

### After
Modal dialogs temporarily become TopMost when the owner is TopMost, and stay above the owner until closed.

<img width="1350" height="807" alt="Image" src="https://github.com/user-attachments/assets/7ef37eec-7303-46b4-a88b-44a55a60676b" />

### Test methodology <!-- How did you ensure quality? -->

-  Manually


## Test environment(s) <!-- Remove any that don't apply -->

-  .net 10.0.0-rc.3.25603.106


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14138)