### PR TITLE
Fix issue 11914: In DarkMode: Add a default color to the ProcessBar.

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ProgressBar/ProgressBar.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ProgressBar/ProgressBar.cs
@@ -81,6 +81,8 @@ public partial class ProgressBar : Control
 
         if (Application.IsDarkModeEnabled)
         {
+            BackColor = SystemColors.ControlDarkDark;
+            ForeColor = SystemColors.Highlight;
             // Disables Visual Styles for the ProgressBar.
             PInvoke.SetWindowTheme(HWND, " ", " ");
         }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ProgressBar/ProgressBar.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ProgressBar/ProgressBar.cs
@@ -81,8 +81,12 @@ public partial class ProgressBar : Control
 
         if (Application.IsDarkModeEnabled)
         {
-            BackColor = SystemColors.ControlDarkDark;
-            ForeColor = SystemColors.Highlight;
+            if (!ShouldSerializeBackColor())
+            {
+                BackColor = SystemColors.ControlDarkDark;
+                ForeColor = SystemColors.Highlight;
+            }
+
             // Disables Visual Styles for the ProgressBar.
             PInvoke.SetWindowTheme(HWND, " ", " ");
         }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ProgressBar/ProgressBar.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ProgressBar/ProgressBar.cs
@@ -84,6 +84,10 @@ public partial class ProgressBar : Control
             if (!ShouldSerializeBackColor())
             {
                 BackColor = SystemColors.ControlDarkDark;
+            }
+
+            if (!ShouldSerializeForeColor())
+            {
                 ForeColor = SystemColors.Highlight;
             }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11914


## Proposed changes

- Add a default ForeColor, BackColor to the ProcessBar.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The ProcessBar displays correctly in dark mode.

## Regression? 

- Yes

## Risk

- Min

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<img width="191" height="276" alt="image" src="https://github.com/user-attachments/assets/41d08731-afde-4581-97ec-57ca40041fe1" />


### After

<img width="797" height="197" alt="image" src="https://github.com/user-attachments/assets/9b452674-0518-44d7-8edf-3c6ac46e0460" />


## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.100-preview.1.26104.118


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14339)