### PR TITLE
Fix issue 14049：The title of the collection editor for custom controls in .NET Core is incorrect.

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.CollectionEditorCollectionForm.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.CollectionEditorCollectionForm.cs
@@ -56,7 +56,7 @@ public partial class CollectionEditor
                 ScaleButtonImageLogicalToDevice(_upButton);
             }
 
-            Text = string.Format(SR.CollectionEditorCaption, CollectionItemType.Name);
+            Text = string.Format(SR.CollectionEditorCaption, GetCollectionItemTypeNameForCaption(CollectionItemType));
 
             HookEvents();
 
@@ -74,6 +74,20 @@ public partial class CollectionEditor
             }
 
             AdjustListBoxItemHeight();
+        }
+
+        private static string GetCollectionItemTypeNameForCaption(Type collectionItemType)
+        {
+            string itemTypeName = collectionItemType.Name;
+
+            if (collectionItemType is { IsGenericType: true, GenericTypeArguments: [Type innerType] }
+                && typeof(Control).IsAssignableFrom(innerType)
+                && collectionItemType.GetGenericTypeDefinition().Name.StartsWith("ControlProxy", StringComparison.Ordinal))
+            {
+                itemTypeName = innerType.Name;
+            }
+
+            return itemTypeName;
         }
 
         private bool IsImmutable

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/CollectionEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/CollectionEditorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -102,6 +102,16 @@ public class CollectionEditorTests
         Assert.NotSame(form, editor.CreateCollectionForm());
     }
 
+    [Fact]
+    public void CollectionEditor_CreateCollectionForm_Caption_UnwrapsControlProxy()
+    {
+        SubCollectionEditor editor = new(typeof(List<ControlProxy<TestChildControl>>));
+        using Form form = editor.CreateCollectionForm();
+
+        Assert.Contains(nameof(TestChildControl), form.Text);
+        Assert.DoesNotContain("ControlProxy`1", form.Text);
+    }
+
     [Theory]
     [InlineData(typeof(object), typeof(object))]
     [InlineData(typeof(int[]), typeof(object))]
@@ -118,6 +128,14 @@ public class CollectionEditorTests
         Type itemType = editor.CreateCollectionItemType();
         Assert.Equal(expected, itemType);
         Assert.Same(itemType, editor.CreateCollectionItemType());
+    }
+
+    private sealed class ControlProxy<TControl>
+    {
+    }
+
+    private sealed class TestChildControl : Control
+    {
     }
 
     public static IEnumerable<object[]> InvalidDesignerHost_TestData()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14049 


## Proposed changes

- Add a helper (GetCollectionItemTypeNameForCaption) that detects a generic ControlProxy<T>-like wrapper and unwraps the inner T when T derives from System.Windows.Forms.Control.
- Add a test case to verify the created collection editor form caption contains the underlying control type name and does not contain ControlProxy\1`.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The title of the collection editor for custom controls in .NET Core show correctly.

## Regression? 

- Yes 

## Risk

- Min

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<img width="1514" height="721" alt="image" src="https://github.com/user-attachments/assets/81ba19df-7568-47ed-9d70-9563f1eb46dc" />

### After

<img width="939" height="615" alt="image" src="https://github.com/user-attachments/assets/07e2297c-e628-4e5e-918c-8fbedae35982" />


## Test methodology <!-- How did you ensure quality? -->

- Manually 

## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.0-preview.2.26122.107


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14375)