### PR TITLE
Fix InvalidCastException in Control.OnHandleDestroyed for non-ControlAccessibleObject

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Control.cs
@@ -7518,14 +7518,16 @@ public unsafe partial class Control :
         ((EventHandler?)Events[s_handleDestroyedEvent])?.Invoke(this, e);
 
         // The Accessibility Object for this Control
-        if (Properties.TryGetValue(s_accessibilityProperty, out ControlAccessibleObject? accObj))
+        if (Properties.TryGetValue(s_accessibilityProperty, out AccessibleObject? accObj)
+            && accObj is ControlAccessibleObject controlAccObj)
         {
-            accObj.Handle = IntPtr.Zero;
+            controlAccObj.Handle = IntPtr.Zero;
         }
 
         // Private accessibility object for control, used to wrap the object that
         // OLEACC.DLL creates to represent the control's non-client (NC) region.
-        if (Properties.TryGetValue(s_ncAccessibilityProperty, out ControlAccessibleObject? nonClientAccessibleObject))
+        if (Properties.TryGetValue(s_ncAccessibilityProperty, out AccessibleObject? ncAccObj)
+            && ncAccObj is ControlAccessibleObject nonClientAccessibleObject)
         {
             nonClientAccessibleObject.Handle = IntPtr.Zero;
         }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ControlTests.Methods.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ControlTests.Methods.cs
@@ -413,6 +413,18 @@ public partial class ControlTests
     }
 
     [WinFormsFact]
+    public void Control_OnHandleDestroyed_CustomAccessibleObject_DoesNotThrow1()
+    {
+        using CustomCreateAccessibilityInstanceControl control = new()
+        {
+            CreateAccessibilityResult = new AccessibleObject()
+        };
+
+        AccessibleObject accessibleObject = control.AccessibilityObject;
+        control.InvokeOnHandleDestroyed(EventArgs.Empty);
+    }
+
+    [WinFormsFact]
     public void Control_CreateControl_Invoke_Success()
     {
         using SubControl control = new();
@@ -14375,6 +14387,8 @@ public partial class ControlTests
         Assert.Equal(0, styleChangedCallCount);
         Assert.Equal(0, createdCallCount);
     }
+
+
 
     private class NoCreateControl : Control
     {

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ControlTests.Methods.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ControlTests.Methods.cs
@@ -14388,8 +14388,6 @@ public partial class ControlTests
         Assert.Equal(0, createdCallCount);
     }
 
-
-
     private class NoCreateControl : Control
     {
         protected override void WndProc(ref Message m)

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ControlTests.Methods.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ControlTests.Methods.cs
@@ -421,7 +421,8 @@ public partial class ControlTests
         };
 
         AccessibleObject accessibleObject = control.AccessibilityObject;
-        control.InvokeOnHandleDestroyed(EventArgs.Empty);
+        Action action = () => control.InvokeOnHandleDestroyed(EventArgs.Empty);
+        action.Should().NotThrow();
     }
 
     [WinFormsFact]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ControlTests.Properties.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ControlTests.Properties.cs
@@ -100,6 +100,8 @@ public partial class ControlTests
         public AccessibleObject CreateAccessibilityResult { get; set; }
 
         protected override AccessibleObject CreateAccessibilityInstance() => CreateAccessibilityResult;
+
+        public void InvokeOnHandleDestroyed(EventArgs eventArgs) => OnHandleDestroyed(eventArgs);
     }
 
     [WinFormsTheory]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14291

## Root Cause

`Control.OnHandleDestroyed` used `Properties.TryGetValue<ControlAccessibleObject>` for both AccessibilityObject and NcAccessibilityObject, assuming the stored instance was always a ControlAccessibleObject. When a control overrides `CreateAccessibleObject()` to return a different AccessibleObject type, the generic `TryGetValue<T>` attempted an invalid cast and threw `InvalidCastException` during handle destruction.

## Proposed changes

-  Change the lookups in `Control.OnHandleDestroyed` for `s_accessibilityProperty` and `s_ncAccessibilityProperty` from `TryGetValue<ControlAccessibleObject>` to `TryGetValue<AccessibleObject>`, then use type pattern matching (`accObj is ControlAccessibleObject controlAccObj`) before resetting `controlAccObj.Handle = IntPtr.Zero`, so only true `ControlAccessibleObject` instances are manipulated and other AccessibleObject types no longer cause invalid casts.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- This change prevents `InvalidCastException` crashes when controls with custom accessible objects are destroyed

## Regression? 

- Yes (Regress by commit https://github.com/dotnet/winforms/commit/d08128b65d172917d624894a558ceaa6e69826aa#diff-07a0a87cedab0d76c974ce8b105912a1b986c87116c7ee0ac73d6d5d65e4b48aL7643)

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Sample project: 
[WinFormsApp15.zip](https://github.com/user-attachments/files/25253150/WinFormsApp15.zip)

On teardown, If a custom overrode CreateAccessibleObject() and returned a different AccessibleObject type, TryGetValue<ControlAccessibleObject> threw an InvalidCastException when the handle was destroyed, potentially crashing the app.

https://github.com/user-attachments/assets/c37feba7-58f8-47db-a20e-fcc540ebc11d


### After
Custom accessible objects that are not `ControlAccessibleObject` are left untouched during handle destruction, so no `InvalidCastException` is thrown and the app stays stable.

https://github.com/user-attachments/assets/9d89b29c-c1b4-4b37-924e-4eaf23bec610


## Test methodology <!-- How did you ensure quality? -->

- Manually
 

## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-preview.2.26080.101


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14295)