### PR TITLE
Fix insufficient contrast for PropertyGrid dropdown text in Dark Mode

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerUtils.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerUtils.cs
@@ -832,7 +832,8 @@ internal static class DesignerUtils
         treeView.HotTracking = true;
         treeView.ShowLines = false;
         HWND hwnd = (HWND)treeView.Handle;
-        PInvoke.SetWindowTheme(hwnd, "Explorer", pszSubIdList: null);
+        string theme = Application.IsDarkModeEnabled ? "DarkMode_Explorer" : "Explorer";
+        PInvoke.SetWindowTheme(hwnd, theme, pszSubIdList: null);
         uint exstyle = TreeView_GetExtendedStyle(hwnd);
         exstyle |= PInvoke.TVS_EX_DOUBLEBUFFER | PInvoke.TVS_EX_FADEINOUTEXPANDOS;
         PInvokeCore.SendMessage(treeView, PInvoke.TVM_SETEXTENDEDSTYLE, 0, (nint)exstyle);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14120


## Root Cause
The `DesignBindingPicker` (used for `DataSource/DisplayMember` property editors) were applying the `Explorer` theme regardless of the color mode. In Dark Mode, this caused insufficient contrast for the **None** text and other items, especially when selected. 

## Proposed changes

-  Update `DesignerUtils.cs`: Modified `ApplyTreeViewThemeStyles` method to apply `DarkMode_Explorer` theme when `Application.IsDarkModeEnabled` is true, otherwise use `Explorer` theme

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

-  Users working with Dark Mode enabled will now experience significantly improved readability when using PropertyGrid dropdowns for `DataSource`, `DisplayMember`

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Insufficient contrast for the "None" text in the Dropdown Panel for the DataSource/DisplayMemeber properties in the DarkMode
<img width="746" height="654" alt="Image" src="https://github.com/user-attachments/assets/12071152-8551-4f1c-8a20-2721c172a7c4" />

### After

The contrast of the text "None" is sufficient.

<img width="1385" height="710" alt="image" src="https://github.com/user-attachments/assets/e8eb0c7c-b224-4e54-a5fb-de1577b3dfd3" />


## Test methodology <!-- How did you ensure quality? -->

- Perform manual testing using the Accessibility Insight tool.

## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-alpha.1.25617.103

<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14152)