### PR TITLE
Fix issue 14089: Disabled menu items incorrectly display highlighted text in dark mode with System renderer

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripSystemDarkModeRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripSystemDarkModeRenderer.cs
@@ -592,10 +592,10 @@ internal class ToolStripSystemDarkModeRenderer : ToolStripRenderer
     {
         ArgumentNullException.ThrowIfNull(e);
 
-        Color textColor = (e.Item.Selected || e.Item.Pressed)
-            ? GetDarkModeColor(SystemColors.HighlightText)
-            : !e.Item.Enabled
-                ? GetDarkModeColor(SystemColors.GrayText)
+        Color textColor = !e.Item.Enabled
+            ? GetDarkModeColor(SystemColors.GrayText)
+            : e.Item.Selected || e.Item.Pressed
+                ? GetDarkModeColor(SystemColors.HighlightText)
                 : GetDarkModeColor(e.TextColor);
 
         TextRenderer.DrawText(


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14089


## Proposed changes

- Fixed a regression where disabled menu items in dark mode would display highlighted text when focused using mouse cursor, making them appear enabled. This issue only occurs when `RenderMode` is set to `System` and the application runs under dark mode.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- When using the system renderer, disabled menu items incorrectly no longer highlight text in dark mode.

## Regression? 

- Yes

## Risk

- Min

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

https://github.com/user-attachments/assets/a78f1881-59dc-48c7-ad01-5960c9d31b39

### After

https://github.com/user-attachments/assets/5fb62c67-eb9f-4b67-9532-55bd15a6ddcc

## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.0-alpha.1.25619.109


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14248)