### PR TITLE
Fix for intermittent test failure on x86 platform 'BindingContext_UpdateBinding_UpdateListBindingWithoutDataMember_Success'

### DIFF
--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/BindingContextTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/BindingContextTests.cs
@@ -910,12 +910,15 @@ public class BindingContextTests
         Assert.Single(context1);
         Assert.Empty(context2);
 
+        // Obtain a reference to the manager1 before updating the binding to context2 to prevent context1 from GC collection.
+        // GC is more aggressive on x86 platform.
+        CurrencyManager manager1 = Assert.IsType<CurrencyManager>(context1[dataSource]);
+
         // Update.
         BindingContext.UpdateBinding(context2, binding);
         Assert.Single(context1);
         Assert.Single(context2);
 
-        CurrencyManager manager1 = Assert.IsType<CurrencyManager>(context1[dataSource]);
         Assert.Empty(manager1.Bindings);
         Assert.Same(dataSource, manager1.List);
         Assert.Equal(1, manager1.Current);


### PR DESCRIPTION
**Issue:** Intermittent `BindingContext_UpdateBinding_UpdateListBindingWithoutDataMember_Success` test failure on x86 platform

CI test failure against 11.0-preview2: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1321935&view=ms.vss-test-web.build-test-results-tab&runId=36910776&resultId=116411&paneView=debug

**Root cause:** `context1` was getting garbage collected after `UpdateBinding` call to `context2` causing the assertions to fail.

**Fix:** Obtain a strong reference to `manager1` before calling `UpdateBinding`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14359)