### PR TITLE
Indeterminate and checked `ToolStripMenuItem` icons are now clearly visible in dark mode on `ContextMenuStrip`, `MenuStrip`, `StatusStrip` and `ToolStrip` drop-down buttons.

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripRenderer.cs
@@ -865,13 +865,7 @@ public abstract class ToolStripRenderer
 
             if (image is Bitmap bitmap)
             {
-                if (Application.IsDarkModeEnabled)
-                {
-                    // In dark mode, the check mark icons are dark glyphs designed for light
-                    // backgrounds. Invert the foreground color so they are visible on dark backgrounds.
-                    image = ControlPaint.CreateBitmapWithInvertedForeColor(bitmap, e.Item.BackColor);
-                }
-                else if (SystemInformation.HighContrast)
+                if (SystemInformation.HighContrast)
                 {
                     Color backgroundColor = e.Item.Selected ? SystemColors.Highlight : e.Item.BackColor;
 
@@ -879,6 +873,12 @@ public abstract class ToolStripRenderer
                     {
                         image = ControlPaint.CreateBitmapWithInvertedForeColor(bitmap, e.Item.BackColor);
                     }
+                }
+                else if (Application.IsDarkModeEnabled)
+                {
+                    // In dark mode, the check mark icons are dark glyphs designed for light
+                    // backgrounds. Invert the foreground color so they are visible on dark backgrounds.
+                    image = ControlPaint.CreateBitmapWithInvertedForeColor(bitmap, e.Item.BackColor);
                 }
             }
         }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripRenderer.cs
@@ -856,11 +856,16 @@ public abstract class ToolStripRenderer
             return;
         }
 
+        // Track images we allocate so they can be disposed after drawing.
+        Image? disabledImage = null;
+        Image? invertedImage = null;
+
         if (e.Item is not null)
         {
             if (!e.Item.Enabled)
             {
-                image = CreateDisabledImage(image, e.ImageAttributes);
+                disabledImage = CreateDisabledImage(image, e.ImageAttributes);
+                image = disabledImage;
             }
 
             if (image is Bitmap bitmap)
@@ -871,20 +876,30 @@ public abstract class ToolStripRenderer
 
                     if (ControlPaint.IsDark(backgroundColor))
                     {
-                        image = ControlPaint.CreateBitmapWithInvertedForeColor(bitmap, e.Item.BackColor);
+                        invertedImage = ControlPaint.CreateBitmapWithInvertedForeColor(bitmap, e.Item.BackColor);
+                        image = invertedImage;
                     }
                 }
                 else if (Application.IsDarkModeEnabled)
                 {
-                    // In dark mode, the check mark icons are dark glyphs designed for light
-                    // backgrounds. Invert the foreground color so they are visible on dark backgrounds.
-                    image = ControlPaint.CreateBitmapWithInvertedForeColor(bitmap, e.Item.BackColor);
+                    Color backgroundColor = e.Item.Selected ? SystemColors.Highlight : e.Item.BackColor;
+
+                    if (ControlPaint.IsDark(backgroundColor))
+                    {
+                        // In dark mode, the check mark icons are dark glyphs designed for light
+                        // backgrounds. Invert the foreground color so they are visible on dark backgrounds.
+                        invertedImage = ControlPaint.CreateBitmapWithInvertedForeColor(bitmap, e.Item.BackColor);
+                        image = invertedImage;
+                    }
                 }
             }
         }
 
         e.Graphics.DrawImage(image, imageRect, 0, 0, imageRect.Width,
         imageRect.Height, GraphicsUnit.Pixel, e.ImageAttributes);
+
+        disabledImage?.Dispose();
+        invertedImage?.Dispose();
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripRenderer.cs
@@ -876,7 +876,7 @@ public abstract class ToolStripRenderer
 
                     if (ControlPaint.IsDark(backgroundColor))
                     {
-                        invertedImage = ControlPaint.CreateBitmapWithInvertedForeColor(bitmap, e.Item.BackColor);
+                        invertedImage = ControlPaint.CreateBitmapWithInvertedForeColor(bitmap, backgroundColor);
                         image = invertedImage;
                     }
                 }
@@ -888,7 +888,7 @@ public abstract class ToolStripRenderer
                     {
                         // In dark mode, the check mark icons are dark glyphs designed for light
                         // backgrounds. Invert the foreground color so they are visible on dark backgrounds.
-                        invertedImage = ControlPaint.CreateBitmapWithInvertedForeColor(bitmap, e.Item.BackColor);
+                        invertedImage = ControlPaint.CreateBitmapWithInvertedForeColor(bitmap, backgroundColor);
                         image = invertedImage;
                     }
                 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripRenderer.cs
@@ -863,14 +863,22 @@ public abstract class ToolStripRenderer
                 image = CreateDisabledImage(image, e.ImageAttributes);
             }
 
-            if (SystemInformation.HighContrast && image is Bitmap bitmap)
+            if (image is Bitmap bitmap)
             {
-                Color backgroundColor = e.Item.Selected ? SystemColors.Highlight : e.Item.BackColor;
-
-                if (ControlPaint.IsDark(backgroundColor))
+                if (Application.IsDarkModeEnabled)
                 {
-                    Image invertedImage = ControlPaint.CreateBitmapWithInvertedForeColor(bitmap, e.Item.BackColor);
-                    image = invertedImage;
+                    // In dark mode, the check mark icons are dark glyphs designed for light
+                    // backgrounds. Invert the foreground color so they are visible on dark backgrounds.
+                    image = ControlPaint.CreateBitmapWithInvertedForeColor(bitmap, e.Item.BackColor);
+                }
+                else if (SystemInformation.HighContrast)
+                {
+                    Color backgroundColor = e.Item.Selected ? SystemColors.Highlight : e.Item.BackColor;
+
+                    if (ControlPaint.IsDark(backgroundColor))
+                    {
+                        image = ControlPaint.CreateBitmapWithInvertedForeColor(bitmap, e.Item.BackColor);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #11933

## Root Cause

`ToolStripRenderer.OnRenderItemCheck` only inverted the check mark glyph when `SystemInformation.HighContrast` was true. In regular dark mode the check mark icons (designed for light backgrounds) were drawn as-is, resulting in a dark glyph on a dark background.

## Proposed changes

Extended the inversion logic in `ToolStripRenderer.OnRenderItemCheck` to also trigger when `Application.IsDarkModeEnabled` is true, using the existing `ControlPaint.CreateBitmapWithInvertedForeColor` helper. The high contrast path is preserved as a separate branch since it already handles its own background-color detection.

## Customer Impact

Indeterminate and checked `ToolStripMenuItem` icons are now clearly visible in dark mode on `ContextMenuStrip`, `MenuStrip`, `StatusStrip` and `ToolStrip` drop-down buttons.

## Regression?

No

## Risk

Minimal

## Screenshots

### Before

![11933-before](https://github.com/user-attachments/assets/9133c0ee-c59b-4d24-8ab5-cec70b898ce8)

### After

![11933-after](https://github.com/user-attachments/assets/2528bc1f-12b4-4a33-af09-edc3a18492cb)

## Test methodology

Manual

## Test environment(s)

- 11.0.100-preview.1.26078.121

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14317)