### PR TITLE
Fix font size of UserControl in ToolStripControlHost after DPI change

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDownItem.cs
@@ -793,12 +793,16 @@ public abstract class ToolStripDropDownItem : ToolStripItem
 
                     childItem.DeviceDpi = newDpi;
 
-                    if (typeof(ToolStripDropDownItem).IsAssignableFrom(childItem.GetType()))
+                    // For ToolStripControlHost, synchronize the hosted control's DeviceDpi.
+                    // This ensures WM_DPICHANGED_BEFOREPARENT will use the correct old DPI
+                    // when calculating font scaling.
+                    if (childItem is ToolStripControlHost controlHost && controlHost.Control is not null)
                     {
-                        if (((ToolStripDropDownItem)childItem)._dropDown is not null)
-                        {
-                            itemsStack.Push((ToolStripDropDownItem)childItem);
-                        }
+                        controlHost.Control.DeviceDpiInternal = newDpi;
+                    }
+                    else if (childItem is ToolStripDropDownItem dropDownItem && dropDownItem._dropDown is not null)
+                    {
+                        itemsStack.Push(dropDownItem);
                     }
                 }
             }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9581

## Root Cause
In ToolStripDropDownItem.ToolStrip_RescaleConstants, when iterating through dropdown items during DPI rescaling, only ToolStripDropDownItem children were processed for recursion. ToolStripControlHost items were ignored, so their hosted control's DeviceDpiInternal was never synchronized with the new DPI.

When the dropdown is later shown and WM_DPICHANGED_BEFOREPARENT is received by the hosted control, it calculates font scaling using stale DPI values, causing incorrect font sizes.

## Proposed changes

- In `ToolStripDropDownItem.ToolStrip_RescaleConstants`, add handling for `ToolStripControlHost `children to synchronize their hosted control's `DeviceDpiInternal` with the new DPI value

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

-  After change,  hosted controls in ToolStripControlHost items display with correct font sizes after DPI changes, regardless of whether the context menu was opened before or after the DPI

## Regression? 

- No

## Risk

- MInimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

The Font of UserControl in ToolStripControlHost is wrong after the system dpi scaling is changed if the contextmenu has never been opened before

![image](https://github.com/dotnet/winforms/assets/3384955/e2a23a17-2222-483e-ad80-bf6196b060ff)


### After
The font of the UserControl within ToolStripControlHost can be scaled according to the system's DPI settings.

https://github.com/user-attachments/assets/5a23523f-2205-4cc9-900f-4d60571dff71


## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-preview.1.26078.110


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14252)