### PR TITLE
Fix issue 11939: [Dark Mode]HelpProvider text color is barely visible

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Help/Help.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Help/Help.cs
@@ -81,7 +81,7 @@ public static class Help
             cbStruct = sizeof(HH_POPUP),
             pt = location,
             rcMargins = new RECT(-1, -1, -1, -1),               // Ignore
-            clrForeground = new COLORREF(unchecked((uint)-1)),  // Ignore
+            clrForeground = SystemColors.WindowText,
             clrBackground = SystemColors.Window
         };
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11939 


## Proposed changes

- Modify the clrForeground property of the HH_POPUP struct instance to ensure that the font color of the pop-up help bubble matches the WinForms theme font color.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- HelpProvider text color is clearly visible.

## Regression? 

- Yes

## Risk

- Min

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<img width="320" height="246" alt="image" src="https://github.com/user-attachments/assets/c1df50c7-c51a-40cb-8fb5-e8adf6d22778" />
<img width="392" height="236" alt="image" src="https://github.com/user-attachments/assets/407741ca-f19b-447b-a5a3-d86713452fcc" />


### After

https://github.com/user-attachments/assets/36af242f-1d2d-49ed-84c5-69d241ee1df9

https://github.com/user-attachments/assets/4774ec87-9adb-4ea2-a0e1-2d7046d428f9

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.100-preview.1.26104.118


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14338)