### PR TITLE
Add System.Diagnostics.DiagnosticSource version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -78,5 +78,8 @@
     <PackageVersion Include="Microsoft.ManifestTool.CrossPlatform" Version="$(MicrosoftManifestToolCrossPlatformVersion)" />
     <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="$(MicrosoftVisualStudioEngMicroBuildCoreVersion)" />
     <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild" Version="$(MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion)" />
+
+    <!-- .NET Framework polyfills -->
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourcePackageVersion)" />
   </ItemGroup>
 </Project>

--- a/Winforms.sln
+++ b/Winforms.sln
@@ -139,12 +139,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "eng", "eng", "{8B4B1E09-B3C
 		.gitignore = .gitignore
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
+		Directory.Packages.props = Directory.Packages.props
 		global.json = global.json
 		eng\Localize\LocProject.json = eng\Localize\LocProject.json
 		NuGet.Config = NuGet.Config
 		eng\packageContent.targets = eng\packageContent.targets
 		eng\Publishing.props = eng\Publishing.props
 		start-vs.cmd = start-vs.cmd
+		eng\Version.Details.props = eng\Version.Details.props
+		eng\Version.Details.xml = eng\Version.Details.xml
 		eng\Versions.props = eng\Versions.props
 	EndProjectSection
 EndProject

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -23,6 +23,7 @@ This file should be imported by eng/Versions.props
     <runtimewinx86MicrosoftNETCoreILAsmPackageVersion>11.0.0-preview.3.26153.117</runtimewinx86MicrosoftNETCoreILAsmPackageVersion>
     <SystemCodeDomPackageVersion>11.0.0-preview.3.26153.117</SystemCodeDomPackageVersion>
     <SystemConfigurationConfigurationManagerPackageVersion>11.0.0-preview.3.26153.117</SystemConfigurationConfigurationManagerPackageVersion>
+    <SystemDiagnosticsDiagnosticSourcePackageVersion>11.0.0-preview.3.26153.117</SystemDiagnosticsDiagnosticSourcePackageVersion>
     <SystemFormatsNrbfPackageVersion>11.0.0-preview.3.26153.117</SystemFormatsNrbfPackageVersion>
     <SystemIOHashingPackageVersion>11.0.0-preview.3.26153.117</SystemIOHashingPackageVersion>
     <SystemReflectionMetadataLoadContextPackageVersion>11.0.0-preview.3.26153.117</SystemReflectionMetadataLoadContextPackageVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -72,6 +72,10 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>15ac4103422d47f7c8f14fa98e813f315432d03b</Sha>
     </Dependency>
+    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="11.0.0-preview.3.26153.117">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>15ac4103422d47f7c8f14fa98e813f315432d03b</Sha>
+    </Dependency>
     <Dependency Name="System.Formats.Nrbf" Version="11.0.0-preview.3.26153.117">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>15ac4103422d47f7c8f14fa98e813f315432d03b</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
 
   <!-- Below have no corresponding entries in Versions.Details.XML because they are not updated via Maestro -->
   <PropertyGroup>
-    <SystemRuntimeCompilerServicesUnsafePackageVersion>6.1.0-preview.1.24511.1</SystemRuntimeCompilerServicesUnsafePackageVersion>
+    <SystemRuntimeCompilerServicesUnsafePackageVersion>6.1.2</SystemRuntimeCompilerServicesUnsafePackageVersion>
     <MicrosoftWindowsCsWin32PackageVersion>0.3.151</MicrosoftWindowsCsWin32PackageVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Useful for .NET Framework polyfill. Tweak System.Runtime.CompilerServices.Unsafe to a newer released version.

Add files to solution folder for convenience.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14358)