### PR TITLE
Fix LinkLabel contrast in Dark Mode

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Labels/LinkLabel.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Labels/LinkLabel.cs
@@ -69,7 +69,21 @@ public partial class LinkLabel : Label, IButtonControl
     [SRDescription(nameof(SR.LinkLabelActiveLinkColorDescr))]
     public Color ActiveLinkColor
     {
-        get => _activeLinkColor.IsEmpty ? IEActiveLinkColor : _activeLinkColor;
+        get
+        {
+            if (!_activeLinkColor.IsEmpty)
+            {
+                return _activeLinkColor;
+            }
+
+            if (Application.IsDarkModeEnabled)
+            {
+                // Use red color for active state in dark mode (similar to IE's hover color)
+                return Color.FromArgb(0xFF, 0x60, 0x60);
+            }
+
+            return IEActiveLinkColor;
+        }
         set
         {
             if (_activeLinkColor != value)
@@ -234,9 +248,26 @@ public partial class LinkLabel : Label, IButtonControl
     [SRDescription(nameof(SR.LinkLabelLinkColorDescr))]
     public Color LinkColor
     {
-        get => _linkColor.IsEmpty
-            ? SystemInformation.HighContrast ? SystemColors.HotTrack : IELinkColor
-            : _linkColor;
+        get
+        {
+            if (!_linkColor.IsEmpty)
+            {
+                return _linkColor;
+            }
+
+            if (SystemInformation.HighContrast)
+            {
+                return SystemColors.HotTrack;
+            }
+
+            if (Application.IsDarkModeEnabled)
+            {
+                // Use a bright blue color that contrasts well with dark backgrounds
+                return Color.FromArgb(0x60, 0xA0, 0xE0);
+            }
+
+            return IELinkColor;
+        }
         set
         {
             if (_linkColor != value)
@@ -346,7 +377,9 @@ public partial class LinkLabel : Label, IButtonControl
     public Color VisitedLinkColor
     {
         get => _visitedLinkColor.IsEmpty
-            ? SystemInformation.HighContrast ? LinkUtilities.GetVisitedLinkColor() : IEVisitedLinkColor
+            ? SystemInformation.HighContrast || Application.IsDarkModeEnabled
+                ? LinkUtilities.GetVisitedLinkColor()
+                : IEVisitedLinkColor
             : _visitedLinkColor;
         set
         {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Labels/LinkLabel.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Labels/LinkLabel.cs
@@ -69,21 +69,11 @@ public partial class LinkLabel : Label, IButtonControl
     [SRDescription(nameof(SR.LinkLabelActiveLinkColorDescr))]
     public Color ActiveLinkColor
     {
-        get
-        {
-            if (!_activeLinkColor.IsEmpty)
-            {
-                return _activeLinkColor;
-            }
-
-            if (Application.IsDarkModeEnabled)
-            {
-                // Use red color for active state in dark mode (similar to IE's hover color)
-                return Color.FromArgb(0xFF, 0x60, 0x60);
-            }
-
-            return IEActiveLinkColor;
-        }
+        get => !_activeLinkColor.IsEmpty
+            ? _activeLinkColor
+            : Application.IsDarkModeEnabled
+                ? LinkUtilities.DarkModeActiveLinkColor
+                : IEActiveLinkColor;
         set
         {
             if (_activeLinkColor != value)
@@ -248,26 +238,13 @@ public partial class LinkLabel : Label, IButtonControl
     [SRDescription(nameof(SR.LinkLabelLinkColorDescr))]
     public Color LinkColor
     {
-        get
-        {
-            if (!_linkColor.IsEmpty)
-            {
-                return _linkColor;
-            }
-
-            if (SystemInformation.HighContrast)
-            {
-                return SystemColors.HotTrack;
-            }
-
-            if (Application.IsDarkModeEnabled)
-            {
-                // Use a bright blue color that contrasts well with dark backgrounds
-                return Color.FromArgb(0x60, 0xA0, 0xE0);
-            }
-
-            return IELinkColor;
-        }
+        get => !_linkColor.IsEmpty
+            ? _linkColor
+            : SystemInformation.HighContrast
+                ? SystemColors.HotTrack
+                : Application.IsDarkModeEnabled
+                    ? LinkUtilities.DarkModeLinkColor
+                    : IELinkColor;
         set
         {
             if (_linkColor != value)
@@ -376,11 +353,13 @@ public partial class LinkLabel : Label, IButtonControl
     [SRDescription(nameof(SR.LinkLabelVisitedLinkColorDescr))]
     public Color VisitedLinkColor
     {
-        get => _visitedLinkColor.IsEmpty
-            ? SystemInformation.HighContrast || Application.IsDarkModeEnabled
+        get => !_visitedLinkColor.IsEmpty
+            ? _visitedLinkColor
+            : SystemInformation.HighContrast
                 ? LinkUtilities.GetVisitedLinkColor()
-                : IEVisitedLinkColor
-            : _visitedLinkColor;
+                : Application.IsDarkModeEnabled
+                    ? LinkUtilities.DarkModeVisitedLinkColor
+                    : IEVisitedLinkColor;
         set
         {
             if (_visitedLinkColor != value)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Labels/LinkUtilities.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Labels/LinkUtilities.cs
@@ -110,6 +110,21 @@ internal static class LinkUtilities
         }
     }
 
+    /// <summary>
+    ///  Gets a light blue link color suitable for dark mode backgrounds.
+    /// </summary>
+    public static Color DarkModeLinkColor => Color.FromArgb(102, 178, 255);
+
+    /// <summary>
+    ///  Gets a light red active link color suitable for dark mode backgrounds.
+    /// </summary>
+    public static Color DarkModeActiveLinkColor => Color.FromArgb(255, 128, 128);
+
+    /// <summary>
+    ///  Gets a light purple visited link color suitable for dark mode backgrounds.
+    /// </summary>
+    public static Color DarkModeVisitedLinkColor => Color.FromArgb(200, 162, 255);
+
     /// Produces a color for visited links using SystemColors
     public static Color GetVisitedLinkColor()
     {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11935


## Proposed changes

 - **LinkColor** (normal link state):
     - Dark Mode: `Color.FromArgb(102, 178, 255)` - A bright blue that contrasts well with dark backgrounds

- **ActiveLinkColor** (when link is being clicked):
    - Dark Mode: `Color.FromArgb(255, 128, 128)` - Light red color for clear visual feedback

- **VisitedLinkColor** (after link has been visited):
    - Dark Mode: Uses `Color.FromArgb(200, 162, 255)` - Light purple color for a visible visited state

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The LinkLabel can be displayed clearly in DarkMode

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

https://github.com/user-attachments/assets/be684ea5-71e2-4ebd-bada-9bb151c5a9fe


### After

https://github.com/user-attachments/assets/e826578a-9db1-4cc7-8b56-1a02654bd7b6


## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-preview.2.26080.101


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14283)