### PR TITLE
[release/10.0]: Updating build agent image to VS2022

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,7 +89,7 @@ extends:
       ${{ else }}:
         name: NetCore1ESPool-Internal
 # image is described here - https://helix.dot.net/#1ESHostedPoolImagesWestUS-rg-Internal
-      image: windows.vs2022preview.amd64
+      image: windows.vs2022.amd64
       os: windows
     customBuildTags:
     - ES365AIMigrationTooling
@@ -151,7 +151,7 @@ extends:
           publishUsingPipelines: true
           pool:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2022preview.amd64
+            demands: ImageOverride -equals windows.vs2022.amd64
 
     # Copied from the arcade repo and modified for winforms
     - template: /eng/common/templates-official/post-build/post-build.yml@self


### PR DESCRIPTION
Missed updating the image name at 2 places in earlier commit.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14330)