### PR TITLE
Issue 14204 fix data grid view excessive cpu+memory usage

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewColumnCollection.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewColumnCollection.cs
@@ -1064,7 +1064,16 @@ public partial class DataGridViewColumnCollection : BaseCollection, IList
 
         if (DataGridView.IsAccessibilityObjectCreated && OsVersion.IsWindows8OrGreater())
         {
-            foreach (DataGridViewRow row in DataGridView.Rows)
+            // Collect unique rows from SharedList using HashSet for deduplication.
+            HashSet<DataGridViewRow> uniqueRows = [];
+            List<DataGridViewRow> sharedList = DataGridView.Rows.SharedList;
+            for (int i = 0; i < sharedList.Count; i++)
+            {
+                uniqueRows.Add(sharedList[i]);
+            }
+
+            // Release UIA providers for the cell at the removed column index
+            foreach (DataGridViewRow row in uniqueRows.Where(row => row.IsAccessibilityObjectCreated))
             {
                 row.Cells[index].ReleaseUiaProvider();
             }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewColumnCollectionTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewColumnCollectionTests.cs
@@ -553,6 +553,30 @@ public class DataGridViewColumnCollectionTests
         Assert.Throws<InvalidOperationException>(() => control.Columns.Add(column));
     }
 
+    [WinFormsFact]
+    public void DataGridViewColumnCollection_RemoveAt_WithAccessibilityObject_DoesNotUnshareRows()
+    {
+        using DataGridView control = new()
+        {
+            ColumnCount = 2,
+            RowCount = 100
+        };
+
+        for (int rowIndex = 0; rowIndex < control.Rows.Count; rowIndex++)
+        {
+            Assert.Equal(-1, control.Rows.SharedRow(rowIndex).Index);
+        }
+
+        _ = control.AccessibilityObject;
+
+        control.Columns.RemoveAt(0);
+
+        for (int rowIndex = 0; rowIndex < control.Rows.Count; rowIndex++)
+        {
+            Assert.Equal(-1, control.Rows.SharedRow(rowIndex).Index);
+        }
+    }
+
     private class SubDataGridView : DataGridView
     {
         public new void OnRowValidating(DataGridViewCellCancelEventArgs e) => base.OnRowValidating(e);

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewTests.cs
@@ -3592,6 +3592,31 @@ public partial class DataGridViewTests : IDisposable
     }
 
     [WinFormsFact]
+    public void DataGridView_ReleaseUiaProvider_WithAccessibilityObject_DoesNotUnshareRows()
+    {
+        const int RowCount = 100;
+
+        using DataGridView control = new()
+        {
+            ColumnCount = 1,
+            RowCount = RowCount
+        };
+
+        for (int rowIndex = 0; rowIndex < control.Rows.Count; rowIndex++)
+        {
+            Assert.Equal(-1, control.Rows.SharedRow(rowIndex).Index);
+        }
+
+        _ = control.AccessibilityObject;
+
+        control.ReleaseUiaProvider(control.HWND);
+
+        int sharedRowCount = Enumerable.Range(0, control.Rows.Count)
+            .Count(rowIndex => control.Rows.SharedRow(rowIndex).Index == -1);
+        Assert.InRange(sharedRowCount, RowCount - 1, RowCount);
+    }
+
+    [WinFormsFact]
     public void DataGridView_CellDoubleClickEvent_Raised_Success()
     {
         SubDataGridView dataGridView = new();


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14204


## Root Cause
The foreach loop over DataGridViewRowCollection uses an enumerator that calls this[index], which unshares (clones) each shared row. For 700k rows, this causes massive memory allocation and CPU usage.
## Proposed changes

- DataGridView.Methods.cs: 
    - Added ReleaseRowUiaProviders() helper method
    - Modified ReleaseUiaProvider() to use HashSet deduplication instead of foreach
- DataGridViewColumnCollection.cs: 
    - Modified RemoveAtInternal() to use HashSet deduplication

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

-  Applications with large DataGridView (700k+ rows) freeze for several seconds when closing forms or removing columns

## Regression? 

- Yes (The regression was introduced in this [commit](https://github.com/dotnet/winforms/commit/6d58d9cc18a75abcf51bb13e81fdfd7923ac8584))

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Closing a form with 700k rows causes 5-10+ seconds of UI freeze and high memory spike due to row cloning.


### After
Form closes near-instantly with minimal memory overhead.


## Test methodology <!-- How did you ensure quality? -->

- Manual test
 

## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-alpha.1.26057.107


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14224)