### PR TITLE
Remove the central TargetFramework property

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,6 @@
   <Import Project="$(RepositoryEngineeringDir)Test.props" Condition="'$(IsTestProject)' == 'true'"/>
 
   <PropertyGroup>
-    <TargetFramework>$(NetCurrent)</TargetFramework>
     <Product>Microsoft&#xAE; .NET</Product>
     <Copyright>$(CopyrightNetFoundation)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/Microsoft.Dotnet.Winforms.ProjectTemplates.csproj
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/Microsoft.Dotnet.Winforms.ProjectTemplates.csproj
@@ -1,6 +1,7 @@
 ﻿<Project InitialTargets="BuildPackage">
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UsingToolTemplateLocalizer>true</UsingToolTemplateLocalizer>

--- a/src/Accessibility/ver/Accessibility-version.csproj
+++ b/src/Accessibility/ver/Accessibility-version.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <!-- this project is intentionally empty, it's only built so that we can 
          use its resources when assembling the Accessibility dll -->
   </PropertyGroup>

--- a/src/BuildAssist/BuildAssist.msbuildproj
+++ b/src/BuildAssist/BuildAssist.msbuildproj
@@ -8,6 +8,7 @@
   </ItemGroup>
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <_AxHostsPath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', 'test', 'unit', '.NET Framework', 'AxHosts', 'AxHosts.csproj'))</_AxHostsPath>
     <_ProjectArgs>/p:BuildWithNetFrameworkHostedCompiler=false /p:Configuration=$(Configuration) /p:Platform=AnyCPU</_ProjectArgs>
   </PropertyGroup>

--- a/src/Common/tests/TestUtilities/System.Private.Windows.Core.TestUtilities.csproj
+++ b/src/Common/tests/TestUtilities/System.Private.Windows.Core.TestUtilities.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <AssemblyName>System.Private.Windows.Core.TestUtilities</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>System</RootNamespace>

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft.VisualBasic.Forms.vbproj
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft.VisualBasic.Forms.vbproj
@@ -6,6 +6,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <AssemblyName>Microsoft.VisualBasic.Forms</AssemblyName>
     <Deterministic>true</Deterministic>
     <OptionExplicit>On</OptionExplicit>

--- a/src/Microsoft.VisualBasic.Forms/tests/UnitTests/Microsoft.VisualBasic.Forms.Tests.vbproj
+++ b/src/Microsoft.VisualBasic.Forms/tests/UnitTests/Microsoft.VisualBasic.Forms.Tests.vbproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <SourceTargetFramework>$(TargetFramework)</SourceTargetFramework>
-    <TargetFramework>$(TargetFramework)-windows7.0</TargetFramework>
+    <SourceTargetFramework>$(NetCurrent)</SourceTargetFramework>
+    <TargetFramework>$(NetCurrent)-windows7.0</TargetFramework>
     <DisableTransitiveFrameworkReferences>true</DisableTransitiveFrameworkReferences>
     <RootNamespace></RootNamespace>
     <LangVersion>latest</LangVersion>

--- a/src/Microsoft.VisualBasic/src/Microsoft.VisualBasic.Facade.csproj
+++ b/src/Microsoft.VisualBasic/src/Microsoft.VisualBasic.Facade.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <AssemblyName>Microsoft.VisualBasic</AssemblyName>
     <!-- Set PackageId to something different than the assembly name as NuGet prunes package and project
          references for dependencies that are inbox in the framework. NuGet uses the PackageId information

--- a/src/Microsoft.VisualBasic/tests/IntegrationTests/Microsoft.VisualBasic.IntegrationTests/Microsoft.VisualBasic.IntegrationTests.csproj
+++ b/src/Microsoft.VisualBasic/tests/IntegrationTests/Microsoft.VisualBasic.IntegrationTests/Microsoft.VisualBasic.IntegrationTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 

--- a/src/Microsoft.VisualBasic/tests/IntegrationTests/VisualBasicRuntimeTest/VisualBasicRuntimeTest.csproj
+++ b/src/Microsoft.VisualBasic/tests/IntegrationTests/VisualBasicRuntimeTest/VisualBasicRuntimeTest.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>

