### PR TITLE
Update the selected anchor color in Dark mode

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AnchorEditor.AnchorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AnchorEditor.AnchorUI.cs
@@ -274,7 +274,15 @@ public sealed partial class AnchorEditor
 
                 if (_solid)
                 {
-                    e.Graphics.FillRectangle(SystemBrushes.ControlDark, rc);
+                    if (Application.IsDarkModeEnabled)
+                    {
+                        e.Graphics.FillRectangle(SystemBrushes.ControlText, rc);
+                    }
+                    else
+                    {
+                        e.Graphics.FillRectangle(SystemBrushes.ControlDark, rc);
+                    }
+
                     e.Graphics.DrawRectangle(SystemPens.WindowFrame, rc.X, rc.Y, rc.Width - 1, rc.Height - 1);
                 }
                 else

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AnchorEditor.AnchorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AnchorEditor.AnchorUI.cs
@@ -274,15 +274,9 @@ public sealed partial class AnchorEditor
 
                 if (_solid)
                 {
-                    if (Application.IsDarkModeEnabled)
-                    {
-                        e.Graphics.FillRectangle(SystemBrushes.ControlText, rc);
-                    }
-                    else
-                    {
-                        e.Graphics.FillRectangle(SystemBrushes.ControlDark, rc);
-                    }
-
+                    e.Graphics.FillRectangle(
+                        Application.IsDarkModeEnabled ? SystemBrushes.ControlText : SystemBrushes.ControlDark,
+                        rc);
                     e.Graphics.DrawRectangle(SystemPens.WindowFrame, rc.X, rc.Y, rc.Width - 1, rc.Height - 1);
                 }
                 else


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14235


## Proposed changes

-  Add dark mode detection for the color of the selected Anchor attribute in the AnchorEditor.AnchorUI.cs

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- In dark mode, the selected anchors in AnchorEditor are correctly distinguished.

## Regression? 

-  No

## Risk

- MInimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<img width="638" height="389" alt="Image" src="https://github.com/user-attachments/assets/386ba0df-35e2-40de-a607-b1e8450c6433" />

### After
<img width="760" height="572" alt="image" src="https://github.com/user-attachments/assets/07e988f5-09da-462c-a317-1b7b0c6337e7" />


## Test methodology <!-- How did you ensure quality? -->

-  Manually

## Test environment(s) <!-- Remove any that don't apply -->

-  .net 11.0.0-alpha.1.26055.11


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14237)