### PR TITLE
Improve ButtonDarkModeAdapter color handling and remove inappropriate HighContrast logic

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/ButtonDarkModeAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/ButtonDarkModeAdapter.cs
@@ -29,17 +29,12 @@ internal class ButtonDarkModeAdapter : ButtonBaseAdapter
     {
         Color textColor;
 
-        if (Control.ForeColor != Forms.Control.DefaultForeColor)
+        if (Control.ShouldSerializeForeColor())
         {
             textColor = new ColorOptions(deviceContext, Control.ForeColor, Control.BackColor)
             {
                 Enabled = Control.Enabled
             }.Calculate().WindowText;
-
-            if (IsHighContrastHighlighted())
-            {
-                textColor = SystemColors.HighlightText;
-            }
         }
         else
         {
@@ -53,14 +48,9 @@ internal class ButtonDarkModeAdapter : ButtonBaseAdapter
     {
         Color backColor;
 
-        if (Control.BackColor != Forms.Control.DefaultBackColor)
+        if (!Control.UseVisualStyleBackColor || Control.ShouldSerializeBackColor())
         {
             backColor = Control.BackColor;
-
-            if (IsHighContrastHighlighted())
-            {
-                backColor = SystemColors.HighlightText;
-            }
         }
         else
         {


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14155


## Proposed changes

- Preserve the core logic that prevents background color changes on hover when `UseVisualStyleBackColor` is false or custom colors are set
- Deleted `IsHighContrastHighlighted()` checks from both `GetButtonTextColor` and `GetButtonBackColor` methods, allowing the adapter to focus solely on Dark Mode rendering
- Replace color comparisons with `Control.ShouldSerializeBackColor()` and `Control.ShouldSerializeForeColor()` to accurately detect when users have explicitly set color properties

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- When `UseVisualStyleBackColor` is set to false, buttons now maintain a consistent background color and no longer change appearance on hover/press states. 

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

https://github.com/user-attachments/assets/4fc360cd-fa89-40d8-b02e-48ecc176d7d5

### After


https://github.com/user-attachments/assets/e901d5da-23c8-474c-b0e5-17b7219b08aa




## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-alpha.1.25617.103


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14161)