### PR TITLE
Add codeql config to mass suppress certain not-applicable rules

### DIFF
--- a/.CodeQL.yml
+++ b/.CodeQL.yml
@@ -1,0 +1,19 @@
+# This file configures CodeQL runs and TSA bug autofiling. For more information, see:
+# https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/codeql/troubleshooting/bugs/generated-library-code
+# (Access restricted to Microsoft employees only.)
+
+queries:
+  #
+  # REPO-WIDE RULE EXCLUSIONS
+  #
+  - exclude:
+      queryId:
+        # [Serializable] doesn't imply that a type is *safe* to [de]serialize; only that it is
+        # *possible* to do so. The rules below incorrectly assume we're trying to make a safety
+        # guarantee.
+        - "cs/dangerous-deserialization-routine"
+        - "cs/deserialization-of-pointer-type"
+        # We already have CodeQL + Roslyn rules running to detect usage of dangerous deserialization
+        # APIs. Those call sites are well-reviewed and don't benefit from extra alerts regarding
+        # the possibility of loading malicious code.
+        - "cs/deserialization-unexpected-subtypes"


### PR DESCRIPTION
**Experimental config.**

This should automatically resolve 40 alerts from our reporting portal once the backend changes come online.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14240)