### PR TITLE
Fixes issue 14400: Pasting controls via CommandSet.OnMenuPaste stopped working when hosting the WinForms designer

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
@@ -1916,6 +1916,7 @@ internal partial class CommandSet : IDisposable
                         if (tree is IOleDragClient oleDragClient)
                         {
                             designer = oleDragClient;
+                            dragClient = true;
                             break;
                         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14400


## Root cause

The logic of `dragClient=true` was accidentally deleted in Commit  commit https://github.com/dotnet/winforms/commit/5978f22a431f4f51cc034b544e883bdb90ec3c19, 
<img width="1811" height="234" alt="image" src="https://github.com/user-attachments/assets/214a8a88-c029-46fd-86b9-fef3ecf4fd7b" />

This resulted in the local flag `dragClient` remaining `false` within the `OnMenuPaste` method—even when an `IOleDragClient` designer had been successfully located. As a result, the entire paste path guarded by `if (dragClient)` was never executed

## Proposed changes

-  In `CommandSet.OnMenuPaste`, when an `IOleDragClient` designer is found, `dragClient` is simultaneously set to `true`, thereby restoring the behavior of adding controls via the Paste command within a managed designer.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Hosting applications that embed the WinForms designer (for example via DesignSurface and IMenuCommandService.GlobalInvoke(StandardCommands.Paste)) cannot paste controls after upgrading from .NET 8 to .NET 10, breaking existing design-time workflows until this fix is applied.

## Regression? 

- Yes 

## Risk

- Low

<!-- end TELL-MODE -->

   
<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14403)