### PR TITLE
PropertyGridView: Prevent out-of-range access when committing next enumerable value

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
@@ -1298,6 +1298,12 @@ internal sealed partial class PropertyGridView :
             {
                 object[] values = gridEntry.GetPropertyValueList();
 
+                // If values.Length is 0, we can't cycle through anything.
+                if (values.Length == 0)
+                {
+                    return;
+                }
+
                 if (index >= (values.Length - 1))
                 {
                     index = 0;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
@@ -3183,6 +3183,12 @@ internal sealed partial class PropertyGridView :
                 int delta = e.Delta > 0 ? -1 : 1;
                 object[] values = _selectedGridEntry.GetPropertyValueList();
 
+                // Prevent out-of-range access
+                if (values.Length == 0)
+                {
+                    return;
+                }
+
                 if (delta > 0 && index >= (values.Length - 1))
                 {
                     index = 0;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14169
Fixes #14170

## Root cause:

The PropertyGrid assumes that the StandardValues list is stable and non‑empty once the current index is computed.
However, during both **double‑click value cycling** and **mouse‑wheel value cycling**, the control calls `GetPropertyValueList()` a second time when committing the next value.
In certain scenarios (dynamic TypeConverters, context‑dependent StandardValues, or volatile data sources), this second call may return an **empty array**, making the previously computed index invalid.
This leads to an out‑of‑range access when executing:

`CommitValue(values[index])`

## Proposed changes

- Update method `DoubleClickRow` and `OnMouseWheel`: After calling `gridEntry.GetPropertyValueList()`, check `values.Length > 0` before trying to access `values[index]`.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Prevents IndexOutOfRangeException or similar crashes when users double‑click or scroll a PropertyGrid entry whose StandardValues list becomes empty at commit time.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->
[WinFormsApp18.zip](https://github.com/user-attachments/files/24426392/WinFormsApp18.zip)

### Before
Double‑clicking or scroll the mouse wheel in the attribute value editing box, `GetPropertyValueList()` may return an empty array 

https://github.com/user-attachments/assets/b19b4119-1930-43ab-901e-9b5ad0340fc0

### After
Logic re‑verifies the StandardValues list before using it.
If `values.Length == 0`, cycling is safely skipped. 
No exceptions are thrown

https://github.com/user-attachments/assets/dab16127-0a0a-458d-b263-04a62d5e0a95

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-alpha.1.25619.109


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14182)