### PR TITLE
Fix dark mode invisible text for CheckBox/RadioButton with FlatStyle.System

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonBase.cs
@@ -1348,6 +1348,23 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
 
     private bool ShouldSerializeUseVisualStyleBackColor() => _isEnableVisualStyleBackgroundSet;
 
+    internal override HBRUSH InitializeDCForWmCtlColor(HDC dc, MessageId msg)
+    {
+        // In dark mode with FlatStyle.System, the control is rendered by the system with a dark
+        // theme applied via SetWindowTheme. The default SystemColors (ControlText, Control) don't
+        // reflect the dark theme, causing dark text on a dark background. Return default to let
+        // the dark theme handle text and background colors correctly.
+        if (FlatStyle == FlatStyle.System
+            && Application.IsDarkModeEnabled
+            && !ShouldSerializeForeColor()
+            && !ShouldSerializeBackColor())
+        {
+            return default;
+        }
+
+        return base.InitializeDCForWmCtlColor(dc, msg);
+    }
+
     protected override void WndProc(ref Message m)
     {
         switch (m.MsgInternal)


### PR DESCRIPTION
## Summary

- Fixes dark mode invisible text on CheckBox/RadioButton controls with `FlatStyle.System` by overriding `InitializeDCForWmCtlColor` in `ButtonBase` to let the dark theme handle text/background colors instead of forcing `SystemColors.ControlText` (which stays dark)
- Returns `default` (null brush) when dark mode is active, `FlatStyle.System` is used, and the user hasn't explicitly set ForeColor/BackColor — following the same pattern as `ScrollBar`
- Respects explicitly set ForeColor/BackColor by falling back to base behavior

Fixes #11950

## Test plan

- [ ] Create a WinForms app with CheckBox and RadioButton controls set to `FlatStyle.System`
- [ ] Enable dark mode via `Application.SetColorMode(SystemColorMode.Dark)`
- [ ] Verify text is visible (light text on dark background)
- [ ] Verify explicitly setting ForeColor/BackColor still works correctly
- [ ] Run existing unit tests for System.Windows.Forms
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14307)