### PR TITLE
Add `ImageList.UseMaskForTransparency` for better image transparency

### DIFF
--- a/src/System.Windows.Forms/Resources/SR.resx
+++ b/src/System.Windows.Forms/Resources/SR.resx
@@ -3447,6 +3447,9 @@ Stack trace where the illegal operation occurred was:
   <data name="ImageListTransparentColorDescr" xml:space="preserve">
     <value>The color that is treated as transparent.</value>
   </data>
+  <data name="ImageListUseMaskForTransparencyDescr" xml:space="preserve">
+    <value>Gets or sets whether to use a mask for transparency.</value>
+  </data>
   <data name="IndexOutOfRange" xml:space="preserve">
     <value>Index {0} is out of range.</value>
   </data>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14171. See that issue for more details.

This is a speculative PR because:
1) I don't know if adding a new bool is actually a wanted approach here, or it should just do this by default.
2) I haven't actually tested this works yet.

## Proposed changes

- Adds UseMaskForTransparency to keep existing behavior the default
- 
- 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Fixes transparent images having poor aliasing due to mask creation, which shouldn't be required when using 32-bit depth colors.

## Regression? 

- No

## Risk

- None?

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- 
- 
- 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- <!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->
