### PR TITLE
[Backport to release/11.0-preview2]: Updating build agent image to use VS2026

### DIFF
--- a/eng/pipelines/build-PR.yml
+++ b/eng/pipelines/build-PR.yml
@@ -17,10 +17,10 @@ jobs:
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: $(DncEngPublicBuildPool)
-        demands: ImageOverride -equals windows.vs2022preview.amd64.open
+        demands: ImageOverride -equals windows.vs2026preview.scout.amd64.open
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
         name: $(DncEngInternalBuildPool)
-        demands: ImageOverride -equals windows.vs2022preview.amd64
+        demands: ImageOverride -equals windows.vs2026preview.scout.amd64
     strategy:
       matrix:
         Debug:

--- a/src/System.Drawing.Common/tests/System/Drawing/Drawing2D/GraphicsPathTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/Drawing2D/GraphicsPathTests.cs
@@ -2348,30 +2348,22 @@ public class GraphicsPathTests
     {
         using GraphicsPath path = new();
         path.AddRoundedRectangle(new Rectangle(10, 10, 20, 20), new(5, 5));
-        path.PathPoints.Should().BeApproximatelyEquivalentTo(
-            new PointF[]
-            {
-                new(27.499994f, 10),
-                new(28.880707f, 9.999997f),
-                new(29.999996f, 11.119284f),
-                new(29.999998f, 12.499999f),
-                new(29.999998f, 12.499999f),
-                new(29.999998f, 12.5f),
-                new(29.999998f, 12.5f),
-                new(29.999998f, 27.499998f),
-                new(29.999998f, 28.88071f),
-                new(28.88071f, 29.999998f),
-                new(27.5f, 29.999998f),
-                new(12.500001f, 29.999998f),
-                new(11.119289f, 30),
-                new(10.000001f, 28.880713f),
-                new(10f, 27.5f),
-                new(9.999999f, 12.500001f),
-                new(9.999998f, 11.119289f),
-                new(11.119286f, 10.000001f),
-                new(12.499997f, 9.999999f),
-            },
-            0.000001f);
+
+        // The number of points (19 or 25) can vary by GDI+ implementation.
+        path.PointCount.Should().BeOneOf(19, 25);
+        path.GetBounds().Should().BeApproximately(new RectangleF(10f, 10f, 20f, 20f), 0.01f);
+
+        PointF[] points = path.PathPoints;
+        PointF first = points[0];
+        PointF last = points[^1];
+
+        // First point should be on the top edge near top-right corner.
+        first.X.Should().BeApproximately(27.5f, 0.001f);
+        first.Y.Should().BeApproximately(10f, 0.001f);
+
+        // Last point should be on the top edge near top-left corner.
+        last.X.Should().BeApproximately(12.5f, 0.001f);
+        last.Y.Should().BeApproximately(10f, 0.001f);
     }
 
     [Fact]
@@ -2379,30 +2371,22 @@ public class GraphicsPathTests
     {
         using GraphicsPath path = new();
         path.AddRoundedRectangle(new RectangleF(10, 10, 20, 20), new(5, 5));
-        path.PathPoints.Should().BeApproximatelyEquivalentTo(
-            new PointF[]
-            {
-                new(27.499994f, 10),
-                new(28.880707f, 9.999997f),
-                new(29.999996f, 11.119284f),
-                new(29.999998f, 12.499999f),
-                new(29.999998f, 12.499999f),
-                new(29.999998f, 12.5f),
-                new(29.999998f, 12.5f),
-                new(29.999998f, 27.499998f),
-                new(29.999998f, 28.88071f),
-                new(28.88071f, 29.999998f),
-                new(27.5f, 29.999998f),
-                new(12.500001f, 29.999998f),
-                new(11.119289f, 30),
-                new(10.000001f, 28.880713f),
-                new(10f, 27.5f),
-                new(9.999999f, 12.500001f),
-                new(9.999998f, 11.119289f),
-                new(11.119286f, 10.000001f),
-                new(12.499997f, 9.999999f),
-            },
-            0.000001f);
+
+        // The number of points can vary by GDI+ implementation (19 or 25).
+        path.PointCount.Should().BeOneOf(19, 25);
+        path.GetBounds().Should().BeApproximately(new RectangleF(10f, 10f, 20f, 20f), 0.01f);
+
+        PointF[] points = path.PathPoints;
+        PointF first = points[0];
+        PointF last = points[^1];
+
+        // First point should be on the top edge near top-right corner.
+        first.X.Should().BeApproximately(27.5f, 0.001f);
+        first.Y.Should().BeApproximately(10f, 0.001f);
+
+        // Last point should be on the top edge near top-left corner.
+        last.X.Should().BeApproximately(12.5f, 0.001f);
+        last.Y.Should().BeApproximately(10f, 0.001f);
     }
 
 #endif

