### PR TITLE
Skipping Analyzer tests on x86 due to OOM exception.

### DIFF
--- a/eng/pipelines/build-PR.yml
+++ b/eng/pipelines/build-PR.yml
@@ -90,7 +90,7 @@ jobs:
         $(_OfficialBuildIdArgs)
         $(_InternalRuntimeDownloadArgs)
         /p:Coverage=$(_Coverage)
-        /p:TestRunnerAdditionalArguments='--filter-not-trait Category=IgnoreForCI --filter-not-trait Category=failing'
+        /p:TestRunnerAdditionalArguments='--filter-not-trait Category=IgnoreForCI --filter-not-trait Category=failing --ignore-exit-code 8'
         /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\Test-${{ parameters.targetArchitecture }}.binlog
         /m:1
       displayName: Run Unit Tests

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/Analyzers/AvoidPassingTaskWithoutCancellationToken/AvoidPassingTaskWithoutCancellationTokenTest.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/Analyzers/AvoidPassingTaskWithoutCancellationToken/AvoidPassingTaskWithoutCancellationTokenTest.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Testing;
 namespace System.Windows.Forms.Analyzers.Tests;
 
 [ForceGC]
+[SkipOnArchitecture(TestArchitectures.X86, "Analyzer tests hit OutOfMemoryException on x86 due to memory-mapped NuGet package extraction")]
 public sealed class AvoidPassingTaskWithoutCancellationTokenTests
 {
     private const string TestCode = """

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/Analyzers/MissingPropertySerializationConfiguration/ControlPropertySerializationDiagnosticAnalyzerTest.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/Analyzers/MissingPropertySerializationConfiguration/ControlPropertySerializationDiagnosticAnalyzerTest.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Testing;
 namespace System.Windows.Forms.Analyzers.Tests;
 
 [ForceGC]
+[SkipOnArchitecture(TestArchitectures.X86, "Analyzer tests hit OutOfMemoryException on x86 due to memory-mapped NuGet package extraction")]
 public sealed class ControlPropertySerializationDiagnosticAnalyzerTest
 {
     private const string GlobalUsingCode = """

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/Analyzers/WFO1001/ImplementITypedDataObjectTests.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/Analyzers/WFO1001/ImplementITypedDataObjectTests.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Testing;
 namespace System.Windows.Forms.Analyzers.Tests;
 
 [ForceGC]
+[SkipOnArchitecture(TestArchitectures.X86, "Analyzer tests hit OutOfMemoryException on x86 due to memory-mapped NuGet package extraction")]
 public sealed class ImplementITypedDataObjectTests
 {
     private const string DiagnosticId = DiagnosticIDs.ImplementITypedDataObject;

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/Generators/ApplicationConfigurationGenerator/ApplicationConfigurationGeneratorTests.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/Generators/ApplicationConfigurationGenerator/ApplicationConfigurationGeneratorTests.cs
@@ -12,6 +12,7 @@ using static System.Windows.Forms.Analyzers.ApplicationConfig;
 namespace System.Windows.Forms.Analyzers.Tests;
 
 [ForceGC]
+[SkipOnArchitecture(TestArchitectures.X86, "Analyzer tests hit OutOfMemoryException on x86 due to memory-mapped NuGet package extraction")]
 public partial class ApplicationConfigurationGeneratorTests
 {
     private const string SourceCompilable = """

--- a/src/System.Windows.Forms.Analyzers.VisualBasic/tests/UnitTests/System.Windows.Forms.Analyzers.VisualBasic.Tests/Analyzers/AvoidPassingTaskWithoutCancellationTokenTests.vb
+++ b/src/System.Windows.Forms.Analyzers.VisualBasic/tests/UnitTests/System.Windows.Forms.Analyzers.VisualBasic.Tests/Analyzers/AvoidPassingTaskWithoutCancellationTokenTests.vb
@@ -11,6 +11,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Testing
 Imports Xunit
 
 <ForceGC()>
+<SkipOnArchitecture(TestArchitectures.X86, "Analyzer tests hit OutOfMemoryException on x86 due to memory-mapped NuGet package extraction")>
 Public Class AvoidPassingTaskWithoutCancellationTokenTests
 
     Private Const TestCode As String = "

--- a/src/System.Windows.Forms.Analyzers.VisualBasic/tests/UnitTests/System.Windows.Forms.Analyzers.VisualBasic.Tests/Analyzers/MissingPropertySerializationConfigurationAnalyzerTest.vb
+++ b/src/System.Windows.Forms.Analyzers.VisualBasic/tests/UnitTests/System.Windows.Forms.Analyzers.VisualBasic.Tests/Analyzers/MissingPropertySerializationConfigurationAnalyzerTest.vb
@@ -6,6 +6,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Testing
 Imports Xunit
 
 <ForceGC()>
+<SkipOnArchitecture(TestArchitectures.X86, "Analyzer tests hit OutOfMemoryException on x86 due to memory-mapped NuGet package extraction")>
 Public Class ControlPropertySerializationDiagnosticAnalyzerTest
 
     Private Const ProblematicCode As String =

--- a/src/System.Windows.Forms.Analyzers.VisualBasic/tests/UnitTests/System.Windows.Forms.Analyzers.VisualBasic.Tests/Analyzers/WFO1001/ImplementITypedDataObjectTests.vb
+++ b/src/System.Windows.Forms.Analyzers.VisualBasic/tests/UnitTests/System.Windows.Forms.Analyzers.VisualBasic.Tests/Analyzers/WFO1001/ImplementITypedDataObjectTests.vb
@@ -9,6 +9,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Testing
 Imports Xunit
 
 <ForceGC()>
+<SkipOnArchitecture(TestArchitectures.X86, "Analyzer tests hit OutOfMemoryException on x86 due to memory-mapped NuGet package extraction")>
 Public NotInheritable Class ImplementITypedDataObjectTests
 
     Private Const DiagnosticId As String = DiagnosticIDs.ImplementITypedDataObject


### PR DESCRIPTION
**Issue**: New packages coming in the [codeflow PR](https://github.com/dotnet/winforms/pull/14334) are again causing analyzer tests to fail on x86 platform. The recently added ForceGC attribute is not helping with these new changes.

Fix:
1. Skipping analyzer tests on x86 platform 
2. Added '--ignore-exit-code 8' switch in PR builds to avoid build failure as xunit returns exit code 8 when the assembly has no tests to execute.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14348)