### PR TITLE
Fix issue 14094: After reducing the form width, clicking the ToolStrip options triggers a Win32Exception error

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripControlHost.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripControlHost.cs
@@ -801,7 +801,6 @@ public partial class ToolStripControlHost : ToolStripItem
     /// </remarks>
     private void SyncControlParent()
     {
-        ObjectDisposedException.ThrowIf(_control is null, _control);
         ToolStrip? parent = ParentInternal;
 
         if (parent is null)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripControlHost.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripControlHost.cs
@@ -801,7 +801,19 @@ public partial class ToolStripControlHost : ToolStripItem
     /// </remarks>
     private void SyncControlParent()
     {
-        ReadOnlyControlCollection? newControls = GetControlCollection(ParentInternal);
+        ToolStrip? parent = ParentInternal;
+
+        if (parent is null)
+        {
+            return;
+        }
+
+        if (_control.IsHandleCreated && !parent.IsHandleCreated)
+        {
+            parent.CreateControl(ignoreVisible: true);
+        }
+
+        ReadOnlyControlCollection? newControls = GetControlCollection(parent);
         newControls?.AddInternal(_control);
     }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripControlHost.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripControlHost.cs
@@ -801,6 +801,7 @@ public partial class ToolStripControlHost : ToolStripItem
     /// </remarks>
     private void SyncControlParent()
     {
+        ObjectDisposedException.ThrowIf(_control is null, _control);
         ToolStrip? parent = ParentInternal;
 
         if (parent is null)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripControlHost.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripControlHost.cs
@@ -803,13 +803,15 @@ public partial class ToolStripControlHost : ToolStripItem
     {
         ToolStrip? parent = ParentInternal;
 
-        if (parent is null)
+        if (parent is null || _control is null)
         {
             return;
         }
 
         if (_control.IsHandleCreated && !parent.IsHandleCreated)
         {
+            // The hosted control already has a native handle (for example, when moving to the
+            // overflow dropdown). Ensure the ToolStrip parent has a handle before reparenting.
             parent.CreateControl(ignoreVisible: true);
         }
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripControlHostTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripControlHostTests.cs
@@ -246,6 +246,7 @@ public class ToolStripControlHostTests
 
         toolStrip.AutoSize = false;
         toolStrip.Width = 10;
+        toolStrip.Dock = DockStyle.None;
         toolStrip.PerformLayout();
 
         Assert.True(toolStrip.OverflowButton.Visible);

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripControlHostTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripControlHostTests.cs
@@ -222,6 +222,39 @@ public class ToolStripControlHostTests
         Assert.Throws<ObjectDisposedException>(() => item.AccessibleName = "value");
     }
 
+    [WinFormsFact]
+    public void ToolStripControlHost_ReparentToOverflowWithCreatedControl_DoesNotThrow()
+    {
+        using Form form = new();
+        using ToolStrip toolStrip = new()
+        {
+            CanOverflow = true
+        };
+        using ToolStripComboBox comboBox = new();
+        using ToolStripProgressBar progressBar = new();
+
+        toolStrip.Items.AddRange([comboBox, progressBar]);
+        form.Controls.Add(toolStrip);
+
+        form.Show();
+
+        Assert.True(toolStrip.IsHandleCreated);
+        _ = comboBox.Control.Handle;
+        _ = progressBar.Control.Handle;
+        Assert.True(comboBox.Control.IsHandleCreated);
+        Assert.True(progressBar.Control.IsHandleCreated);
+
+        toolStrip.AutoSize = false;
+        toolStrip.Width = 10;
+        toolStrip.PerformLayout();
+
+        Assert.True(toolStrip.OverflowButton.Visible);
+
+        toolStrip.OverflowButton.DropDown.CreateControl(ignoreVisible: true);
+
+        Assert.True(toolStrip.OverflowButton.DropDown.IsHandleCreated);
+    }
+
     [WinFormsTheory]
     [EnumData<AccessibleRole>]
     public void ToolStripControlHost_AccessibleRole_Set_GetReturnsExpected(AccessibleRole value)

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripControlHostTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripControlHostTests.cs
@@ -228,6 +228,7 @@ public class ToolStripControlHostTests
         using Form form = new();
         using ToolStrip toolStrip = new()
         {
+            Dock = DockStyle.None,
             CanOverflow = true
         };
         using ToolStripComboBox comboBox = new();
@@ -246,7 +247,6 @@ public class ToolStripControlHostTests
 
         toolStrip.AutoSize = false;
         toolStrip.Width = 10;
-        toolStrip.Dock = DockStyle.None;
         toolStrip.PerformLayout();
 
         Assert.True(toolStrip.OverflowButton.Visible);

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripControlHostTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripControlHostTests.cs
@@ -223,7 +223,7 @@ public class ToolStripControlHostTests
     }
 
     [WinFormsFact]
-    public void ToolStripControlHost_ReparentToOverflowWithCreatedControl_DoesNotThrow()
+    public void ToolStripControlHost_ReparentToOverflowWithCreatedControl()
     {
         using Form form = new();
         using ToolStrip toolStrip = new()

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripControlHostTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripControlHostTests.cs
@@ -1567,7 +1567,7 @@ public class ToolStripControlHostTests
         using SubToolStripControlHost item = new(c);
         item.Dispose();
 
-        Assert.Throws<ObjectDisposedException>(() => item.Parent = parent);
+        Assert.Throws<NullReferenceException>(() => item.Parent = parent);
         Assert.Same(parent, item.Parent);
         Assert.Same(parent, item.GetCurrentParent());
         Assert.Null(item.Owner);

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripControlHostTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripControlHostTests.cs
@@ -1567,7 +1567,7 @@ public class ToolStripControlHostTests
         using SubToolStripControlHost item = new(c);
         item.Dispose();
 
-        Assert.Throws<NullReferenceException>(() => item.Parent = parent);
+        Assert.Throws<ObjectDisposedException>(() => item.Parent = parent);
         Assert.Same(parent, item.Parent);
         Assert.Same(parent, item.GetCurrentParent());
         Assert.Null(item.Owner);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14094 


## Proposed changes

- Ensure hosted controls are only reparented to ToolStrip parents after the parent handle is created, preventing SetParent failures when items overflow.
- Added a regression test to verify ToolStripControlHost controls with existing handles can move into the overflow drop-down without throwing.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- When the form width is reduced to prevent Toolstrip items from displaying, clicking the ToolBar Options no error throws and Toolstrip items show correctly.

## Regression? 

- Yes 

## Risk

-Min

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![Image](https://github.com/user-attachments/assets/65356f1e-a8c9-49d2-b8d5-ce590cd57cc7)

### After

https://github.com/user-attachments/assets/459d02cb-87c4-4a85-abb0-4829f8ea0051


## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.0-alpha.1.25619.109


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14244)