--- a/src/System.Drawing.Common/tests/System/Drawing/Drawing2D/MatrixTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/Drawing2D/MatrixTests.cs
@@ -308,8 +308,14 @@ public partial class MatrixTests
         yield return new object[] { new Matrix(10, 20, 30, 40, 50, 60), new Matrix(float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity), MatrixOrder.Prepend, new float[] { float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity } };
         yield return new object[] { new Matrix(10, 20, 30, 40, 50, 60), new Matrix(float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity), MatrixOrder.Append, new float[] { float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity } };
 
-        yield return new object[] { new Matrix(10, 20, 30, 40, 50, 60), new Matrix(float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue), MatrixOrder.Prepend, new float[] { float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue } };
-        yield return new object[] { new Matrix(10, 20, 30, 40, 50, 60), new Matrix(float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue), MatrixOrder.Append, new float[] { float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue } };
+        // On x86, multiplying matrix coefficients (10-60) by MaxValue overflows float to infinity
+        // due to x87 FPU 80-bit intermediate precision behavior.
+        float expectedMaxMultiply = RuntimeInformation.ProcessArchitecture == Architecture.X86
+            ? float.PositiveInfinity
+            : float.MaxValue;
+
+        yield return new object[] { new Matrix(10, 20, 30, 40, 50, 60), new Matrix(float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue), MatrixOrder.Prepend, new float[] { expectedMaxMultiply, expectedMaxMultiply, expectedMaxMultiply, expectedMaxMultiply, expectedMaxMultiply, expectedMaxMultiply } };
+        yield return new object[] { new Matrix(10, 20, 30, 40, 50, 60), new Matrix(float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue), MatrixOrder.Append, new float[] { expectedMaxMultiply, expectedMaxMultiply, expectedMaxMultiply, expectedMaxMultiply, expectedMaxMultiply, expectedMaxMultiply } };
     }
 
     [Theory]
@@ -531,8 +537,14 @@ public partial class MatrixTests
         yield return new object[] { new Matrix(10, 20, 30, 40, 50, 60), float.NegativeInfinity, float.NegativeInfinity, MatrixOrder.Prepend, new float[] { float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity, 50, 60 } };
         yield return new object[] { new Matrix(10, 20, 30, 40, 50, 60), float.NegativeInfinity, float.NegativeInfinity, MatrixOrder.Append, new float[] { float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity } };
 
-        yield return new object[] { new Matrix(10, 20, 30, 40, 50, 60), float.MaxValue, float.MaxValue, MatrixOrder.Prepend, new float[] { float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, 50, 60 } };
-        yield return new object[] { new Matrix(10, 20, 30, 40, 50, 60), float.MaxValue, float.MaxValue, MatrixOrder.Append, new float[] { float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue } };
+        // On x86, scaling matrix coefficients (10-60) by MaxValue overflows float to infinity
+        // due to x87 FPU 80-bit intermediate precision behavior.
+        float expectedMaxScale = RuntimeInformation.ProcessArchitecture == Architecture.X86
+            ? float.PositiveInfinity
+            : float.MaxValue;
+
+        yield return new object[] { new Matrix(10, 20, 30, 40, 50, 60), float.MaxValue, float.MaxValue, MatrixOrder.Prepend, new float[] { expectedMaxScale, expectedMaxScale, expectedMaxScale, expectedMaxScale, 50, 60 } };
+        yield return new object[] { new Matrix(10, 20, 30, 40, 50, 60), float.MaxValue, float.MaxValue, MatrixOrder.Append, new float[] { expectedMaxScale, expectedMaxScale, expectedMaxScale, expectedMaxScale, expectedMaxScale, expectedMaxScale } };
     }
 
     [Theory]
@@ -597,8 +609,14 @@ public partial class MatrixTests
         yield return new object[] { new Matrix(10, 20, 30, 40, 50, 60), float.NegativeInfinity, float.NegativeInfinity, MatrixOrder.Prepend, new float[] { float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity, 50, 60 } };
         yield return new object[] { new Matrix(10, 20, 30, 40, 50, 60), float.NegativeInfinity, float.NegativeInfinity, MatrixOrder.Append, new float[] { float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity } };
 
