### PR TITLE
 Fix disabled RichTextBox multiline text rendering in Dark Mode

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
@@ -3445,17 +3445,21 @@ public partial class RichTextBox : TextBoxBase
                     // Paint the background
                     g.FillRectangle(SystemBrushes.ControlDark, ClientRectangle);
 
+                    RECT formattingRect = default;
+                    PInvokeCore.SendMessage(this, PInvokeCore.EM_GETRECT, (WPARAM)0, ref formattingRect);
+                    Rectangle textBounds = formattingRect;
+
                     // Paint the text
                     TextRenderer.DrawText(
                         g,
                         Text,
                         Font,
-                        ClientRectangle,
+                        textBounds,
                         SystemColors.GrayText,
                         TextFormatFlags.Left
                         | TextFormatFlags.Top
                         | TextFormatFlags.WordBreak
-                        | TextFormatFlags.EndEllipsis);
+                        | TextFormatFlags.TextBoxControl);
 
                     return;
                 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
@@ -3445,16 +3445,12 @@ public partial class RichTextBox : TextBoxBase
                     // Paint the background
                     g.FillRectangle(SystemBrushes.ControlDark, ClientRectangle);
 
-                    RECT formattingRect = default;
-                    PInvokeCore.SendMessage(this, PInvokeCore.EM_GETRECT, (WPARAM)0, ref formattingRect);
-                    Rectangle textBounds = formattingRect;
-
                     // Paint the text
                     TextRenderer.DrawText(
                         g,
                         Text,
                         Font,
-                        textBounds,
+                        ClientRectangle,
                         SystemColors.GrayText,
                         TextFormatFlags.Left
                         | TextFormatFlags.Top

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
@@ -3445,12 +3445,18 @@ public partial class RichTextBox : TextBoxBase
                     // Paint the background
                     g.FillRectangle(SystemBrushes.ControlDark, ClientRectangle);
 
+                    // Use EM_GETRECT to get the text formatting rectangle, which accounts
+                    // for internal borders and padding, rather than using ClientRectangle.
+                    RECT textRect = default;
+                    PInvokeCore.SendMessage(this, PInvokeCore.EM_GETRECT, (WPARAM)0, ref textRect);
+                    Rectangle textBounds = textRect;
+
                     // Paint the text
                     TextRenderer.DrawText(
                         g,
                         Text,
                         Font,
-                        ClientRectangle,
+                        textBounds,
                         SystemColors.GrayText,
                         TextFormatFlags.Left
                         | TextFormatFlags.Top


### PR DESCRIPTION
Fixes #14203

## Root Cause

- When a RichTextBox is disabled in Dark Mode, the custom painting code used `ClientRectangle` instead of the proper text formatting rectangle, causing text to render incorrectly at the control's edge rather than within the text area bounds.
- The `EndEllipsis` flag was incompatible with multiline text, causing premature truncation.

## Proposed changes

- Use `EM_GETRECT` to get the proper text formatting rectangle that accounts for borders and padding.
- Replace `EndEllipsis` with `TextBoxControl` flag for proper multiline text rendering.

## Customer Impact

- Disabled RichTextBox controls now display multiline text correctly in Dark Mode.

## Regression?

- No

## Risk

- Minimal

## Screenshots

### Before

<img width="778" height="248" alt="14203-BEFORE" src="https://github.com/user-attachments/assets/fdecdaba-db29-4f1f-bdb3-878309a5cbd5" />

### After

<img width="775" height="236" alt="14203-AFTER" src="https://github.com/user-attachments/assets/a66b24f9-a56b-4eba-bddf-dd170bf33163" />

## Test methodology

- Manual

## Test environment(s)

- 11.0.100-alpha.1.25618.104

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14216)