### PR TITLE
[release/11.0-preview2]: Fix for OOM exception while running Analyzer tests on x86 platform

### DIFF
--- a/src/Common/tests/TestUtilities/XUnit/ForceGCAttribute.cs
+++ b/src/Common/tests/TestUtilities/XUnit/ForceGCAttribute.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Xunit.v3;
+
+namespace Xunit;
+
+/// <summary>
+///  Apply this attribute to a test class or method to force a full GC collection
+///  after each test. This helps prevent <see cref="OutOfMemoryException"/> in x86
+///  test runs where memory-intensive operations (e.g. Roslyn compilations) accumulate.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+public sealed class ForceGCAttribute : BeforeAfterTestAttribute
+{
+    public override void After(MethodInfo methodUnderTest, IXunitTest test)
+    {
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+    }
+}

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/Analyzers/AvoidPassingTaskWithoutCancellationToken/AvoidPassingTaskWithoutCancellationTokenTest.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/Analyzers/AvoidPassingTaskWithoutCancellationToken/AvoidPassingTaskWithoutCancellationTokenTest.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Testing;
 
 namespace System.Windows.Forms.Analyzers.Tests;
 
+[ForceGC]
 public sealed class AvoidPassingTaskWithoutCancellationTokenTests
 {
     private const string TestCode = """

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/Analyzers/MissingPropertySerializationConfiguration/ControlPropertySerializationDiagnosticAnalyzerTest.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/Analyzers/MissingPropertySerializationConfiguration/ControlPropertySerializationDiagnosticAnalyzerTest.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Testing;
 
 namespace System.Windows.Forms.Analyzers.Tests;
 
+[ForceGC]
 public sealed class ControlPropertySerializationDiagnosticAnalyzerTest
 {
     private const string GlobalUsingCode = """

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/Analyzers/WFO1001/ImplementITypedDataObjectTests.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/Analyzers/WFO1001/ImplementITypedDataObjectTests.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Testing;
 
 namespace System.Windows.Forms.Analyzers.Tests;
 
+[ForceGC]
 public sealed class ImplementITypedDataObjectTests
 {
     private const string DiagnosticId = DiagnosticIDs.ImplementITypedDataObject;

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/Generators/ApplicationConfigurationGenerator/ApplicationConfigurationGeneratorTests.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/Generators/ApplicationConfigurationGenerator/ApplicationConfigurationGeneratorTests.cs
@@ -11,6 +11,7 @@ using static System.Windows.Forms.Analyzers.ApplicationConfig;
 
 namespace System.Windows.Forms.Analyzers.Tests;
 
+[ForceGC]
 public partial class ApplicationConfigurationGeneratorTests
 {
     private const string SourceCompilable = """

--- a/src/System.Windows.Forms.Analyzers.VisualBasic/tests/UnitTests/System.Windows.Forms.Analyzers.VisualBasic.Tests/Analyzers/AvoidPassingTaskWithoutCancellationTokenTests.vb
+++ b/src/System.Windows.Forms.Analyzers.VisualBasic/tests/UnitTests/System.Windows.Forms.Analyzers.VisualBasic.Tests/Analyzers/AvoidPassingTaskWithoutCancellationTokenTests.vb
@@ -10,6 +10,7 @@ Imports Microsoft.CodeAnalysis.Testing
 Imports Microsoft.CodeAnalysis.VisualBasic.Testing
 Imports Xunit
 
+<ForceGC()>
 Public Class AvoidPassingTaskWithoutCancellationTokenTests
 
     Private Const TestCode As String = "

--- a/src/System.Windows.Forms.Analyzers.VisualBasic/tests/UnitTests/System.Windows.Forms.Analyzers.VisualBasic.Tests/Analyzers/MissingPropertySerializationConfigurationAnalyzerTest.vb
+++ b/src/System.Windows.Forms.Analyzers.VisualBasic/tests/UnitTests/System.Windows.Forms.Analyzers.VisualBasic.Tests/Analyzers/MissingPropertySerializationConfigurationAnalyzerTest.vb
@@ -5,6 +5,7 @@ Imports Microsoft.CodeAnalysis.Testing
 Imports Microsoft.CodeAnalysis.VisualBasic.Testing
 Imports Xunit
 
+<ForceGC()>
 Public Class ControlPropertySerializationDiagnosticAnalyzerTest
 
     Private Const ProblematicCode As String =

--- a/src/System.Windows.Forms.Analyzers.VisualBasic/tests/UnitTests/System.Windows.Forms.Analyzers.VisualBasic.Tests/Analyzers/WFO1001/ImplementITypedDataObjectTests.vb
+++ b/src/System.Windows.Forms.Analyzers.VisualBasic/tests/UnitTests/System.Windows.Forms.Analyzers.VisualBasic.Tests/Analyzers/WFO1001/ImplementITypedDataObjectTests.vb
@@ -8,6 +8,7 @@ Imports Microsoft.CodeAnalysis.Testing
 Imports Microsoft.CodeAnalysis.VisualBasic.Testing
 Imports Xunit
 
+<ForceGC()>
 Public NotInheritable Class ImplementITypedDataObjectTests
 
     Private Const DiagnosticId As String = DiagnosticIDs.ImplementITypedDataObject


### PR DESCRIPTION
Cherry pick from PR:https://github.com/dotnet/winforms/pull/14328

**Issue**: Analyzer tests are running into OutOfMemory exceptions on x86 platform. This is because multiple Roslyn compilations are held into memory which causes memory usage to shoot up before GC gets a chance to collect the finalized objects. On x86 the memory space is 2 GB which runs into OOM.

This issue doesn't repro on x64 or when these tests are executed locally in isolation.

**Fix**: To run GC.Collect after every test execution
###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14328)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14332)