-        yield return new object[] { new Matrix(10, 20, 30, 40, 50, 60), float.MaxValue, float.MaxValue, MatrixOrder.Prepend, new float[] { float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, 50, 60 } };
-        yield return new object[] { new Matrix(10, 20, 30, 40, 50, 60), float.MaxValue, float.MaxValue, MatrixOrder.Append, new float[] { float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue } };
+        // On x86, shearing matrix coefficients (10-60) by MaxValue overflows float to infinity
+        // due to x87 FPU 80-bit intermediate precision behavior.
+        float expectedMaxShear = RuntimeInformation.ProcessArchitecture == Architecture.X86
+            ? float.PositiveInfinity
+            : float.MaxValue;
+
+        yield return new object[] { new Matrix(10, 20, 30, 40, 50, 60), float.MaxValue, float.MaxValue, MatrixOrder.Prepend, new float[] { expectedMaxShear, expectedMaxShear, expectedMaxShear, expectedMaxShear, 50, 60 } };
+        yield return new object[] { new Matrix(10, 20, 30, 40, 50, 60), float.MaxValue, float.MaxValue, MatrixOrder.Append, new float[] { expectedMaxShear, expectedMaxShear, expectedMaxShear, expectedMaxShear, expectedMaxShear, expectedMaxShear } };
     }
 
     [Theory]
@@ -654,7 +672,12 @@ public partial class MatrixTests
         yield return new object[] { new Matrix(1, 2, 3, 4, 5, 6), float.NegativeInfinity, float.NegativeInfinity, MatrixOrder.Prepend, new float[] { 1, 2, 3, 4, float.NegativeInfinity, float.NegativeInfinity } };
         yield return new object[] { new Matrix(1, 2, 3, 4, 5, 6), float.NegativeInfinity, float.NegativeInfinity, MatrixOrder.Append, new float[] { 1, 2, 3, 4, float.NegativeInfinity, float.NegativeInfinity } };
 
