### PR TITLE
[release/10.0]: Avoid double free of STGMEDIUM while fetching stream data from clipboard

### DIFF
--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/Composition.NativeToManagedAdapter.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/Composition.NativeToManagedAdapter.cs
@@ -420,8 +420,9 @@ internal unsafe partial class Composition<TOleServices, TNrbfSerializer, TDataFo
                     return false;
                 }
 
-                using ComScope<Com.IStream> pStream = new((Com.IStream*)medium.hGlobal);
-                pStream.Value->Stat(out Com.STATSTG sstg, (uint)Com.STATFLAG.STATFLAG_DEFAULT);
+                // Don't wrap in ComScope - ReleaseStgMedium will release the stream.
+                Com.IStream* pStream = (Com.IStream*)medium.hGlobal;
+                pStream->Stat(out Com.STATSTG sstg, (uint)Com.STATFLAG.STATFLAG_DEFAULT);
 
                 hglobal = PInvokeCore.GlobalAlloc(GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE | GLOBAL_ALLOC_FLAGS.GMEM_ZEROINIT, (uint)sstg.cbSize);
 
@@ -433,7 +434,7 @@ internal unsafe partial class Composition<TOleServices, TNrbfSerializer, TDataFo
                 }
 
                 void* ptr = PInvokeCore.GlobalLock(hglobal);
-                pStream.Value->Read((byte*)ptr, (uint)sstg.cbSize, null);
+                pStream->Read((byte*)ptr, (uint)sstg.cbSize, null);
                 PInvokeCore.GlobalUnlock(hglobal);
 
                 return TryGetDataFromHGLOBAL(hglobal, in request, out data);

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Private/Windows/Ole/IStreamNativeDataObject.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Private/Windows/Ole/IStreamNativeDataObject.cs
@@ -1,0 +1,83 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.System.Com;
+
+namespace System.Private.Windows.Ole;
+
+/// <summary>
+///  A native data object mock that returns data via <see cref="TYMED.TYMED_ISTREAM"/>.
+/// </summary>
+internal unsafe class IStreamNativeDataObject : NativeDataObjectMock
+{
+    private readonly Stream _stream;
+    private readonly ushort _format;
+
+    public IStreamNativeDataObject(Stream stream, ushort format)
+    {
+        _stream = stream;
+        _format = format;
+    }
+
+    public override HRESULT QueryGetData(FORMATETC* pformatetc)
+    {
+        if (pformatetc is null)
+        {
+            return HRESULT.DV_E_FORMATETC;
+        }
+
+        if (pformatetc->cfFormat != _format)
+        {
+            return HRESULT.DV_E_FORMATETC;
+        }
+
+        if (pformatetc->dwAspect != (uint)DVASPECT.DVASPECT_CONTENT)
+        {
+            return HRESULT.DV_E_DVASPECT;
+        }
+
+        if (pformatetc->lindex != -1)
+        {
+            return HRESULT.DV_E_LINDEX;
+        }
+
+        if (pformatetc->tymed != (uint)TYMED.TYMED_ISTREAM)
+        {
+            return HRESULT.DV_E_TYMED;
+        }
+
+        return HRESULT.S_OK;
+    }
+
+    public override HRESULT GetData(FORMATETC* pformatetcIn, STGMEDIUM* pmedium)
+    {
+        HRESULT result = QueryGetData(pformatetcIn);
+        if (result.Failed)
+        {
+            return result;
+        }
+
+        if (pmedium is null)
+        {
+            return HRESULT.E_POINTER;
+        }
+
+        // Reset stream position for each GetData call
+        _stream.Position = 0;
+
+        // Create a ComManagedStream wrapper
+        ComManagedStream comStream = new(_stream);
+
+        // Return the IStream pointer in the STGMEDIUM
+        // Note: hGlobal is a union with pstm in STGMEDIUM
+        pmedium->hGlobal = (HGLOBAL)(nint)ComHelpers.GetComPointer<IStream>(comStream);
+        pmedium->tymed = TYMED.TYMED_ISTREAM;
+        pmedium->pUnkForRelease = null;
+
+        return HRESULT.S_OK;
+    }
+
+    protected override void Dispose(bool disposing) => _stream.Dispose();
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/winforms/issues/14308

**Description/Customer Impact:** In WPF GitHub repo, a customer reported that after upgrading to .NET 10, a WPF application intermittently crashes with an unhandled native CFG violation exception: `Indirect call guard check detected invalid control transfer`

The crash occurs inside `Clipboard.ContainsText(...)` API when it is called in response to `WM_CLIPBOARDUPDATE` message. The same code path worked reliably in previous .NET versions.

**Regression**: Since .NET 9, WinForms and WPF have started using shared Clipboard code which is owned by WinForms. This change modified the clipboard logic substantially for both the UI stacks as compared to .NET 8 and previous versions.

**Risk of this change:** Low. The change only avoids using ComScope which was double freeing the memory pointer. In all other places in the code, ComScope is not in use for STGMEDIUM. So there is prior art for this fix.
Although we couldn't repro the issue internally, CTI team did extensive internal testing with the changes in this PR and didn't find any new issue.

**Issue**: https://github.com/dotnet/winforms/issues/14308

**main branch commit**: https://github.com/dotnet/winforms/pull/14257

**Root cause**: Due to use of ComScope , the STGMEDIUM was getting released twice - once by ComScope and once in the finally block. It was causing intermittent CFG exception.

**Fix**: Don't use ComScope in this case.

**Note**: We checked other use cases of STGMEDIUM in the repo and confirmed that ComScope is not being used for them.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14296)