### PR TITLE
Fix UIA Invoke hang when ToolStripMenuItem opens modal dialog from MenuStrip

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.ToolStripMenuItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.ToolStripMenuItemAccessibleObject.cs
@@ -121,6 +121,20 @@ public partial class ToolStripMenuItem
 
         private protected override bool IsInternal => true;
 
+        internal override void Invoke()
+        {
+            ToolStrip? owner = _owningToolStripMenuItem.Owner;
+
+            if (owner is not null && owner.IsHandleCreated)
+            {
+                owner.BeginInvoke(new MethodInvoker(DoDefaultAction));
+
+                return;
+            }
+
+            DoDefaultAction();
+        }
+
         internal override bool IsPatternSupported(UIA_PATTERN_ID patternId) =>
             patternId switch
             {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.ToolStripMenuItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.ToolStripMenuItemAccessibleObject.cs
@@ -123,11 +123,11 @@ public partial class ToolStripMenuItem
 
         internal override void Invoke()
         {
-            ToolStrip? owner = _owningToolStripMenuItem.Owner;
+            ToolStrip? owningToolStrip = _owningToolStripMenuItem.Owner;
 
-            if (owner is not null && owner.IsHandleCreated)
+            if (owningToolStrip is { IsHandleCreated: true })
             {
-                owner.BeginInvoke(new MethodInvoker(DoDefaultAction));
+                owningToolStrip.BeginInvoke(new MethodInvoker(DoDefaultAction));
 
                 return;
             }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10244

## Root Cause

- UI Automation invokes menu items via `ToolStripMenuItemAccessibleObject.Invoke`, which previously called `DoDefaultAction()` synchronously.
- When the menu item lives on a MenuStrip and its click handler opens a modal window (e.g. ShowDialog / MessageBox.Show), this happens while WinForms is inside the Win32 “menu mode” message loop.
- The synchronous call starts a nested modal loop inside the menu loop while the UIA client is still blocked waiting for Invoke to return, which can lead to the invoke call appearing “stuck” or the app becoming unresponsive in this scenario.

## Proposed changes

- Override ToolStripMenuItemAccessibleObject.Invoke to dispatch the default action asynchronously when the item has an owning ToolStrip with a created handle:
   - If Owner is non-null and Owner.IsHandleCreated is true, call owner.BeginInvoke(new MethodInvoker(DoDefaultAction)); and return immediately.
   - If there is no owner (or no handle yet), fall back to calling DoDefaultAction() directly as before.
- This ensures that for real MenuStrip scenarios the click logic (and any modal UI it shows) runs after the menu loop has exited, under the normal UI message pump, while non-attached/test-only items preserve their existing synchronous behavior.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

-  UI Automation tools invoking MenuStrip menu items that open modal dialogs will no longer hang or throw errors, so automated testing and accessibility scenarios can reliably trigger these commands.

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Accessibility tools and UIA-based automation that invoke `ToolStripMenuItem` items which open dialogs from a MenuStrip will   blocked, `invokes` will fail to complete.

https://github.com/user-attachments/assets/5ccf94f7-57a2-4f76-ab44-c41de4bf9e4b



### After
Accessibility tools and UIA-based automation that invoke `ToolStripMenuItem` items which open dialogs from a MenuStrip will no longer hang or appear blocked, invokes will complete and dialogs will show reliably.

https://github.com/user-attachments/assets/375d06a2-8ab1-4a30-b2ff-faf0a42d8072



## Test methodology <!-- How did you ensure quality? -->

- Unit test 

## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-preview.2.26080.101

<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14301)