### PR TITLE
Fix issue 11956: [Dark Mode] CheckBox in TreeView/ListView is not in dark mode after enabled SystemColorMode.Dark

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
@@ -572,6 +572,12 @@ public partial class ListView : Control
                     }
                 }
             }
+
+            if (Application.IsDarkModeEnabled
+                && DarkModeRequestState is true)
+            {
+                UpdateDarkModeCheckBoxImages();
+            }
         }
     }
 
@@ -4733,8 +4739,20 @@ public partial class ListView : Control
             TransparentColor = Color.Transparent
         };
 
-        imageList.Images.Add(CreateDarkModeCheckBoxBitmap(isChecked: false, size));
-        imageList.Images.Add(CreateDarkModeCheckBoxBitmap(isChecked: true, size));
+        using Bitmap uncheckedBitmap = new(size, size);
+        using (Graphics g = Graphics.FromImage(uncheckedBitmap))
+        {
+            CheckBoxRenderer.DrawCheckBoxWithVisualStyles(g, new Point(0, 0), CheckBoxState.UncheckedNormal, HWNDInternal);
+        }
+
+        using Bitmap checkedBitmap = new(size, size);
+        using (Graphics g = Graphics.FromImage(checkedBitmap))
+        {
+            CheckBoxRenderer.DrawCheckBoxWithVisualStyles(g, new Point(0, 0), CheckBoxState.CheckedNormal, HWNDInternal);
+        }
+
+        imageList.Images.Add(uncheckedBitmap);
+        imageList.Images.Add(checkedBitmap);
 
         // Ensure the checkbox extended style is active before assigning our custom state imagelist,
         // otherwise the style refresh may overwrite the list with the default light-themed images.
@@ -4771,18 +4789,6 @@ public partial class ListView : Control
                 (WPARAM)0,
                 (LPARAM)(Items.Count - 1));
         }
-    }
-
-    private Bitmap CreateDarkModeCheckBoxBitmap(bool isChecked, int size)
-    {
-        Bitmap bitmap = new(size, size);
-
-        using Graphics graphics = Graphics.FromImage(bitmap);
-        graphics.Clear(Color.Transparent);
-        CheckBoxState state = isChecked ? CheckBoxState.CheckedNormal : CheckBoxState.UncheckedNormal;
-        CheckBoxRenderer.DrawCheckBoxWithVisualStyles(graphics, new Point(0, 0), state, HWNDInternal);
-
-        return bitmap;
     }
 
     protected override void OnHandleDestroyed(EventArgs e)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -2024,7 +2024,7 @@ public partial class TreeView : Control
         imageList.Images.Add(uncheckedBitmap);
         imageList.Images.Add(checkedBitmap);
 
-        PInvokeCore.SendMessage(this, PInvoke.TVM_SETIMAGELIST, (WPARAM)PInvoke.TVSIL_STATE, (LPARAM)imageList.Handle);
+        SetStateImageList(imageList.Handle);
 
         _internalStateImageList?.Dispose();
         _internalStateImageList = imageList;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -284,6 +284,7 @@ public partial class TreeView : Control
                     if (CheckBoxes)
                     {
                         UpdateStyles();
+                        UpdateCheckBoxImages();
                     }
                     else
                     {
@@ -1869,6 +1870,7 @@ public partial class TreeView : Control
             int style = (int)PInvokeCore.GetWindowLong(this, WINDOW_LONG_PTR_INDEX.GWL_STYLE);
             style |= (int)PInvoke.TVS_CHECKBOXES;
             PInvokeCore.SetWindowLong(this, WINDOW_LONG_PTR_INDEX.GWL_STYLE, style);
+            UpdateCheckBoxImages();
         }
 
         if (ShowNodeToolTips && !DesignMode)
@@ -1989,6 +1991,43 @@ public partial class TreeView : Control
 
         _internalStateImageList?.Dispose();
         _internalStateImageList = newImageList;
