### PR TITLE
Adding retry logic while querying\fetching data from clipboard

### DIFF
--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/ClipboardConstants.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/ClipboardConstants.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Private.Windows.Ole;
+
+internal static class ClipboardConstants
+{
+    /// <summary>
+    ///  The number of times to retry OLE clipboard operations.
+    /// </summary>
+    internal const int OleRetryCount = 10;
+
+    /// <summary>
+    ///  The amount of time in milliseconds to sleep between retrying OLE clipboard operations.
+    /// </summary>
+    internal const int OleRetryDelay = 100;
+}

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/ClipboardCore.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/ClipboardCore.cs
@@ -13,22 +13,12 @@ internal static unsafe class ClipboardCore<TOleServices>
     where TOleServices : IOleServices
 {
     /// <summary>
-    ///  The number of times to retry OLE clipboard operations.
-    /// </summary>
-    private const int OleRetryCount = 10;
-
-    /// <summary>
-    ///  The amount of time in milliseconds to sleep between retrying OLE clipboard operations.
-    /// </summary>
-    private const int OleRetryDelay = 100;
-
-    /// <summary>
     ///  Removes all data from the Clipboard.
     /// </summary>
     /// <returns>An <see cref="HRESULT"/> indicating the success or failure of the operation.</returns>
     internal static HRESULT Clear(
-        int retryTimes = OleRetryCount,
-        int retryDelay = OleRetryDelay)
+        int retryTimes = ClipboardConstants.OleRetryCount,
+        int retryDelay = ClipboardConstants.OleRetryDelay)
     {
         TOleServices.EnsureThreadState();
 
@@ -53,8 +43,8 @@ internal static unsafe class ClipboardCore<TOleServices>
     /// </summary>
     /// <returns>An <see cref="HRESULT"/> indicating the success or failure of the operation.</returns>
     internal static HRESULT Flush(
-        int retryTimes = OleRetryCount,
-        int retryDelay = OleRetryDelay)
+        int retryTimes = ClipboardConstants.OleRetryCount,
+        int retryDelay = ClipboardConstants.OleRetryDelay)
     {
         TOleServices.EnsureThreadState();
 
@@ -85,8 +75,8 @@ internal static unsafe class ClipboardCore<TOleServices>
     internal static HRESULT SetData(
         IComVisibleDataObject dataObject,
         bool copy,
-        int retryTimes = OleRetryCount,
-        int retryDelay = OleRetryDelay)
+        int retryTimes = ClipboardConstants.OleRetryCount,
+        int retryDelay = ClipboardConstants.OleRetryDelay)
     {
         TOleServices.EnsureThreadState();
 
@@ -134,8 +124,8 @@ internal static unsafe class ClipboardCore<TOleServices>
     internal static HRESULT TryGetData(
         out ComScope<IDataObject> proxyDataObject,
         out object? originalObject,
-        int retryTimes = OleRetryCount,
-        int retryDelay = OleRetryDelay)
+        int retryTimes = ClipboardConstants.OleRetryCount,
+        int retryDelay = ClipboardConstants.OleRetryDelay)
     {
         TOleServices.EnsureThreadState();
 
@@ -184,8 +174,8 @@ internal static unsafe class ClipboardCore<TOleServices>
     /// <inheritdoc cref="SetData(IComVisibleDataObject, bool, int, int)"/>
     internal static bool IsObjectOnClipboard(
         object @object,
-        int retryTimes = OleRetryCount,
-        int retryDelay = OleRetryDelay)
+        int retryTimes = ClipboardConstants.OleRetryCount,
+        int retryDelay = ClipboardConstants.OleRetryDelay)
     {
         if (@object is null)
         {
@@ -210,8 +200,8 @@ internal static unsafe class ClipboardCore<TOleServices>
     /// </summary>
     internal static HRESULT GetDataObject<TDataObject, TIDataObject>(
         out TIDataObject? dataObject,
-        int retryTimes = OleRetryCount,
-        int retryDelay = OleRetryDelay)
+        int retryTimes = ClipboardConstants.OleRetryCount,
+        int retryDelay = ClipboardConstants.OleRetryDelay)
         where TDataObject : class, IDataObjectInternal<TDataObject, TIDataObject>, TIDataObject
         where TIDataObject : class
     {

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/Utilities.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/Utilities.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Private.Windows.Ole;
+
+internal static class Utilities
+{
+    /// <summary>
+    ///  Executes the given action with retry logic for OLE operations.
+    /// </summary>
+    /// <param name="action">Execute the action which returns bool value indicating whether to continue retries or stop.</param>
+    /// <param name="retryCount">Number of retry attempts.</param>
+    /// <param name="retryDelay">Delay in milliseconds between retries.</param>
+    internal static void ExecuteWithRetry(
+        Func<bool> action,
+        int retryCount = ClipboardConstants.OleRetryCount,
+        int retryDelay = ClipboardConstants.OleRetryDelay)
+    {
+        int attempts = 0;
+
+        while (attempts < retryCount)
+        {
+            if (action())
+            {
+                attempts++;
+                Thread.Sleep(retryDelay);
+
+                continue;
+            }
+
+            break;
+        }
+    }
+}

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Private/Windows/Ole/UtilitiesTests.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Private/Windows/Ole/UtilitiesTests.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Private.Windows.Ole;
+
+public class UtilitiesTests
+{
+    [Fact]
+    public void ExecuteWithRetry_ActionReturnsFalse_CallsOnce()
+    {
+        int calls = 0;
+
+        Utilities.ExecuteWithRetry(() =>
+        {
+            calls++;
+
+            return false;
+        },
+        retryCount: 3,
+        retryDelay: 0);
+
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void ExecuteWithRetry_ActionReturnsTrueThenFalse_RetriesUntilFalse()
+    {
+        int calls = 0;
+
+        Utilities.ExecuteWithRetry(() =>
+        {
+            calls++;
+
+            return calls < 3;
+        },
+        retryCount: 5,
+        retryDelay: 0);
+
+        Assert.Equal(3, calls);
+    }
+
+    [Fact]
+    public void ExecuteWithRetry_ActionAlwaysReturnsTrue_StopsAtRetryCount()
+    {
+        int calls = 0;
+
+        Utilities.ExecuteWithRetry(() =>
+        {
+            calls++;
+
+            return true;
+        },
+        retryCount: 3,
+        retryDelay: 0);
+
+        Assert.Equal(3, calls);
+    }
+}


### PR DESCRIPTION
**Issue:** Frequent copy/paste operations from clipboard can cause `IDataObject.QueryGetData(...)` and `IDataObject.GetData(...)` to fail with `HResult = CLIPBRD_E_CANT_OPEN`. It can happen if the clipboard is in locked state by another process when a second process is attempting to read data.

**Fix:** Retry logic around these calls with a small delay fixes the issue reliably.