-        yield return new object[] { new Matrix(1, 2, 3, 4, 5, 6), float.MaxValue, float.MaxValue, MatrixOrder.Prepend, new float[] { 1, 2, 3, 4, float.MaxValue, float.MaxValue } };
+        // On x86, Prepend operation causes float overflow to infinity due to x87 FPU behavior.
+        float expectedMaxTranslation = RuntimeInformation.ProcessArchitecture == Architecture.X86
+            ? float.PositiveInfinity
+            : float.MaxValue;
+
+        yield return new object[] { new Matrix(1, 2, 3, 4, 5, 6), float.MaxValue, float.MaxValue, MatrixOrder.Prepend, new float[] { 1, 2, 3, 4, expectedMaxTranslation, expectedMaxTranslation } };
         yield return new object[] { new Matrix(1, 2, 3, 4, 5, 6), float.MaxValue, float.MaxValue, MatrixOrder.Append, new float[] { 1, 2, 3, 4, float.MaxValue, float.MaxValue } };
     }
 

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
@@ -2189,12 +2189,6 @@ public class GraphicsTest : IDisposable
     [Fact]
     public void VisibleClipBound()
     {
-        if (PlatformDetection.IsArmOrArm64Process)
-        {
-            // [ActiveIssue("https://github.com/dotnet/winforms/issues/8817")]
-            Assert.Skip("Precision on float numbers");
-        }
-
         // see #78958
         using Bitmap bmp = new(100, 100);
         using Graphics g = Graphics.FromImage(bmp);
@@ -2214,7 +2208,7 @@ public class GraphicsTest : IDisposable
 
         g.RotateTransform(90);
         RectangleF rotclip = g.VisibleClipBounds;
-        Assert.Equal(0, rotclip.X);
+        Assert.Equal(0.0, rotclip.X, 4);
         Assert.Equal(-32.0, rotclip.Y, 4);
         Assert.Equal(32.0, rotclip.Width, 4);
         Assert.Equal(32.0, rotclip.Height, 4);
@@ -2223,12 +2217,6 @@ public class GraphicsTest : IDisposable
     [Fact]
     public void VisibleClipBound_BigClip()
     {
-        if (PlatformDetection.IsArmOrArm64Process)
-        {
-            // ActiveIssue: 35744
-            Assert.Skip("Precision on float numbers");
-        }
-
         using Bitmap bmp = new(100, 100);
         using Graphics g = Graphics.FromImage(bmp);
         RectangleF noclip = g.VisibleClipBounds;
@@ -2253,13 +2241,13 @@ public class GraphicsTest : IDisposable
 
         g.RotateTransform(90);
         RectangleF rotclipbound = g.ClipBounds;
-        Assert.Equal(0, rotclipbound.X);
+        Assert.Equal(0.0, rotclipbound.X, 4);
         Assert.Equal(-200.0, rotclipbound.Y, 4);
         Assert.Equal(200.0, rotclipbound.Width, 4);
         Assert.Equal(200.0, rotclipbound.Height, 4);
 
         RectangleF rotclip = g.VisibleClipBounds;
-        Assert.Equal(0, rotclip.X);
+        Assert.Equal(0.0, rotclip.X, 4);
         Assert.Equal(-100.0, rotclip.Y, 4);
         Assert.Equal(100.0, rotclip.Width, 4);
         Assert.Equal(100.0, rotclip.Height, 4);
@@ -2268,12 +2256,6 @@ public class GraphicsTest : IDisposable
     [Fact]
     public void Rotate()
     {
-        if (PlatformDetection.IsArmOrArm64Process)
-        {
-            // ActiveIssue: 35744
-            Assert.Skip("Precision on float numbers");
-        }
-
         using Bitmap bmp = new(100, 50);
         using Graphics g = Graphics.FromImage(bmp);
         RectangleF vcb = g.VisibleClipBounds;
@@ -2284,7 +2266,7 @@ public class GraphicsTest : IDisposable
 
         g.RotateTransform(90);
         RectangleF rvcb = g.VisibleClipBounds;
-        Assert.Equal(0, rvcb.X);
+        Assert.Equal(0.0, rvcb.X, 4);
         Assert.Equal(-100.0, rvcb.Y, 4);
         Assert.Equal(50.0, rvcb.Width, 4);
         Assert.Equal(100.0, rvcb.Height, 4);

--- a/src/test/integration/UIIntegrationTests/FormTests.cs
+++ b/src/test/integration/UIIntegrationTests/FormTests.cs
@@ -35,25 +35,18 @@ public class FormTests : ControlTestBase
 
             form.WindowState = windowState;
 
+            // Snap left using Win+Left shortcut. This directly snaps the window
+            // to the left half of the screen without requiring snap layout panel navigation.
             await InputSimulator.SendAsync(
                 form,
-                inputSimulator => inputSimulator.Keyboard.ModifiedKeyStroke(VIRTUAL_KEY.VK_LWIN, VIRTUAL_KEY.VK_Z));
-
-            // inputSimulator.Sleep appears wildly inconsistent with snap panel timing. Task.Delay does not
-            await Task.Delay(SnapLayoutDelayMS);
-
-            // Snap left
-            await InputSimulator.SendAsync(
-                form,
-                inputSimulator => inputSimulator.Keyboard.KeyPress(VIRTUAL_KEY.VK_RIGHT)
-                                                         .KeyPress(VIRTUAL_KEY.VK_RETURN));
+                inputSimulator => inputSimulator.Keyboard
+                    .ModifiedKeyStroke(VIRTUAL_KEY.VK_LWIN, VIRTUAL_KEY.VK_LEFT));
 
             await Task.Delay(SnapLayoutDelayMS);
 
-            // At this point, Windows displays a panel containing all running applications so the
-            // user can select one to dock next to our form. It also takes the keyboard focus away.
-            // If left in this state, subsequently run tests will fail since keyboard focus is not
-            // given to any newly launched window until this panel is dismissed.
+            // After snapping left, Windows may display a panel containing all running
+            // applications so the user can select one to dock next to our form. It also
+            // takes the keyboard focus away. Dismiss it with Escape.
             await InputSimulator.SendAsync(
                 form,
                 inputSimulator => inputSimulator.Keyboard.KeyPress(VIRTUAL_KEY.VK_ESCAPE));
@@ -94,26 +87,18 @@ public class FormTests : ControlTestBase
 
             form.WindowState = windowState;
 
+            // Snap right using Win+Right shortcut. This directly snaps the window
+            // to the right half of the screen without requiring snap layout panel navigation.
             await InputSimulator.SendAsync(
                 form,
-                inputSimulator => inputSimulator.Keyboard.ModifiedKeyStroke(VIRTUAL_KEY.VK_LWIN, VIRTUAL_KEY.VK_Z));
-
-            // inputSimulator.Sleep appears wildly inconsistent with snap panel timing. Task.Delay does not
-            await Task.Delay(SnapLayoutDelayMS);
-
-            // Snap right
-            await InputSimulator.SendAsync(
-                form,
-                inputSimulator => inputSimulator.Keyboard.KeyPress(VIRTUAL_KEY.VK_RIGHT)
-                                                         .KeyPress(VIRTUAL_KEY.VK_RIGHT)
-                                                         .KeyPress(VIRTUAL_KEY.VK_RETURN));
+                inputSimulator => inputSimulator.Keyboard
+                    .ModifiedKeyStroke(VIRTUAL_KEY.VK_LWIN, VIRTUAL_KEY.VK_RIGHT));
 
             await Task.Delay(SnapLayoutDelayMS);
 
-            // At this point, Windows displays a panel containing all running applications so the
-            // user can select one to dock next to our form. It also takes the keyboard focus away.
-            // If left in this state, subsequently run tests will fail since keyboard focus is not
-            // given to any newly launched window until this panel is dismissed.
+            // After snapping right, Windows may display a panel containing all running
+            // applications so the user can select one to dock next to our form. It also
+            // takes the keyboard focus away. Dismiss it with Escape.
             await InputSimulator.SendAsync(
                 form,
                 inputSimulator => inputSimulator.Keyboard.KeyPress(VIRTUAL_KEY.VK_ESCAPE));

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/InputLanguageTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/InputLanguageTests.cs
@@ -190,7 +190,10 @@ public class InputLanguageTests
 
         if (CultureInfo.InstalledUICulture.Name.StartsWith("en-", StringComparison.OrdinalIgnoreCase))
         {
-            language.LayoutName.Should().Be(layoutName);
+            // Layout display names may include OS-specific suffixes e.g. "French" became
+            // "French (Legacy, AZERTY)" in Windows 11.0. Due to this reason we are using StartsWith
+            // instead of equality check for layout name.
+            language.LayoutName.Should().StartWith(layoutName);
         }
         else
         {


### PR DESCRIPTION
Backport from #14299 

* Updating build agent image to use VS2026

VS2022 images have been deprecated this week and we need to move to VS2026. This change will need to be backported to servicing branches also.

* Using scout images

* The Form_SnapsRightAsync(Maximized) test failed because the Win+Z snap layout panel interaction was broken. The test used Win+Z to open the snap layout panel, then navigated with arrow keys to select the right-half snap position. However, each SendAsync(Form, params object[]) call invoked SetForegroundWindow on the form, which dismissed the snap layout panel before the arrow keys could navigate it. For maximized windows, the window remained maximized and the snap never occurred.

Root Cause
1. SetForegroundWindow in SendAsync(Form, params object[]) dismissed the Win+Z snap layout panel before arrow keys could navigate it.

2. Win+Z snap panel keyboard navigation is fragile and varies across Windows versions, making it unreliable for automated testing.

Fix: Replaced Win+Z + keyboard navigation with Win+Left/Win+Right shortcuts in both Form_SnapsLeftAsync(FormWindowState) and Form_SnapsRightAsync(FormWindowState). These shortcuts directly snap windows without requiring interaction with the snap layout panel, making the tests more reliable across Windows versions.

* Test fix: Layout display names may include OS-specific suffixes e.g. "French" became "French (Legacy, AZERTY)" in Windows 11.0. Due to this reason we are using StartsWith instead of equality check for layout name.

* Test fix for GraphicsPath_AddRoundedRectangle_Integer and GraphicsPath_AddRoundedRectangle_Float failure on x86.

Issue: Old and new GDI+ are producing different number of points: 19 and 25 respectively for rounded rectangles' arcs.

Fix
Updated both tests to validate shape correctness rather than exact point sequences:
1. Point count: Assert that the count is one of the two valid values (19 or 25)
2. Bounding box: Verify the path bounds match the expected (10, 10, 20, 20) rectangle
3. Key coordinates: Verify the first point (top-right corner start at ~27.5, 10) and last point (top-left corner end at ~12.5, 10) are correct This makes the tests robust across different GDI+ implementations while still validating that AddRoundedRectangle(Rectangle, Size) produces a geometrically correct rounded rectangle.

* Test issue: The VisibleClipBound(), VisibleClipBound_BigClip(), and Rotate() tests were failing on x86 Windows due to floating-point precision differences after RotateTransform(90). There are tiny epsilon differences (e.g., 1.9E-06 instead of exactly 0). The tests used exact Assert.Equal(0, rotclip.X) for values computed through rotation matrix transforms, which broke on x86.

The same issue already existed on ARM (covered by IsArmOrArm64Process skip guards).

Fix
For all three tests:
1. Replaced exact equality (Assert.Equal(0, value)) with tolerance-based equality (Assert.Equal(0.0, value, 4)) for values computed after RotateTransform() — specifically the .X properties that should be 0 but may have tiny epsilon drift. Note that similar change was already done for verifying other points/lengths.
2. Removed the ARM skip guards (IsArmOrArm64Process + Skip(uint)) since the tolerance-based assertions now handle precision differences on all architectures (ARM, x86, x64).

* Due to GDI+ changes in Windows 11 on x86, floating point overflow causes the value to change to Infinity instead of float.MaxValue.

* Trigger PR update

* Fix for remaining matrix tests which are also failing on x86 due to similar issue as Translation Matrix test.