--- a/src/Microsoft.VisualBasic/tests/UnitTests/Microsoft.VisualBasic.Tests.csproj
+++ b/src/Microsoft.VisualBasic/tests/UnitTests/Microsoft.VisualBasic.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(TargetFramework)-windows7.0</TargetFramework>
+    <TargetFramework>$(NetCurrent)-windows7.0</TargetFramework>
     <DisableTransitiveFrameworkReferences>true</DisableTransitiveFrameworkReferences>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/src/System.Design/src/System.Design.Facade.csproj
+++ b/src/System.Design/src/System.Design.Facade.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <AssemblyName>System.Design</AssemblyName>
   </PropertyGroup>
 

--- a/src/System.Drawing.Common/src/System.Drawing.Common.csproj
+++ b/src/System.Drawing.Common/src/System.Drawing.Common.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCurrent);$(NetPrevious);$(NetMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
-    <!-- Unset TargetFramework as this property gets set in Directory.Build.props. This is necessary to avoid over-building. -->
-    <TargetFramework />
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <WarningsNotAsErrors>CS0618</WarningsNotAsErrors>
     <EnableAOTAnalyzer>false</EnableAOTAnalyzer>

--- a/src/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
+++ b/src/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>annotations</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/src/System.Drawing.Design/src/System.Drawing.Design.Facade.csproj
+++ b/src/System.Drawing.Design/src/System.Drawing.Design.Facade.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <AssemblyName>System.Drawing.Design</AssemblyName>
   </PropertyGroup>
 

--- a/src/System.Drawing/src/System.Drawing.Facade.csproj
+++ b/src/System.Drawing/src/System.Drawing.Facade.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <AssemblyName>System.Drawing</AssemblyName>
     <NoWarn>$(NoWarn);SYSLIB0003</NoWarn>
   </PropertyGroup>

--- a/src/System.Private.Windows.Core/src/System.Private.Windows.Core.csproj
+++ b/src/System.Private.Windows.Core/src/System.Private.Windows.Core.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <AssemblyName>System.Private.Windows.Core</AssemblyName>
     <TargetFrameworks>$(NetCurrent);$(NetPrevious);$(NetMinimum)</TargetFrameworks>
-    <!-- Unset TargetFramework as this property gets set in Directory.Build.props. This is necessary to avoid over-building. -->
-    <TargetFramework />
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <!--

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/BinaryFormatTests.csproj
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/BinaryFormatTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(TargetFramework)-windows7.0</TargetFramework>
+    <TargetFramework>$(NetCurrent)-windows7.0</TargetFramework>
     <DisableTransitiveFrameworkReferences>true</DisableTransitiveFrameworkReferences>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System.Private.Windows.Core.Tests.csproj
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System.Private.Windows.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(TargetFramework)-windows7.0</TargetFramework>
+    <TargetFramework>$(NetCurrent)-windows7.0</TargetFramework>
     <DisableTransitiveFrameworkReferences>true</DisableTransitiveFrameworkReferences>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!--

--- a/src/System.Private.Windows.GdiPlus/System.Private.Windows.GdiPlus.csproj
+++ b/src/System.Private.Windows.GdiPlus/System.Private.Windows.GdiPlus.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <AssemblyName>System.Private.Windows.GdiPlus</AssemblyName>
     <TargetFrameworks>$(NetCurrent);$(NetPrevious);$(NetMinimum)</TargetFrameworks>
-    <!-- Unset TargetFramework as this property gets set in Directory.Build.props. This is necessary to avoid over-building. -->
-    <TargetFramework />
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <StrongNameKeyId>ECMA</StrongNameKeyId>

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System.Windows.Forms.Analyzers.CSharp.Tests.csproj
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System.Windows.Forms.Analyzers.CSharp.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <Nullable>enable</Nullable>
     <DefaultItemExcludesInProjectFolder>$(DefaultItemExcludesInProjectFolder);**/TestData/*.cs</DefaultItemExcludesInProjectFolder>
   </PropertyGroup>

--- a/src/System.Windows.Forms.Analyzers.VisualBasic/tests/UnitTests/System.Windows.Forms.Analyzers.VisualBasic.Tests/System.Windows.Forms.Analyzers.VisualBasic.Tests.vbproj
+++ b/src/System.Windows.Forms.Analyzers.VisualBasic/tests/UnitTests/System.Windows.Forms.Analyzers.VisualBasic.Tests/System.Windows.Forms.Analyzers.VisualBasic.Tests.vbproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>15.5</LangVersion>
     <RootNamespace>System.Windows.Forms.Analyzers.Tests</RootNamespace>

--- a/src/System.Windows.Forms.Analyzers/tests/UnitTests/System.Windows.Forms.Analyzers.Tests.csproj
+++ b/src/System.Windows.Forms.Analyzers/tests/UnitTests/System.Windows.Forms.Analyzers.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/System.Windows.Forms.Design.Editors/src/System.Windows.Forms.Design.Editors.Facade3x.csproj
+++ b/src/System.Windows.Forms.Design.Editors/src/System.Windows.Forms.Design.Editors.Facade3x.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <AssemblyName>System.Windows.Forms.Design.Editors</AssemblyName>
   </PropertyGroup>
 

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <AssemblyName>System.Windows.Forms.Design</AssemblyName>
     <CLSCompliant>true</CLSCompliant>
     <Deterministic>true</Deterministic>

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System.Windows.Forms.Design.Tests.csproj
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System.Windows.Forms.Design.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <SourceTargetFramework>$(TargetFramework)</SourceTargetFramework>
-    <TargetFramework>$(TargetFramework)-windows7.0</TargetFramework>
+    <SourceTargetFramework>$(NetCurrent)</SourceTargetFramework>
+    <TargetFramework>$(NetCurrent)-windows7.0</TargetFramework>
     <DisableTransitiveFrameworkReferences>true</DisableTransitiveFrameworkReferences>
     <AssemblyName>System.Windows.Forms.Design.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/src/System.Windows.Forms.Primitives/src/System.Windows.Forms.Primitives.csproj
+++ b/src/System.Windows.Forms.Primitives/src/System.Windows.Forms.Primitives.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <AssemblyName>System.Windows.Forms.Primitives</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLSCompliant>true</CLSCompliant>

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities.Tests/System.Windows.Forms.Primitives.TestUtilities.Tests.csproj
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities.Tests/System.Windows.Forms.Primitives.TestUtilities.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <AssemblyName>System.Windows.Forms.Primitives.TestUtilities.Tests</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);618</NoWarn>

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/System.Windows.Forms.Primitives.TestUtilities.csproj
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/System.Windows.Forms.Primitives.TestUtilities.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <AssemblyName>System.Windows.Forms.Primitives.TestUtilities</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>System</RootNamespace>

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System.Windows.Forms.Primitives.Tests.csproj
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System.Windows.Forms.Primitives.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(TargetFramework)-windows7.0</TargetFramework>
+    <TargetFramework>$(NetCurrent)-windows7.0</TargetFramework>
     <DisableTransitiveFrameworkReferences>true</DisableTransitiveFrameworkReferences>
     <AssemblyName>System.Windows.Forms.Primitives.Tests</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/System.Windows.Forms.PrivateSourceGenerators/tests/UnitTests/System.Windows.Forms.PrivateSourceGenerators.Tests.csproj
+++ b/src/System.Windows.Forms.PrivateSourceGenerators/tests/UnitTests/System.Windows.Forms.PrivateSourceGenerators.Tests.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
       <PrivateAssets>all</PrivateAssets>

--- a/src/System.Windows.Forms/System.Windows.Forms.csproj
+++ b/src/System.Windows.Forms/System.Windows.Forms.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <AssemblyName>System.Windows.Forms</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLSCompliant>true</CLSCompliant>

--- a/src/test/integration/DesignSurface/DemoConsole/DemoConsole.csproj
+++ b/src/test/integration/DesignSurface/DemoConsole/DemoConsole.csproj
@@ -23,8 +23,6 @@
     <ExcludeFromDotNetBuild>true</ExcludeFromDotNetBuild>
     <IsTestUtilityProject>true</IsTestUtilityProject>
     <TargetFrameworks>$(NetCurrent)-windows;net481</TargetFrameworks>
-    <!-- Unset TargetFramework as this property gets set in the repo's root. This is necessary to  avoid over-building. -->
-    <TargetFramework />
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net481'">

--- a/src/test/integration/DesignSurface/DesignSurfaceExt/DesignSurfaceExt.csproj
+++ b/src/test/integration/DesignSurface/DesignSurfaceExt/DesignSurfaceExt.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <AssemblyName>DesignSurfaceExt</AssemblyName>
     <RootNamespace>DesignSurfaceExt</RootNamespace>
 

--- a/src/test/integration/ScratchProject/ScratchProject.csproj
+++ b/src/test/integration/ScratchProject/ScratchProject.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <OutputType>WinExe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/test/integration/ScratchProjectWithInternals/ScratchProjectWithInternals.csproj
+++ b/src/test/integration/ScratchProjectWithInternals/ScratchProjectWithInternals.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <OutputType>WinExe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/test/integration/System.Windows.Forms.IntegrationTests.Common/System.Windows.Forms.IntegrationTests.Common.csproj
+++ b/src/test/integration/System.Windows.Forms.IntegrationTests.Common/System.Windows.Forms.IntegrationTests.Common.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
  
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>

--- a/src/test/integration/System.Windows.Forms.Maui.IntegrationTests/System.Windows.Forms.Maui.IntegrationTests.csproj
+++ b/src/test/integration/System.Windows.Forms.Maui.IntegrationTests/System.Windows.Forms.Maui.IntegrationTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/test/integration/TrimTest/TrimTest.csproj
+++ b/src/test/integration/TrimTest/TrimTest.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <OutputType>WinExe</OutputType>
     <Nullable>enable</Nullable>
     <OutputType>WinExe</OutputType>

--- a/src/test/integration/TrimTestBinaryDeserialization/TrimTestBinaryDeserialization.csproj
+++ b/src/test/integration/TrimTestBinaryDeserialization/TrimTestBinaryDeserialization.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <OutputType>WinExe</OutputType>
     <Nullable>enable</Nullable>
     <OutputType>WinExe</OutputType>

--- a/src/test/integration/UIIntegrationTests/System.Windows.Forms.UI.IntegrationTests.csproj
+++ b/src/test/integration/UIIntegrationTests/System.Windows.Forms.UI.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(TargetFramework)-windows7.0</TargetFramework>
+    <TargetFramework>$(NetCurrent)-windows7.0</TargetFramework>
     <DisableTransitiveFrameworkReferences>true</DisableTransitiveFrameworkReferences>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>

--- a/src/test/integration/WinformsControlsTest/WinformsControlsTest.csproj
+++ b/src/test/integration/WinformsControlsTest/WinformsControlsTest.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <AssemblyName>WinFormsControlsTest</AssemblyName>
     <RootNamespace>WinFormsControlsTest</RootNamespace>
     <ApplicationIcon />

--- a/src/test/unit/System.Windows.Forms/ComDisabled/ComDisabled.Tests.csproj
+++ b/src/test/unit/System.Windows.Forms/ComDisabled/ComDisabled.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <SourceTargetFramework>$(TargetFramework)</SourceTargetFramework>
-    <TargetFramework>$(TargetFramework)-windows7.0</TargetFramework>
+    <SourceTargetFramework>$(NetCurrent)</SourceTargetFramework>
+    <TargetFramework>$(NetCurrent)-windows7.0</TargetFramework>
     <DisableTransitiveFrameworkReferences>true</DisableTransitiveFrameworkReferences>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/src/test/unit/System.Windows.Forms/System.Windows.Forms.Tests.csproj
+++ b/src/test/unit/System.Windows.Forms/System.Windows.Forms.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <SourceTargetFramework>$(TargetFramework)</SourceTargetFramework>
-    <TargetFramework>$(TargetFramework)-windows7.0</TargetFramework>
+    <SourceTargetFramework>$(NetCurrent)</SourceTargetFramework>
+    <TargetFramework>$(NetCurrent)-windows7.0</TargetFramework>
     <DisableTransitiveFrameworkReferences>true</DisableTransitiveFrameworkReferences>
     <AssemblyName>System.Windows.Forms.Tests</AssemblyName>
     <RootNamespace />

--- a/src/test/unit/accessibility/TestPassApp/TestPassApp.csproj
+++ b/src/test/unit/accessibility/TestPassApp/TestPassApp.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <OutputType>WinExe</OutputType>
     <RootNamespace>TestPassApp</RootNamespace>
     <AssemblyName>TestPassApp</AssemblyName>

--- a/src/test/util/System.Windows.Forms/System.Windows.Forms.TestUtilities.csproj
+++ b/src/test/util/System.Windows.Forms/System.Windows.Forms.TestUtilities.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <AssemblyName>System.Windows.Forms.TestUtilities</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>System</RootNamespace>


### PR DESCRIPTION
It creates complications with multitargeting. Remove workarounds.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14357)