### PR TITLE
Fix TabControl spinner button not applying Dark Mode when TabPages added dynamically

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabControl.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabControl.cs
@@ -2068,7 +2068,16 @@ public partial class TabControl : Control
             case MessageId.WM_REFLECT_MEASUREITEM:
                 // We use TCM_SETITEMSIZE instead
                 break;
+            case PInvokeCore.WM_PARENTNOTIFY:
+                // Apply dark mode to spinner (updown) button when it's created
+                if (m.WParamInternal.LOWORD == PInvokeCore.WM_CREATE && Application.IsDarkModeEnabled)
+                {
+                    HWND childHandle = (HWND)m.LParamInternal;
+                    PInvoke.SetWindowTheme(childHandle, $"{DarkModeIdentifier}_{ExplorerThemeIdentifier}", null);
+                }
 
+                base.WndProc(ref m);
+                break;
             case PInvokeCore.WM_NOTIFY:
             case MessageId.WM_REFLECT_NOTIFY:
                 NMHDR* nmhdr = (NMHDR*)(nint)m.LParamInternal;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabControl.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabControl.cs
@@ -2069,11 +2069,14 @@ public partial class TabControl : Control
                 // We use TCM_SETITEMSIZE instead
                 break;
             case PInvokeCore.WM_PARENTNOTIFY:
-                // Apply dark mode to spinner (updown) button when it's created
-                if (m.WParamInternal.LOWORD == PInvokeCore.WM_CREATE && Application.IsDarkModeEnabled)
+                // Apply dark mode theme to dynamically created child windows (e.g. spinner button)
+                if (Application.IsDarkModeEnabled && m.WParamInternal.LOWORD == PInvokeCore.WM_CREATE)
                 {
                     HWND childHandle = (HWND)m.LParamInternal;
-                    PInvoke.SetWindowTheme(childHandle, $"{DarkModeIdentifier}_{ExplorerThemeIdentifier}", null);
+                    if (!childHandle.IsNull)
+                    {
+                        StyleChildren(childHandle);
+                    }
                 }
 
                 base.WndProc(ref m);


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14159

## Root Cause:

- The TabControl's spinner button is created on-demand by Windows when TabPages exceed available display space and Multiline = false
- ApplyDarkModeOnDemand() only executes during handle creation (OnHandleCreated) or recreation (RecreateHandleCore)
- When TabPages are added dynamically (e.g., through PropertyGrid), the spinner button child window is created without Dark Mode theme applied

## Proposed changes

-  Added `WM_PARENTNOTIFY` message handling in TabControl's WndProc method to apply Dark Mode theme to dynamically created child windows (specifically the spinner button).

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Spinner buttons now correctly render in Dark Mode when TabPages are added dynamically through PropertyGrid

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
The Spinner button of Tabcontrol not in DarkMode when adding the TabPage items by using TabPages property in the PropretyGrid control

https://github.com/user-attachments/assets/0c91db04-001f-4f43-884b-174d864bf51f

### After
Dynamically created TabControl child windows (spinner buttons) now automatically receive Dark Mode theme when created

https://github.com/user-attachments/assets/608fa270-db16-476f-9adc-3cbce6915e12

## Test methodology <!-- How did you ensure quality? -->

-  Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-alpha.1.25617.103

<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14162)