### PR TITLE
Fix issue 11954: [Dark Mode] ToolTip is not in dark mode after enabled SystemColorMode.Dark

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/ToolTip/ToolTip.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/ToolTip/ToolTip.cs
@@ -718,6 +718,10 @@ public partial class ToolTip : Component, IExtenderProvider, IHandle<HWND>
             {
                 PInvoke.SetWindowTheme(HWND, string.Empty, string.Empty);
             }
+            else if (Application.IsDarkModeEnabled)
+            {
+                PInvoke.SetWindowTheme(HWND, $"{Control.DarkModeIdentifier}_{Control.ExplorerThemeIdentifier}", null);
+            }
         }
 
         // If in OwnerDraw mode, we don't want the default border.
@@ -730,12 +734,6 @@ public partial class ToolTip : Component, IExtenderProvider, IHandle<HWND>
 
         // Setting the max width has the added benefit of enabling multiline tool tips.
         PInvokeCore.SendMessage(this, PInvoke.TTM_SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
-
-        Form? activeForm = Form.ActiveForm;
-        if (Application.IsDarkModeEnabled && !SystemInformation.HighContrast && activeForm is not null && activeForm.DarkModeRequestState is true)
-        {
-            PInvoke.SetWindowTheme(HWND, $"{Control.DarkModeIdentifier}_{Control.ExplorerThemeIdentifier}", null);
-        }
 
         if (_auto)
         {

--- a/src/System.Windows.Forms/System/Windows/Forms/ToolTip/ToolTip.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/ToolTip/ToolTip.cs
@@ -731,6 +731,11 @@ public partial class ToolTip : Component, IExtenderProvider, IHandle<HWND>
         // Setting the max width has the added benefit of enabling multiline tool tips.
         PInvokeCore.SendMessage(this, PInvoke.TTM_SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
 
+        if (Application.IsDarkModeEnabled)
+        {
+            PInvoke.SetWindowTheme(HWND, $"{Control.DarkModeIdentifier}_{Control.ExplorerThemeIdentifier}", null);
+        }
+
         if (_auto)
         {
             // AutomaticDelay property should overwrite other delay timer values, _auto field indicates that

--- a/src/System.Windows.Forms/System/Windows/Forms/ToolTip/ToolTip.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/ToolTip/ToolTip.cs
@@ -731,7 +731,8 @@ public partial class ToolTip : Component, IExtenderProvider, IHandle<HWND>
         // Setting the max width has the added benefit of enabling multiline tool tips.
         PInvokeCore.SendMessage(this, PInvoke.TTM_SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
 
-        if (Application.IsDarkModeEnabled)
+        Form? activeForm = Form.ActiveForm;
+        if (Application.IsDarkModeEnabled && !SystemInformation.HighContrast && activeForm is not null && activeForm.DarkModeRequestState is true)
         {
             PInvoke.SetWindowTheme(HWND, $"{Control.DarkModeIdentifier}_{Control.ExplorerThemeIdentifier}", null);
         }


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11954


## Proposed changes

- Add dark mode support to Tooltip

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

-  ToolTip is in dark mode after enabled SystemColorMode.Dark

## Regression? 

- Yes 

## Risk

- Min 

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<img width="374" height="255" alt="image" src="https://github.com/user-attachments/assets/4a91cacf-50a7-48dc-ba56-1900ba4aa9ef" />

### After

<img width="779" height="479" alt="image" src="https://github.com/user-attachments/assets/872b99f7-31e1-4551-88f9-76473252152d" />

## Test methodology <!-- How did you ensure quality? -->

- Manual
 

## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.0-alpha.1.25619.109


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14381)