### PR TITLE
Fix Form with StartPosition=CenterParent and WindowState=Maximized opening on wrong monitor

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Form.cs
@@ -5757,8 +5757,6 @@ public partial class Form : ContainerControl
                 // So, it is necessary to not set the owner before creating the handle. Otherwise,
                 // the window may never receive Dpi changed event even if its parent has different Dpi.
                 // Users at runtime, has to move the window between the screens to get the Dpi changed events triggered.
-
-                Properties.AddOrRemoveValue(s_propDialogOwner, owner);
                 if (owner is Form form && owner != oldOwner)
                 {
                     Owner = form;

--- a/src/System.Windows.Forms/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Form.cs
@@ -5731,6 +5731,13 @@ public partial class Form : ContainerControl
             // to CreateControl().
             _dialogResult = DialogResult.None;
 
+            // Set dialog owner before CreateControl() so that
+            // FillInCreateParamsStartPosition can access it when positioning maximized forms
+            if (owner is not null && !ownerHwnd.IsNull)
+            {
+                Properties.AddOrRemoveValue(s_propDialogOwner, owner);
+            }
+
             // If "this" is an MDI parent then the window gets activated,
             // causing GetActiveWindow to return "this.handle"... to prevent setting
             // the owner of this to this, we must create the control AFTER calling

--- a/src/System.Windows.Forms/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Form.cs
@@ -5752,11 +5752,17 @@ public partial class Form : ContainerControl
                     throw new ArgumentException(string.Format(SR.OwnsSelfOrOwner, nameof(ShowDialog)), nameof(owner));
                 }
 
-                // In a multi Dpi environment and applications in PMV2 mode, Dpi changed events triggered
-                // only when there is a Dpi change happened for the Handle directly or via its parent.
-                // So, it is necessary to not set the owner before creating the handle. Otherwise,
-                // the window may never receive Dpi changed event even if its parent has different Dpi.
-                // Users at runtime, has to move the window between the screens to get the Dpi changed events triggered.
+                // IMPORTANT: Do not change the order in which the Win32 owner (HWND owner) is assigned.
+                // In a multi-DPI environment and applications in PMv2 mode, DPI changed events are only
+                // raised when there is a DPI change for this Handle directly or via its HWND parent.
+                // If the HWND owner were set before the Handle is created, and that owner lives in a
+                // different DPI context, this window might never receive DPI changed events until the
+                // user manually moves it between monitors.
+                //
+                // The value store in the property bag (s_propDialogOwner) is only the *logical* owner
+                // used for dialog positioning. It does not change the Win32 owner relationship and is
+                // therefore safe to assign before CreateControl(). The actual HWND owner continues to be
+                // established below via Owner = form / SetWindowLong after the Handle has been created.
                 if (owner is Form form && owner != oldOwner)
                 {
                     Owner = form;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8932

## Root Cause:

In the `ShowDialog` method, the `s_propDialogOwner` property was set after `CreateControl()` was called. This meant that during window creation, when `FillInCreateParamsStartPosition` is invoked to determine window coordinates, the dialog owner information was not yet available. As a result, the window coordinates defaulted to the primary monitor, and Windows would maximize the form on that monitor regardless of where the parent form was located.

## Proposed changes

- Move the `Properties.AddOrRemoveValue(s_propDialogOwner, owner)` call to before `CreateControl()` in the `ShowDialog` method
- Remove the duplicate `Properties.AddOrRemoveValue(s_propDialogOwner, owner)` call that occurred after `CreateControl()`
- This allows `FillInCreateParamsStartPosition` to access the dialog owner information during the `CenterScreen` positioning logic, which already has code to detect the owner's screen and position the window accordingly


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Forms with `StartPosition=CenterParent` and `WindowState=Maximized` will now correctly maximize on the same monitor as their owner/parent form

## Regression? 

- Yes 

## Risk

- Minimal (The change only affects the timing of when `s_propDialogOwner` is set in Properties dictionary, does not affect the Windows API parent-child relationship)

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

In the form with value `FormWindowState.Maximized` it is always displayed on the main monitor.

### After
A maximized window is displayed on the monitor where its parent window is located (i.e., the secondary monitor).

https://github.com/user-attachments/assets/413ecb94-c4c1-4bc5-b6e9-e50e037f5482



## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-alpha.1.25617.103


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14156)