### PR TITLE
[release/9.0] Fix issue 14259: Deserialization of the CodeTypeReference to generic type is incorrect

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs
@@ -74,6 +74,7 @@ public abstract partial class CodeDomSerializerBase
         else
         {
             // create the MyGeneric`2[ part
+            typeName.Append(typeref.BaseType);
             if (!typeref.BaseType.Contains('`'))
             {
                 typeName.Append($"`{typeref.TypeArguments.Count}");

--- a/src/System.Windows.Forms.Design/tests/UnitTests/Serialization/CodeDomSerializerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/Serialization/CodeDomSerializerTests.cs
@@ -1,7 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.CodeDom;
+using System.ComponentModel.Design;
 using System.ComponentModel.Design.Serialization;
+using Moq;
 
 namespace System.Windows.Forms.Design.Serialization.Tests;
 
@@ -12,5 +15,27 @@ public class CodeDomSerializerTests
     {
         CodeDomSerializer underTest = new();
         Assert.NotNull(underTest);
+    }
+
+    [Fact]
+    public void CodeDomSerializer_Deserialize_GenericTypeRef()
+    {
+        CodeDomSerializer underTest = new();
+        Type type = typeof(List<int?>);
+        CodeTypeOfExpression expression = new(new CodeTypeReference(type));
+
+        Mock<IDesignerSerializationManager> mockManager = new(MockBehavior.Strict);
+        mockManager
+            .Setup(s => s.GetService(typeof(TypeDescriptionProviderService)))
+            .Returns(null);
+        mockManager
+            .Setup(s => s.GetType("System.Int32"))
+            .Returns(typeof(int));
+        mockManager
+            .Setup(s => s.GetType($"System.Collections.Generic.List`1[[System.Nullable`1[[{typeof(int).AssemblyQualifiedName}]]]]"))
+            .Returns(type);
+
+        object result = underTest.Deserialize(mockManager.Object, expression);
+        Assert.Equal(type, result);
     }
 }


### PR DESCRIPTION
Backport of #14260 to release/9.0
Fixes #14259

## Proposed changes

-  Fixed a regression where CodeDomSerializer doesn't deserialize generic types.

## Customer Impact

- When a custom designer tries to deserialize a generic type the error is occuered

## Regression? 

- Yes

## Risk

- Min

## Test methodology

-  custom  example

## Test environment(s)

8.0.23
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14270)