### PR TITLE
[release/10.0]: Updating build agent image to VS 2022 GA release

### DIFF
--- a/eng/pipelines/build-PR.yml
+++ b/eng/pipelines/build-PR.yml
@@ -17,10 +17,10 @@ jobs:
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: $(DncEngPublicBuildPool)
-        demands: ImageOverride -equals windows.vs2022preview.amd64.open
+        demands: ImageOverride -equals windows.vs2022.amd64.open
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
         name: $(DncEngInternalBuildPool)
-        demands: ImageOverride -equals windows.vs2022preview.amd64
+        demands: ImageOverride -equals windows.vs2022.amd64
     strategy:
       matrix:
         Debug:


### PR DESCRIPTION
Earlier we were using VS2022 Preview images which have been deprecated. We need to move to VS 2022 GA image.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14314)