### PR TITLE
ComSafeArrayScope wrong implicit operator for SAFEARRAY**

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/ComSafeArrayScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/ComSafeArrayScope.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using Windows.Win32.System.Variant;
 
 namespace Windows.Win32.System.Com;
@@ -67,7 +68,8 @@ internal readonly unsafe ref struct ComSafeArrayScope<T> where T : unmanaged, IC
 
     public void Dispose() => _value.Dispose();
 
-    public static implicit operator SAFEARRAY**(in ComSafeArrayScope<T> scope) => scope._value;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator SAFEARRAY**(in ComSafeArrayScope<T> scope) => (SAFEARRAY**)Unsafe.AsPointer(ref Unsafe.AsRef(in scope._value));
 
     public static implicit operator SAFEARRAY*(in ComSafeArrayScope<T> scope) => scope._value;
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #


## Proposed changes

- Implementation of operator for SAFEARRAY** of ComSafeArrayScope like SafeArrayScope
- 
- 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Don't know if this operator is used
- 

## Regression? 

- No

## Risk

- Low

<!-- end TELL-MODE -->


### Before

SAFEARRAY** operator has wrong value

### After

SAFEARRAY** operator has correct value


## Test methodology <!-- How did you ensure quality? -->

- 
- 
- 

 

## Test environment(s) <!-- Remove any that don't apply -->

- <!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14215)