### PR TITLE
[release/10.0]: Using VS2022 GA images for CI and CodeQL pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,7 +126,7 @@ extends:
             binlogPath: msbuild.binlog
             pool:
               name: $(DncEngInternalBuildPool)
-              demands: ImageOverride -equals windows.vs2022preview.amd64
+              demands: ImageOverride -equals windows.vs2022.amd64
 
     - ${{ if eq(variables['EnableLoc'], 'true') }}:
       - stage: OneLocBuild

--- a/eng/pipelines/azure-pipelines-codeql.yml
+++ b/eng/pipelines/azure-pipelines-codeql.yml
@@ -45,7 +45,7 @@ jobs:
   displayName: CodeQL
   pool:
     name: $(DncEngInternalBuildPool)
-    demands: ImageOverride -equals windows.vs2022preview.amd64
+    demands: ImageOverride -equals windows.vs2022.amd64
   timeoutInMinutes: 90
 
   steps:


### PR DESCRIPTION
Using VS2022 image for CI and CodeQL build pipelines because VS2022preview images have been deprecated.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14323)