+    }
+
+    private void UpdateCheckBoxImages()
+    {
+        if (DesignMode || !IsHandleCreated || !CheckBoxes || _stateImageList is not null)
+        {
+            return;
+        }
+
+        int size = StateImageSize?.Width ?? ScaleHelper.ScaleToInitialSystemDpi(16);
+        ImageList imageList = new()
+        {
+            ImageSize = new Size(size, size),
+            ColorDepth = ColorDepth.Depth32Bit
+        };
+
+        using Bitmap uncheckedBitmap = new(size, size);
+        using (Graphics g = Graphics.FromImage(uncheckedBitmap))
+        {
+            CheckBoxRenderer.DrawCheckBoxWithVisualStyles(g, new Point(0, 0), CheckBoxState.UncheckedNormal, HWNDInternal);
+        }
+
+        using Bitmap checkedBitmap = new(size, size);
+        using (Graphics g = Graphics.FromImage(checkedBitmap))
+        {
+            CheckBoxRenderer.DrawCheckBoxWithVisualStyles(g, new Point(0, 0), CheckBoxState.CheckedNormal, HWNDInternal);
+        }
+
+        // TreeView uses 1-based indexing: index 0=placeholder, 1=unchecked, 2=checked
+        imageList.Images.Add(new Bitmap(size, size)); // Placeholder
+        imageList.Images.Add(uncheckedBitmap);
+        imageList.Images.Add(checkedBitmap);
+
+        PInvokeCore.SendMessage(this, PInvoke.TVM_SETIMAGELIST, (WPARAM)PInvoke.TVSIL_STATE, (LPARAM)imageList.Handle);
+
+        _internalStateImageList?.Dispose();
+        _internalStateImageList = imageList;
     }
 
     private void SetStateImageList(IntPtr handle)
@@ -3385,6 +3424,7 @@ public partial class TreeView : Control
             case PInvokeCore.WM_SYSCOLORCHANGE:
                 PInvokeCore.SendMessage(this, PInvoke.TVM_SETINDENT, (WPARAM)Indent);
                 base.WndProc(ref m);
+                UpdateCheckBoxImages();
                 break;
             case PInvokeCore.WM_SETFOCUS:
                 // If we get focus through the LButtonDown .. we might have done the validation...

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -1870,6 +1870,17 @@ public partial class TreeView : Control
             int style = (int)PInvokeCore.GetWindowLong(this, WINDOW_LONG_PTR_INDEX.GWL_STYLE);
             style |= (int)PInvoke.TVS_CHECKBOXES;
             PInvokeCore.SetWindowLong(this, WINDOW_LONG_PTR_INDEX.GWL_STYLE, style);
+
+            if (Application.IsDarkModeEnabled
+                && DarkModeRequestState is true
+                && RecreatingHandle)
+            {
+                _ = PInvoke.SetWindowTheme(
+                    hwnd: HWND,
+                    pszSubAppName: $"{DarkModeIdentifier}_{ExplorerThemeIdentifier}",
+                    pszSubIdList: null);
+            }
+
             UpdateCheckBoxImages();
         }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -2006,7 +2006,7 @@ public partial class TreeView : Control
 
     private void UpdateCheckBoxImages()
     {
-        if (DesignMode || !IsHandleCreated || !CheckBoxes || _stateImageList is not null)
+        if (!Application.IsDarkModeEnabled || DesignMode || !IsHandleCreated || !CheckBoxes || _stateImageList is not null)
         {
             return;
         }
@@ -2030,8 +2030,9 @@ public partial class TreeView : Control
             CheckBoxRenderer.DrawCheckBoxWithVisualStyles(g, new Point(0, 0), CheckBoxState.CheckedNormal, HWNDInternal);
         }
 
+        using Bitmap placeholderBitmap = new(size, size);
         // TreeView uses 1-based indexing: index 0=placeholder, 1=unchecked, 2=checked
-        imageList.Images.Add(new Bitmap(size, size)); // Placeholder
+        imageList.Images.Add(placeholderBitmap); // Placeholder
         imageList.Images.Add(uncheckedBitmap);
         imageList.Images.Add(checkedBitmap);
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11956 


## Proposed changes

Fixed an issue where the checkboxes in TreeView/ListView were not rendered correctly in dark theme. The main changes are as follows:
- TreeView: Creates/uses UpdateCheckBoxImages to generate a state imagelist of checkboxes that fits the dark system color, and refreshes and applies it when creating control code, enabling CheckBoxes, and setting WM_SYSCOLORCHANGE.
- ListView: Generates and applies a dark state imagelist to the checkboxes in ApplyDarkModeOnDemand, and refreshes the project state images to ensure the checkboxes display correctly in dark mode.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The checkboxes in TreeView/ListView render correctly in dark theme.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<img width="374" height="255" alt="image" src="https://github.com/user-attachments/assets/4fbc0854-dbfb-466a-abbc-4bc76b63cf0e" />

### After

<img width="878" height="319" alt="image" src="https://github.com/user-attachments/assets/bc5d48b1-b130-4263-a1cd-e06343d7525b" />


## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.100-preview.1.26078.121


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14288)