### PR TITLE
Run the issue-labeler over pull requests using polling

### DIFF
--- a/.github/workflows/labeler-predict-pulls.yml
+++ b/.github/workflows/labeler-predict-pulls.yml
@@ -25,12 +25,17 @@ on:
       - 'main'
       - 'release/**'
 
+  # Poll for open pull requests that need labels every 5 minutes
+  schedule:
+    - cron: "*/5 * * * *"
+
   # Allow dispatching the workflow via the Actions UI, specifying ranges of numbers
+  # If no pull request numbers are provided, it behaves as a polling event
   workflow_dispatch:
     inputs:
       pulls:
-        description: "Pull Request Numbers (comma-separated list of ranges)."
-        required: true
+        description: "Pull Request Numbers (comma-separated list of ranges). Leave empty to poll."
+        required: false
       cache_key:
         description: "The cache key suffix to use for restoring the model. Defaults to 'ACTIVE'."
         required: true
@@ -45,15 +50,70 @@ env:
   DEFAULT_LABEL: "needs-area-label"
 
 jobs:
+  poll-pull-requests:
+    # Run on schedule trigger or workflow_dispatch without PR numbers, within the 'dotnet' org
+    if: ${{ (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.pulls == '')) && github.repository_owner == 'dotnet' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      pull-requests: read
+    outputs:
+      pulls: ${{ steps.get-pulls.outputs.pulls }}
+    steps:
+      - name: "Get open pull requests needing labels"
+        id: get-pulls
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          # Get the last successful schedule run's timestamp (minus 5 minutes for overlap)
+          last_run=$(gh run list --repo ${{ github.repository }} --workflow "${{ github.workflow }}" --event schedule --status success --limit 1 --json updatedAt --jq '.[0].updatedAt // empty')
+
+          if [ -n "$last_run" ]; then
+            # Subtract 5 minutes from the last run timestamp for overlap
+            since=$(date -u -d "$last_run - 5 minutes" +"%Y-%m-%dT%H:%M:%SZ")
+            echo "Filtering PRs updated since: $since (last run: $last_run)"
+            pulls=$(gh pr list --repo ${{ github.repository }} --state open --json number,labels,updatedAt --limit 1000 --search "updated:>=$since")
+          else
+            # No previous run found; get all open pull requests
+            echo "No previous schedule run found. Getting all open pull requests."
+            pulls=$(gh pr list --repo ${{ github.repository }} --state open --json number,labels --limit 1000)
+          fi
+
+          # Filter to PRs that don't have a label starting with LABEL_PREFIX
+          needs_label=$(echo "$pulls" | jq -r --arg prefix "${{ env.LABEL_PREFIX }}" '
+            [.[] | select(
+              (.labels | map(.name) | any(startswith($prefix)) | not)
+            ) | .number] | join(",")
+          ')
+
+          echo "Pull requests needing labels: $needs_label"
+          echo "pulls=$needs_label" >> $GITHUB_OUTPUT
+
   predict-pull-label:
+    # The 'if' uses always() so this job runs even when poll-pull-requests is skipped
     # Do not automatically run the workflow on forks outside the 'dotnet' org
-    if: ${{ github.event_name == 'workflow_dispatch' || github.repository_owner == 'dotnet' }}
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || github.repository_owner == 'dotnet') }}
+    needs: [poll-pull-requests]
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
+      - name: "Determine pull requests to process"
+        id: determine-pulls
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ -n "${{ inputs.pulls }}" ]; then
+            pulls="${{ inputs.pulls }}"
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ] || [ "${{ github.event_name }}" == "schedule" ]; then
+            pulls="${{ needs.poll-pull-requests.outputs.pulls }}"
+          else
+            pulls="${{ github.event.number }}"
+          fi
+          echo "pulls=$pulls" >> $GITHUB_OUTPUT
+          echo "Processing pull requests: $pulls"
+
       - name: "Restore pulls model from cache"
         id: restore-model
+        if: ${{ steps.determine-pulls.outputs.pulls != '' }}
         uses: dotnet/issue-labeler/restore@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0
         with:
           type: pulls
@@ -62,10 +122,10 @@ jobs:
 
       - name: "Predict pull labels"
         id: prediction
-        if: ${{ steps.restore-model.outputs.cache-hit == 'true' }}
+        if: ${{ steps.determine-pulls.outputs.pulls != '' && steps.restore-model.outputs.cache-hit == 'true' }}
         uses: dotnet/issue-labeler/predict@46125e85e6a568dc712f358c39f35317366f5eed # v2.0.0
         with:
-          pulls: ${{ inputs.pulls || github.event.number }}
+          pulls: ${{ steps.determine-pulls.outputs.pulls }}
           label_prefix: ${{ env.LABEL_PREFIX }}
           threshold: ${{ env.THRESHOLD }}
           default_label: ${{ env.DEFAULT_LABEL }}


### PR DESCRIPTION
Copilot-authored pull requests run workflows with permissions lower than other PRs (including those submitted by external contributors). This blocks the issue-labeler workflow from being able to run on those PRs, leaving a prompt for the workflow to be approved.

To run issue-labeler over these PRs as well as other PRs that have missed labeling (such as GitHub service interruptions when the events don't trigger), the PR label prediction workflow adds a cron schedule for as frequently as GitHub will run it (by using every 5 minutes). When triggered from the polling event, we collect the list of open and unlabeled PRs that have been updated since the last polling run (plus 5 extra minutes), and we run the issue-labeler prediction against those.

This also updates the workflow_dispatch event to allow an empty list of PR numbers to force a polling event run.

Addresses [(dotnet/issue-labeler#105) Pull Request Labeling does not run automatically for Copilot PRs](https://github.com/dotnet/issue-labeler/issues/105) for this repository. Replicates dotnet/.github#20 and dotnet/runtime#124023.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14280)