### PR TITLE
Fix issue 14198: [Dark Mode] Improve visual contrast of the Group Headers in ListView control in dark

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
@@ -7607,12 +7607,9 @@ public partial class ListView : Control
                     // Suppress native hover processing in dark mode group overlay mode.
                     // Native hover invalidates group headers while mouse moves over grouped content,
                     // causing repaint jitter.
-                    bool allowNativeHover = HoverSelection || HotTracking;
-                    if (allowNativeHover)
-                    {
-                        LVHITTESTINFO lvhi = SetupHitTestInfo();
-                        allowNativeHover = (int)PInvokeCore.SendMessage(this, PInvoke.LVM_HITTEST, (WPARAM)0, ref lvhi) >= 0;
-                    }
+                    LVHITTESTINFO lvhi = SetupHitTestInfo();
+                    bool isMouseOverItem = (int)PInvokeCore.SendMessage(this, PInvoke.LVM_HITTEST, (WPARAM)0, ref lvhi) >= 0;
+                    bool allowNativeHover = isMouseOverItem || HoverSelection || HotTracking;
 
                     if (!allowNativeHover)
                     {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
@@ -96,6 +96,184 @@ public partial class ListView : Control
     private const int LVLABELEDITTIMER = 0x2A;
     private const int LVTOOLTIPTRACKING = 0x30;
     private const int MAXTILECOLUMNS = 20;
+    private const uint LVM_SETGROUPMETRICS = PInvoke.LVM_FIRST + 155;
+    private const uint LVGMF_TEXTCOLOR = 0x00000004;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct LVGROUPMETRICS
+    {
+        public uint cbSize;
+        public uint mask;
+        public uint Left;
+        public uint Top;
+        public uint Right;
+        public uint Bottom;
+        public COLORREF crLeft;
+        public COLORREF crTop;
+        public COLORREF crRight;
+        public COLORREF crBottom;
+        public COLORREF crHeader;
+        public COLORREF crFooter;
+    }
+
+    private unsafe bool TryGetGroupRect(int groupId, uint rectType, out Rectangle rect)
+    {
+        RECT nativeRect = default;
+        nativeRect.top = (int)rectType;
+
+        if (PInvokeCore.SendMessage(this, PInvoke.LVM_GETGROUPRECT, (WPARAM)groupId, ref nativeRect) == 0)
+        {
+            rect = Rectangle.Empty;
+            return false;
+        }
+
+        rect = (Rectangle)nativeRect;
+        return true;
+    }
+
+    private void DrawDarkModeGroupSubtitleAndFooterOverlay()
+    {
+        if (!Application.IsDarkModeEnabled || !GroupsEnabled || OwnerDraw || !IsHandleCreated)
+        {
+            return;
+        }
+
+        using Graphics g = CreateGraphicsInternal();
+        Color textColor = ForeColor;
+        Color headerColor = Color.FromArgb(120, 180, 255);
+        Color chevronColor = Color.FromArgb(80, 170, 255);
+        using Font headerFont = new(Font, FontStyle.Bold);
+
+        for (int i = 0; i < Groups.Count; i++)
+        {
+            ListViewGroup group = Groups[i];
+            bool collapsed = group.GetNativeCollapsedState() == ListViewGroupCollapsedState.Collapsed;
+
+            if (!TryGetGroupRect(group.ID, PInvoke.LVGGR_HEADER, out Rectangle headerRect)
+                || !TryGetGroupRect(group.ID, PInvoke.LVGGR_GROUP, out Rectangle groupRect))
+            {
+                continue;
+            }
+
+            Rectangle headerRectText = new(
+                headerRect.Left + 8,
+                headerRect.Top,
+                Math.Max(0, headerRect.Width - 32),
+                headerFont.Height + 6);
+
+            if (!string.IsNullOrEmpty(group.Header))
+            {
+
+                using (Brush backBrush = new SolidBrush(BackColor))
+                {
+                    g.FillRectangle(backBrush, headerRectText);
+                }
+
+                TextRenderer.DrawText(g, group.Header, headerFont, headerRectText, headerColor, TextFormatFlags.Left | TextFormatFlags.NoPrefix | TextFormatFlags.EndEllipsis);
+            }
+
+            DrawDarkModeGroupChevron(g, headerRect, headerRectText, group.Header, headerFont, collapsed, headerColor, chevronColor, BackColor);
+
+            if (!string.IsNullOrEmpty(group.Subtitle))
+            {
+                Rectangle subtitleRect = new(
+                    headerRect.Left + 8,
+                    headerRect.Top + Font.Height + 2,
+                    Math.Max(0, groupRect.Width - 32),
+                    Font.Height + 6);
+
+                TextRenderer.DrawText(g, group.Subtitle, Font, subtitleRect, textColor, TextFormatFlags.Left | TextFormatFlags.NoPrefix | TextFormatFlags.EndEllipsis);
+            }
+
+            if (!string.IsNullOrEmpty(group.Footer))
+            {
+                int footerY;
+
+                if (!collapsed && group.Items.Count > 0)
+                {
+                    Rectangle lastItemBounds = group.Items[^1].Bounds;
+                    footerY = lastItemBounds.Bottom + 2;
+                }
+                else
+                {
+                    int subtitleOffset = string.IsNullOrEmpty(group.Subtitle) ? 1 : 2;
+                    footerY = headerRect.Top + (Font.Height * subtitleOffset) + 4;
+                }
+
+                Rectangle footerRect = new(
+                    headerRect.Left + 8,
+                    footerY,
+                    Math.Max(0, groupRect.Width - 32),
+                    Font.Height + 6);
+
+                TextRenderer.DrawText(g, group.Footer, Font, footerRect, textColor, TextFormatFlags.Left | TextFormatFlags.NoPrefix | TextFormatFlags.EndEllipsis);
+            }
+        }
+    }
+
+    private static void DrawDarkModeGroupChevron(
+        Graphics g,
+        Rectangle headerRect,
+        Rectangle headerTextRect,
+        string headerText,
+        Font headerFont,
+        bool collapsed,
+        Color lineColor,
+        Color chevronColor,
+        Color backgroundColor)
+    {
+        int centerX = headerRect.Right - 9;
+        int centerY = headerTextRect.Top + (headerTextRect.Height / 2) + 1;
+
+        Rectangle nativeChevronRect = new(
+            headerRect.Right - 24,
+            headerTextRect.Top - 3,
+            24,
+            headerTextRect.Height + 8);
+        using (Brush backgroundBrush = new SolidBrush(backgroundColor))
+        {
+            g.FillRectangle(backgroundBrush, nativeChevronRect);
+        }
+
+        Point[] points = collapsed
+            ? [new Point(centerX - 3, centerY - 5), new Point(centerX + 2, centerY), new Point(centerX - 3, centerY + 5)]
+            : [new Point(centerX - 5, centerY - 2), new Point(centerX, centerY + 3), new Point(centerX + 5, centerY - 2)];
+
+        using Pen chevronPen = new(chevronColor, 2.6f)
+        {
+            StartCap = Drawing.Drawing2D.LineCap.Round,
+            EndCap = Drawing.Drawing2D.LineCap.Round,
+            LineJoin = Drawing.Drawing2D.LineJoin.Round
+        };
+
+        g.DrawLines(chevronPen, points);
+
+        int lineY = centerY;
+        int lineStartX = headerRect.Left + 8;
+        if (!string.IsNullOrEmpty(headerText))
+        {
+            int measuredHeaderWidth = TextRenderer.MeasureText(
+                g,
+                headerText,
+                headerFont,
+                Size.Empty,
+                TextFormatFlags.SingleLine | TextFormatFlags.NoPrefix | TextFormatFlags.NoPadding).Width;
+
+            lineStartX += measuredHeaderWidth + 8;
+        }
+
+        int lineEndX = centerX - 10;
+        if (lineEndX > lineStartX)
+        {
+            using Pen linePen = new(lineColor, 1f)
+            {
+                StartCap = Drawing.Drawing2D.LineCap.Round,
+                EndCap = Drawing.Drawing2D.LineCap.Round
+            };
+
+            g.DrawLine(linePen, lineStartX, lineY, lineEndX, lineY);
+        }
+    }
 
     // PERF: take all the bools and put them into a state variable
     private Collections.Specialized.BitVector32 _listViewState; // see LISTVIEWSTATE_ constants above
@@ -2600,14 +2778,21 @@ public partial class ListView : Control
                         return;
                     }
 
-                    // We want custom draw for this paint cycle
-                    m.ResultInternal = (LRESULT)(nint)(PInvoke.CDRF_NOTIFYSUBITEMDRAW | PInvoke.CDRF_NEWFONT);
+                    // We want custom draw for this paint cycle.
+                    // CDRF_NOTIFYITEMDRAW is required for group items (LVCDI_GROUP) so that
+                    // CDDS_ITEMPREPAINT notifications are raised for group header/subtitle/footer.
+                    m.ResultInternal = (LRESULT)(nint)(PInvoke.CDRF_NOTIFYITEMDRAW | PInvoke.CDRF_NOTIFYSUBITEMDRAW | PInvoke.CDRF_NEWFONT);
 
                     // refresh the cache of the current color & font settings for this paint cycle
                     _odCacheBackColor = BackColor;
                     _odCacheForeColor = ForeColor;
                     _odCacheFont = Font;
                     _odCacheFontHandle = FontHandle;
+
+                    if (Application.IsDarkModeEnabled && !nmcd->nmcd.hdc.IsNull)
+                    {
+                        PInvokeCore.SetTextColor(nmcd->nmcd.hdc, (COLORREF)ColorTranslator.ToWin32(ForeColor));
+                    }
 
                     // If preparing to paint a group item, make sure its bolded.
                     if (nmcd->dwItemType == NMLVCUSTOMDRAW_ITEM_TYPE.LVCDI_GROUP)
@@ -2618,7 +2803,7 @@ public partial class ListView : Control
                         _odCacheFontHandleWrapper = new FontHandleWrapper(_odCacheFont);
                         _odCacheFontHandle = _odCacheFontHandleWrapper.Handle;
                         PInvokeCore.SelectObject(nmcd->nmcd.hdc, _odCacheFontHandleWrapper.Handle);
-                        m.ResultInternal = (LRESULT)(nint)PInvoke.CDRF_NEWFONT;
+                        m.ResultInternal = (LRESULT)(nint)(PInvoke.CDRF_NOTIFYITEMDRAW | PInvoke.CDRF_NOTIFYSUBITEMDRAW | PInvoke.CDRF_NEWFONT);
                     }
 
                     return;
@@ -2629,6 +2814,25 @@ public partial class ListView : Control
                 // HOWEVER... we only want to do this for report styles...
 
                 case NMCUSTOMDRAW_DRAW_STAGE.CDDS_ITEMPREPAINT:
+
+                    if (Application.IsDarkModeEnabled
+                        && !OwnerDraw
+                        && nmcd->dwItemType == NMLVCUSTOMDRAW_ITEM_TYPE.LVCDI_GROUP)
+                    {
+                        COLORREF textColor = (COLORREF)ColorTranslator.ToWin32(BackColor);
+                        COLORREF textBackColor = (COLORREF)ColorTranslator.ToWin32(BackColor);
+                        nmcd->clrText = textColor;
+                        nmcd->clrTextBk = textBackColor;
+
+                        if (!nmcd->nmcd.hdc.IsNull)
+                        {
+                            PInvokeCore.SetTextColor(nmcd->nmcd.hdc, textColor);
+                            PInvokeCore.SetBkColor(nmcd->nmcd.hdc, textBackColor);
+                        }
+
+                        m.ResultInternal = (LRESULT)(nint)PInvoke.CDRF_NEWFONT;
+                        return;
+                    }
 
                     int itemIndex = (int)nmcd->nmcd.dwItemSpec;
                     // The following call silently returns Rectangle.Empty if no corresponding
@@ -4688,7 +4892,7 @@ public partial class ListView : Control
             // Apply dark mode theme to the ListView
             _ = PInvoke.SetWindowTheme(
                 HWND,
-                $"{DarkModeIdentifier}_{ExplorerThemeIdentifier}",
+                $"{DarkModeIdentifier}_{ItemsViewThemeIdentifier}",
                 null);
 
             // Get the ListView's ColumnHeader handle:
@@ -4703,7 +4907,29 @@ public partial class ListView : Control
                 columnHeaderHandle,
                 $"{DarkModeIdentifier}_{ItemsViewThemeIdentifier}",
                 null);
+
+            UpdateDarkModeGroupTextColors();
         }
+    }
+
+    private unsafe void UpdateDarkModeGroupTextColors()
+    {
+        if (!IsHandleCreated || !GroupsEnabled)
+        {
+            return;
+        }
+
+        COLORREF textColor = (COLORREF)ColorTranslator.ToWin32(ForeColor);
+        COLORREF headerColor = (COLORREF)ColorTranslator.ToWin32(BackColor);
+        LVGROUPMETRICS groupMetrics = new()
+        {
+            cbSize = (uint)sizeof(LVGROUPMETRICS),
+            mask = LVGMF_TEXTCOLOR,
+            crHeader = headerColor,
+            crFooter = textColor
+        };
+
+        PInvokeCore.SendMessage(this, LVM_SETGROUPMETRICS, (WPARAM)0, ref groupMetrics);
     }
 
     protected override void OnHandleDestroyed(EventArgs e)
@@ -6018,8 +6244,11 @@ public partial class ListView : Control
             }
             else if (nmlvcd->nmcd.dwDrawStage == NMCUSTOMDRAW_DRAW_STAGE.CDDS_ITEMPREPAINT)
             {
-                // Setting the current ForeColor to the text color.
-                PInvokeCore.SetTextColor(nmlvcd->nmcd.hdc, ForeColor);
+                Color textColor = nmlvcd->dwItemType == NMLVCUSTOMDRAW_ITEM_TYPE.LVCDI_GROUP
+                    ? BackColor
+                    : ForeColor;
+
+                PInvokeCore.SetTextColor(nmlvcd->nmcd.hdc, textColor);
 
                 // and the rest remains the same.
                 m.ResultInternal = (LRESULT)(nint)PInvoke.CDRF_DODEFAULT;
@@ -7081,6 +7310,7 @@ public partial class ListView : Control
 
                 Capture = false;
                 base.WndProc(ref m);
+
                 break;
             case PInvokeCore.WM_MOUSEHOVER:
                 if (HoverSelection)
@@ -7126,10 +7356,13 @@ public partial class ListView : Control
                 // ItemHovered events should be raised.
                 _prevHoveredItem = null;
                 base.WndProc(ref m);
+
                 break;
 
             case PInvokeCore.WM_PAINT:
                 base.WndProc(ref m);
+
+                DrawDarkModeGroupSubtitleAndFooterOverlay();
 
                 // win32 ListView
                 BeginInvoke(new MethodInvoker(CleanPreviousBackgroundImageFiles));

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
@@ -163,6 +163,26 @@ public partial class ListView : Control
             return rect;
         }
 
+        static Color BlendColor(Color background, Color overlay)
+        {
+            int alpha = overlay.A;
+            if (alpha <= 0)
+            {
+                return background;
+            }
+
+            if (alpha >= 255)
+            {
+                return Color.FromArgb(255, overlay.R, overlay.G, overlay.B);
+            }
+
+            int invAlpha = 255 - alpha;
+            int r = ((background.R * invAlpha) + (overlay.R * alpha)) / 255;
+            int g = ((background.G * invAlpha) + (overlay.G * alpha)) / 255;
+            int b = ((background.B * invAlpha) + (overlay.B * alpha)) / 255;
+            return Color.FromArgb(255, r, g, b);
+        }
+
         for (int i = 0; i < Groups.Count; i++)
         {
             ListViewGroup group = Groups[i];
@@ -189,6 +209,18 @@ public partial class ListView : Control
             Color groupBackgroundColor = _darkModeGroupBackgroundColors.TryGetValue(group.ID, out Color cachedColor)
                 ? cachedColor
                 : BackColor;
+            NMCUSTOMDRAW_DRAW_STATE_FLAGS groupDrawState = _darkModeGroupStateFlags.TryGetValue(group.ID, out NMCUSTOMDRAW_DRAW_STATE_FLAGS cachedState)
+                ? cachedState
+                : 0;
+            bool isHovered = _darkModeHoveredGroupId == group.ID;
+            bool isSelected = _darkModeSelectedGroupId == group.ID
+                || (groupDrawState & (NMCUSTOMDRAW_DRAW_STATE_FLAGS.CDIS_SELECTED | NMCUSTOMDRAW_DRAW_STATE_FLAGS.CDIS_FOCUS)) != 0;
+            Color groupInteractionOverlayColor = isSelected
+                ? Color.FromArgb(64, 90, 150, 255)
+                : (isHovered ? Color.FromArgb(28, 255, 255, 255) : Color.Empty);
+            Color groupContentBackgroundColor = groupInteractionOverlayColor.IsEmpty
+                ? groupBackgroundColor
+                : BlendColor(groupBackgroundColor, groupInteractionOverlayColor);
             int firstItemTop = (!collapsed && group.Items.Count > 0) ? group.Items[0].Bounds.Top : -1;
             int horizontalPadding = LogicalToDeviceUnits(8);
             int totalHorizontalPadding = LogicalToDeviceUnits(32);
@@ -205,17 +237,47 @@ public partial class ListView : Control
                 headerTextWidth,
                 headerFont.Height + headerVerticalPadding);
 
-            Rectangle headerCoverRect = TrimOverlayRect(headerRect, firstItemTop);
-            if (!headerCoverRect.IsEmpty)
+            int interactionBottom = headerRect.Bottom;
+            if (!string.IsNullOrEmpty(group.Subtitle))
             {
-                using Brush groupBackBrush = new SolidBrush(groupBackgroundColor);
-                g.FillRectangle(groupBackBrush, headerCoverRect);
+                interactionBottom = headerRect.Top + Font.Height + verticalSpacing + Font.Height + headerVerticalPadding;
+            }
+
+            if (!string.IsNullOrEmpty(group.Footer) && (collapsed || group.Items.Count == 0))
+            {
+                int subtitleOffset = string.IsNullOrEmpty(group.Subtitle) ? 1 : 2;
+                int collapsedFooterY = headerRect.Top + (Font.Height * subtitleOffset) + footerCollapsedAdditionalOffset;
+                interactionBottom = Math.Min(interactionBottom, Math.Max(headerRect.Top, collapsedFooterY - LogicalToDeviceUnits(1)));
+            }
+
+            Rectangle interactionRect = Rectangle.Intersect(
+                groupRect,
+                new Rectangle(
+                    groupRect.Left,
+                    headerRect.Top,
+                    groupRect.Width,
+                    Math.Max(0, interactionBottom - headerRect.Top)));
+
+            Rectangle interactionCoverRect = TrimOverlayRect(interactionRect, firstItemTop);
+            if (!interactionCoverRect.IsEmpty)
+            {
+                using Brush groupBackBrush = new SolidBrush(groupContentBackgroundColor);
+                g.FillRectangle(groupBackBrush, interactionCoverRect);
+
+                Rectangle interactionSeamRect = TrimOverlayRect(
+                    new Rectangle(groupRect.Left, interactionCoverRect.Bottom - 1, groupRect.Width, 2),
+                    firstItemTop);
+
+                if (!interactionSeamRect.IsEmpty)
+                {
+                    g.FillRectangle(groupBackBrush, interactionSeamRect);
+                }
             }
 
             TextFormatFlags baseTextFlags = TextFormatFlags.NoPrefix | TextFormatFlags.EndEllipsis;
             TextFormatFlags headerTextFlags = baseTextFlags | (isRtl ? (TextFormatFlags.RightToLeft | TextFormatFlags.Right) : TextFormatFlags.Left);
 
-            DrawDarkModeGroupChevron(g, headerRect, headerRectText, group.Header, headerFont, collapsed, headerColor, chevronColor, groupBackgroundColor);
+            DrawDarkModeGroupChevron(g, headerRect, headerRectText, group.Header, headerFont, collapsed, headerColor, chevronColor, groupContentBackgroundColor);
 
             if (!string.IsNullOrEmpty(group.Header))
             {
@@ -238,9 +300,9 @@ public partial class ListView : Control
                     headerTextBackgroundWidth,
                     headerRectText.Height);
 
-                using Brush headerTextBackgroundBrush = new SolidBrush(groupBackgroundColor);
+                using Brush headerTextBackgroundBrush = new SolidBrush(groupContentBackgroundColor);
                 g.FillRectangle(headerTextBackgroundBrush, headerTextBackgroundRect);
-                TextRenderer.DrawText(g, group.Header, headerFont, headerRectText, headerColor, groupBackgroundColor, headerTextFlags);
+                TextRenderer.DrawText(g, group.Header, headerFont, headerRectText, headerColor, groupContentBackgroundColor, headerTextFlags);
             }
 
             TextFormatFlags bodyTextFlags = baseTextFlags | (isRtl ? (TextFormatFlags.RightToLeft | TextFormatFlags.Right) : TextFormatFlags.Left);
@@ -259,7 +321,7 @@ public partial class ListView : Control
                 Rectangle subtitleCoverRect = TrimOverlayRect(Rectangle.Inflate(subtitleRect, 2, 0), firstItemTop);
                 if (!subtitleCoverRect.IsEmpty)
                 {
-                    using Brush subtitleBackBrush = new SolidBrush(groupBackgroundColor);
+                    using Brush subtitleBackBrush = new SolidBrush(groupContentBackgroundColor);
                     g.FillRectangle(subtitleBackBrush, subtitleCoverRect);
                 }
 
@@ -291,7 +353,9 @@ public partial class ListView : Control
                     footerWidth,
                     Font.Height + headerVerticalPadding);
 
-                Rectangle footerCoverRect = TrimOverlayRect(Rectangle.Inflate(footerRect, 2, 0), firstItemTop);
+                Rectangle footerCoverRect = TrimOverlayRect(
+                    new Rectangle(groupRect.Left, footerRect.Top, groupRect.Width, footerRect.Height),
+                    firstItemTop);
                 if (!footerCoverRect.IsEmpty)
                 {
                     using Brush footerBackBrush = new SolidBrush(groupBackgroundColor);
@@ -407,6 +471,9 @@ public partial class ListView : Control
     private ImageList? _imageListState;
     private ImageList? _imageListGroup;
     private readonly Dictionary<int, Color> _darkModeGroupBackgroundColors = [];
+    private readonly Dictionary<int, NMCUSTOMDRAW_DRAW_STATE_FLAGS> _darkModeGroupStateFlags = [];
+    private int _darkModeHoveredGroupId = -1;
+    private int _darkModeSelectedGroupId = -1;
 
     private MouseButtons _downButton;
     private int _itemCount;
@@ -2894,6 +2961,9 @@ public partial class ListView : Control
                         return;
                     }
 
+                    _darkModeGroupBackgroundColors.Clear();
+                    _darkModeGroupStateFlags.Clear();
+
                     // We want custom draw for this paint cycle.
                     // CDRF_NOTIFYITEMDRAW is required for group items (LVCDI_GROUP) so that
                     // CDDS_ITEMPREPAINT notifications are raised for group header/subtitle/footer.
@@ -2939,6 +3009,7 @@ public partial class ListView : Control
                         // so skip native group drawing to avoid native artifacts and hover repaint flicker.
                         COLORREF textBackColor = nmcd->clrTextBk;
                         _darkModeGroupBackgroundColors[(int)nmcd->nmcd.dwItemSpec] = ColorTranslator.FromWin32((int)(uint)textBackColor);
+                        _darkModeGroupStateFlags[(int)nmcd->nmcd.dwItemSpec] = nmcd->nmcd.uItemState;
 
                         m.ResultInternal = (LRESULT)(nint)PInvoke.CDRF_SKIPDEFAULT;
                         return;
@@ -6739,6 +6810,96 @@ public partial class ListView : Control
         return lvhi;
     }
 
+    private int GetDarkModeGroupHeaderHitId()
+    {
+        if (!IsHandleCreated || !GroupsDisplayed)
+        {
+            return -1;
+        }
+
+        LVHITTESTINFO lvhi = SetupHitTestInfo();
+        int groupId = (int)PInvokeCore.SendMessage(this, PInvoke.LVM_HITTEST, (WPARAM)(-1), ref lvhi);
+        if (groupId == -1)
+        {
+            Point cursorPoint = PointToClient(Cursor.Position);
+            for (int i = 0; i < Groups.Count; i++)
+            {
+                ListViewGroup group = Groups[i];
+                if (TryGetDarkModeGroupInteractionRect(group, out Rectangle interactionRect)
+                    && interactionRect.Contains(cursorPoint))
+                {
+                    return group.ID;
+                }
+            }
+
+            return -1;
+        }
+
+        bool groupHeaderHovered = lvhi.flags == LVHITTESTINFO_FLAGS.LVHT_EX_GROUP_HEADER;
+        bool groupChevronHovered = (lvhi.flags & LVHITTESTINFO_FLAGS.LVHT_EX_GROUP_COLLAPSE) == LVHITTESTINFO_FLAGS.LVHT_EX_GROUP_COLLAPSE;
+        return groupHeaderHovered || groupChevronHovered ? groupId : -1;
+    }
+
+    private bool TryGetDarkModeGroupInteractionRect(ListViewGroup group, out Rectangle interactionRect)
+    {
+        interactionRect = Rectangle.Empty;
+        if (!TryGetGroupRect(group.ID, PInvoke.LVGGR_HEADER, out Rectangle headerRect)
+            || !TryGetGroupRect(group.ID, PInvoke.LVGGR_GROUP, out Rectangle groupRect))
+        {
+            return false;
+        }
+
+        bool collapsed = group.GetNativeCollapsedState() == ListViewGroupCollapsedState.Collapsed;
+        int headerVerticalPadding = LogicalToDeviceUnits(6);
+        int verticalSpacing = LogicalToDeviceUnits(2);
+        int footerCollapsedAdditionalOffset = LogicalToDeviceUnits(4);
+        int interactionBottom = headerRect.Bottom;
+        if (!string.IsNullOrEmpty(group.Subtitle))
+        {
+            interactionBottom = headerRect.Top + Font.Height + verticalSpacing + Font.Height + headerVerticalPadding;
+        }
+
+        if (!string.IsNullOrEmpty(group.Footer) && (collapsed || group.Items.Count == 0))
+        {
+            int subtitleOffset = string.IsNullOrEmpty(group.Subtitle) ? 1 : 2;
+            int collapsedFooterY = headerRect.Top + (Font.Height * subtitleOffset) + footerCollapsedAdditionalOffset;
+            interactionBottom = Math.Min(interactionBottom, Math.Max(headerRect.Top, collapsedFooterY - LogicalToDeviceUnits(1)));
+        }
+
+        interactionRect = Rectangle.Intersect(
+            groupRect,
+            new Rectangle(
+                groupRect.Left,
+                headerRect.Top,
+                groupRect.Width,
+                Math.Max(0, interactionBottom - headerRect.Top)));
+
+        return !interactionRect.IsEmpty;
+    }
+
+    private void InvalidateDarkModeGroupHeader(int groupId)
+    {
+        if (groupId < 0 || !IsHandleCreated)
+        {
+            return;
+        }
+
+        ListViewGroup? group = null;
+        for (int i = 0; i < Groups.Count; i++)
+        {
+            if (Groups[i].ID == groupId)
+            {
+                group = Groups[i];
+                break;
+            }
+        }
+
+        if (group is not null && TryGetDarkModeGroupInteractionRect(group, out Rectangle interactionRect))
+        {
+            Invalidate(interactionRect, invalidateChildren: false);
+        }
+    }
+
     private void Unhook()
     {
         foreach (ListViewItem listViewItem in Items)
@@ -7370,6 +7531,14 @@ public partial class ListView : Control
                 ItemCollectionChangedInMouseDown = false;
                 WmMouseDown(ref m, MouseButtons.Left, 1);
 
+                if (Application.IsDarkModeEnabled && GroupsDisplayed && !OwnerDraw && IsHandleCreated)
+                {
+                    int oldSelectedGroupId = _darkModeSelectedGroupId;
+                    _darkModeSelectedGroupId = GetDarkModeGroupHeaderHitId();
+                    InvalidateDarkModeGroupHeader(oldSelectedGroupId);
+                    InvalidateDarkModeGroupHeader(_darkModeSelectedGroupId);
+                }
+
                 if (cancelLabelEdit)
                 {
                     CancelPendingLabelEdit();
@@ -7426,10 +7595,26 @@ public partial class ListView : Control
 
                 if (Application.IsDarkModeEnabled && GroupsDisplayed && !OwnerDraw && IsHandleCreated)
                 {
+                    int oldHoveredGroupId = _darkModeHoveredGroupId;
+                    int hoveredGroupId = GetDarkModeGroupHeaderHitId();
+                    if (_darkModeHoveredGroupId != hoveredGroupId)
+                    {
+                        _darkModeHoveredGroupId = hoveredGroupId;
+                        InvalidateDarkModeGroupHeader(oldHoveredGroupId);
+                        InvalidateDarkModeGroupHeader(_darkModeHoveredGroupId);
+                    }
+
                     // Suppress native hover processing in dark mode group overlay mode.
-                    // Native hover invalidates group headers while mouse moves over items,
-                    // causing unrelated group repaint/flicker.
-                    if (!HoverSelection && !HotTracking)
+                    // Native hover invalidates group headers while mouse moves over grouped content,
+                    // causing repaint jitter.
+                    bool allowNativeHover = HoverSelection || HotTracking;
+                    if (allowNativeHover)
+                    {
+                        LVHITTESTINFO lvhi = SetupHitTestInfo();
+                        allowNativeHover = (int)PInvokeCore.SendMessage(this, PInvoke.LVM_HITTEST, (WPARAM)0, ref lvhi) >= 0;
+                    }
+
+                    if (!allowNativeHover)
                     {
                         Capture = false;
                         return;
@@ -7483,6 +7668,13 @@ public partial class ListView : Control
                 // if the mouse leaves and then re-enters the ListView
                 // ItemHovered events should be raised.
                 _prevHoveredItem = null;
+                if (_darkModeHoveredGroupId != -1)
+                {
+                    int oldHoveredGroupId = _darkModeHoveredGroupId;
+                    _darkModeHoveredGroupId = -1;
+                    InvalidateDarkModeGroupHeader(oldHoveredGroupId);
+                }
+
                 base.WndProc(ref m);
 
                 break;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
@@ -10,11 +10,14 @@ using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Windows.Forms.Layout;
 using System.Windows.Forms.VisualStyles;
+
 using Windows.Win32.System.Variant;
 using Windows.Win32.UI.Accessibility;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
+
 using static System.Windows.Forms.ListViewGroup;
 using static System.Windows.Forms.ListViewItem;
+
 using NMHEADERW = Windows.Win32.UI.Controls.NMHEADERW;
 using NMLVLINK = Windows.Win32.UI.Controls.NMLVLINK;
 
@@ -133,7 +136,7 @@ public partial class ListView : Control
 
     private void DrawDarkModeGroupSubtitleAndFooterOverlay()
     {
-        if (!Application.IsDarkModeEnabled || !GroupsEnabled || OwnerDraw || !IsHandleCreated)
+        if (!Application.IsDarkModeEnabled || !GroupsEnabled || !GroupsDisplayed || OwnerDraw || !IsHandleCreated)
         {
             return;
         }
@@ -155,34 +158,56 @@ public partial class ListView : Control
                 continue;
             }
 
+            Rectangle clientRect = ClientRectangle;
+            if (!clientRect.IntersectsWith(headerRect) && !clientRect.IntersectsWith(groupRect))
+            {
+                continue;
+            }
+
+            bool isRtl = RightToLeft == RightToLeft.Yes && RightToLeftLayout;
+            int horizontalPadding = LogicalToDeviceUnits(8);
+            int totalHorizontalPadding = LogicalToDeviceUnits(32);
+            int headerVerticalPadding = LogicalToDeviceUnits(6);
+            int verticalSpacing = LogicalToDeviceUnits(2);
+            int footerCollapsedAdditionalOffset = LogicalToDeviceUnits(4);
+            int headerTextWidth = Math.Max(0, headerRect.Width - totalHorizontalPadding);
+            int headerTextX = isRtl ? headerRect.Right - horizontalPadding - headerTextWidth
+                : headerRect.Left + horizontalPadding;
+
             Rectangle headerRectText = new(
-                headerRect.Left + 8,
+                headerTextX,
                 headerRect.Top,
-                Math.Max(0, headerRect.Width - 32),
-                headerFont.Height + 6);
+                headerTextWidth,
+                headerFont.Height + headerVerticalPadding);
+
+            TextFormatFlags baseTextFlags = TextFormatFlags.NoPrefix | TextFormatFlags.EndEllipsis;
+            TextFormatFlags headerTextFlags = baseTextFlags | (isRtl ? (TextFormatFlags.RightToLeft | TextFormatFlags.Right) : TextFormatFlags.Left);
 
             if (!string.IsNullOrEmpty(group.Header))
             {
-
                 using (Brush backBrush = new SolidBrush(BackColor))
                 {
                     g.FillRectangle(backBrush, headerRectText);
                 }
 
-                TextRenderer.DrawText(g, group.Header, headerFont, headerRectText, headerColor, TextFormatFlags.Left | TextFormatFlags.NoPrefix | TextFormatFlags.EndEllipsis);
+                TextRenderer.DrawText(g, group.Header, headerFont, headerRectText, headerColor, headerTextFlags);
             }
 
             DrawDarkModeGroupChevron(g, headerRect, headerRectText, group.Header, headerFont, collapsed, headerColor, chevronColor, BackColor);
+            TextFormatFlags bodyTextFlags = baseTextFlags | (isRtl ? (TextFormatFlags.RightToLeft | TextFormatFlags.Right) : TextFormatFlags.Left);
 
             if (!string.IsNullOrEmpty(group.Subtitle))
             {
+                int subtitleWidth = Math.Max(0, groupRect.Width - totalHorizontalPadding);
+                int subtitleX = isRtl ? headerRect.Right - horizontalPadding - subtitleWidth
+                    : headerRect.Left + horizontalPadding;
                 Rectangle subtitleRect = new(
-                    headerRect.Left + 8,
-                    headerRect.Top + Font.Height + 2,
-                    Math.Max(0, groupRect.Width - 32),
-                    Font.Height + 6);
+                    subtitleX,
+                    headerRect.Top + Font.Height + verticalSpacing,
+                    subtitleWidth,
+                    Font.Height + headerVerticalPadding);
 
-                TextRenderer.DrawText(g, group.Subtitle, Font, subtitleRect, textColor, TextFormatFlags.Left | TextFormatFlags.NoPrefix | TextFormatFlags.EndEllipsis);
+                TextRenderer.DrawText(g, group.Subtitle, Font, subtitleRect, textColor, bodyTextFlags);
             }
 
             if (!string.IsNullOrEmpty(group.Footer))
@@ -192,21 +217,25 @@ public partial class ListView : Control
                 if (!collapsed && group.Items.Count > 0)
                 {
                     Rectangle lastItemBounds = group.Items[^1].Bounds;
-                    footerY = lastItemBounds.Bottom + 2;
+                    footerY = lastItemBounds.Bottom + verticalSpacing;
                 }
                 else
                 {
                     int subtitleOffset = string.IsNullOrEmpty(group.Subtitle) ? 1 : 2;
-                    footerY = headerRect.Top + (Font.Height * subtitleOffset) + 4;
+                    footerY = headerRect.Top + (Font.Height * subtitleOffset) + footerCollapsedAdditionalOffset;
                 }
 
-                Rectangle footerRect = new(
-                    headerRect.Left + 8,
-                    footerY,
-                    Math.Max(0, groupRect.Width - 32),
-                    Font.Height + 6);
+                int footerWidth = Math.Max(0, groupRect.Width - totalHorizontalPadding);
+                int footerX = isRtl ? headerRect.Right - horizontalPadding - footerWidth
+                    : headerRect.Left + horizontalPadding;
 
-                TextRenderer.DrawText(g, group.Footer, Font, footerRect, textColor, TextFormatFlags.Left | TextFormatFlags.NoPrefix | TextFormatFlags.EndEllipsis);
+                Rectangle footerRect = new(
+                    footerX,
+                    footerY,
+                    footerWidth,
+                    Font.Height + headerVerticalPadding);
+
+                TextRenderer.DrawText(g, group.Footer, Font, footerRect, textColor, bodyTextFlags);
             }
         }
     }
@@ -4914,7 +4943,7 @@ public partial class ListView : Control
 
     private unsafe void UpdateDarkModeGroupTextColors()
     {
-        if (!IsHandleCreated || !GroupsEnabled)
+        if (!IsHandleCreated || !GroupsEnabled || OwnerDraw)
         {
             return;
         }
@@ -7361,7 +7390,6 @@ public partial class ListView : Control
 
             case PInvokeCore.WM_PAINT:
                 base.WndProc(ref m);
-
                 DrawDarkModeGroupSubtitleAndFooterOverlay();
 
                 // win32 ListView

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
@@ -142,10 +142,26 @@ public partial class ListView : Control
         }
 
         using Graphics g = CreateGraphicsInternal();
+        Rectangle clipRect = Rectangle.Ceiling(g.VisibleClipBounds);
         Color textColor = ForeColor;
         Color headerColor = Color.FromArgb(120, 180, 255);
         Color chevronColor = Color.FromArgb(80, 170, 255);
         using Font headerFont = new(Font, FontStyle.Bold);
+
+        static Rectangle TrimOverlayRect(Rectangle rect, int firstItemTop)
+        {
+            if (firstItemTop <= 0 || rect.IsEmpty || rect.Top >= firstItemTop)
+            {
+                return rect;
+            }
+
+            if (rect.Bottom >= firstItemTop)
+            {
+                rect.Height = Math.Max(0, firstItemTop - rect.Top - 1);
+            }
+
+            return rect;
+        }
 
         for (int i = 0; i < Groups.Count; i++)
         {
@@ -164,7 +180,16 @@ public partial class ListView : Control
                 continue;
             }
 
+            if (!clipRect.IsEmpty && !clipRect.IntersectsWith(headerRect) && !clipRect.IntersectsWith(groupRect))
+            {
+                continue;
+            }
+
             bool isRtl = RightToLeft == RightToLeft.Yes && RightToLeftLayout;
+            Color groupBackgroundColor = _darkModeGroupBackgroundColors.TryGetValue(group.ID, out Color cachedColor)
+                ? cachedColor
+                : BackColor;
+            int firstItemTop = (!collapsed && group.Items.Count > 0) ? group.Items[0].Bounds.Top : -1;
             int horizontalPadding = LogicalToDeviceUnits(8);
             int totalHorizontalPadding = LogicalToDeviceUnits(32);
             int headerVerticalPadding = LogicalToDeviceUnits(6);
@@ -180,20 +205,44 @@ public partial class ListView : Control
                 headerTextWidth,
                 headerFont.Height + headerVerticalPadding);
 
+            Rectangle headerCoverRect = TrimOverlayRect(headerRect, firstItemTop);
+            if (!headerCoverRect.IsEmpty)
+            {
+                using Brush groupBackBrush = new SolidBrush(groupBackgroundColor);
+                g.FillRectangle(groupBackBrush, headerCoverRect);
+            }
+
             TextFormatFlags baseTextFlags = TextFormatFlags.NoPrefix | TextFormatFlags.EndEllipsis;
             TextFormatFlags headerTextFlags = baseTextFlags | (isRtl ? (TextFormatFlags.RightToLeft | TextFormatFlags.Right) : TextFormatFlags.Left);
 
+            DrawDarkModeGroupChevron(g, headerRect, headerRectText, group.Header, headerFont, collapsed, headerColor, chevronColor, groupBackgroundColor);
+
             if (!string.IsNullOrEmpty(group.Header))
             {
-                using (Brush backBrush = new SolidBrush(BackColor))
-                {
-                    g.FillRectangle(backBrush, headerRectText);
-                }
+                int measuredHeaderTextWidth = TextRenderer.MeasureText(
+                    g,
+                    group.Header,
+                    headerFont,
+                    Size.Empty,
+                    TextFormatFlags.SingleLine | TextFormatFlags.NoPrefix | TextFormatFlags.NoPadding).Width;
 
-                TextRenderer.DrawText(g, group.Header, headerFont, headerRectText, headerColor, headerTextFlags);
+                int renderedHeaderTextWidth = Math.Min(Math.Max(0, measuredHeaderTextWidth), Math.Max(0, headerRectText.Width));
+                int headerTextBackgroundWidth = Math.Min(headerRectText.Width, renderedHeaderTextWidth + LogicalToDeviceUnits(2));
+                int headerTextBackgroundX = isRtl
+                    ? headerRectText.Right - headerTextBackgroundWidth
+                    : headerRectText.Left;
+
+                Rectangle headerTextBackgroundRect = new(
+                    headerTextBackgroundX,
+                    headerRectText.Top,
+                    headerTextBackgroundWidth,
+                    headerRectText.Height);
+
+                using Brush headerTextBackgroundBrush = new SolidBrush(groupBackgroundColor);
+                g.FillRectangle(headerTextBackgroundBrush, headerTextBackgroundRect);
+                TextRenderer.DrawText(g, group.Header, headerFont, headerRectText, headerColor, groupBackgroundColor, headerTextFlags);
             }
 
-            DrawDarkModeGroupChevron(g, headerRect, headerRectText, group.Header, headerFont, collapsed, headerColor, chevronColor, BackColor);
             TextFormatFlags bodyTextFlags = baseTextFlags | (isRtl ? (TextFormatFlags.RightToLeft | TextFormatFlags.Right) : TextFormatFlags.Left);
 
             if (!string.IsNullOrEmpty(group.Subtitle))
@@ -206,6 +255,13 @@ public partial class ListView : Control
                     headerRect.Top + Font.Height + verticalSpacing,
                     subtitleWidth,
                     Font.Height + headerVerticalPadding);
+
+                Rectangle subtitleCoverRect = TrimOverlayRect(Rectangle.Inflate(subtitleRect, 2, 0), firstItemTop);
+                if (!subtitleCoverRect.IsEmpty)
+                {
+                    using Brush subtitleBackBrush = new SolidBrush(groupBackgroundColor);
+                    g.FillRectangle(subtitleBackBrush, subtitleCoverRect);
+                }
 
                 TextRenderer.DrawText(g, group.Subtitle, Font, subtitleRect, textColor, bodyTextFlags);
             }
@@ -235,7 +291,33 @@ public partial class ListView : Control
                     footerWidth,
                     Font.Height + headerVerticalPadding);
 
+                Rectangle footerCoverRect = TrimOverlayRect(Rectangle.Inflate(footerRect, 2, 0), firstItemTop);
+                if (!footerCoverRect.IsEmpty)
+                {
+                    using Brush footerBackBrush = new SolidBrush(groupBackgroundColor);
+                    g.FillRectangle(footerBackBrush, footerCoverRect);
+                }
+
                 TextRenderer.DrawText(g, group.Footer, Font, footerRect, textColor, bodyTextFlags);
+            }
+        }
+
+        if (View == View.Details && !GridLines && Columns.Count == 1)
+        {
+            int dividerX = Columns[0].Width;
+            if (dividerX > 0 && dividerX < ClientRectangle.Right)
+            {
+                int paintTop = 0;
+                HWND header = (HWND)PInvokeCore.SendMessage(this, PInvoke.LVM_GETHEADER);
+                if (!header.IsNull)
+                {
+                    PInvokeCore.GetWindowRect(header, out RECT headerRect);
+                    paintTop = RectangleToClient((Rectangle)headerRect).Bottom;
+                }
+
+                Rectangle dividerCoverRect = new(dividerX, paintTop, 1, Math.Max(0, ClientRectangle.Bottom - paintTop));
+                using Brush dividerCoverBrush = new SolidBrush(BackColor);
+                g.FillRectangle(dividerCoverBrush, dividerCoverRect);
             }
         }
     }
@@ -255,10 +337,10 @@ public partial class ListView : Control
         int centerY = headerTextRect.Top + (headerTextRect.Height / 2) + 1;
 
         Rectangle nativeChevronRect = new(
-            headerRect.Right - 24,
-            headerTextRect.Top - 3,
-            24,
-            headerTextRect.Height + 8);
+            headerRect.Right - 28,
+            headerRect.Top,
+            28,
+            headerRect.Height);
         using (Brush backgroundBrush = new SolidBrush(backgroundColor))
         {
             g.FillRectangle(backgroundBrush, nativeChevronRect);
@@ -279,19 +361,23 @@ public partial class ListView : Control
 
         int lineY = centerY;
         int lineStartX = headerRect.Left + 8;
+
         if (!string.IsNullOrEmpty(headerText))
         {
-            int measuredHeaderWidth = TextRenderer.MeasureText(
+            int measuredHeaderTextWidth = TextRenderer.MeasureText(
                 g,
                 headerText,
                 headerFont,
                 Size.Empty,
                 TextFormatFlags.SingleLine | TextFormatFlags.NoPrefix | TextFormatFlags.NoPadding).Width;
 
-            lineStartX += measuredHeaderWidth + 8;
+            const int dividerTextSpacing = 6;
+            lineStartX = Math.Max(
+                lineStartX,
+                headerTextRect.Left + Math.Min(measuredHeaderTextWidth, headerTextRect.Width) + dividerTextSpacing);
         }
 
-        int lineEndX = centerX - 10;
+        int lineEndX = nativeChevronRect.Left - 6;
         if (lineEndX > lineStartX)
         {
             using Pen linePen = new(lineColor, 1f)
@@ -320,6 +406,7 @@ public partial class ListView : Control
     private ImageList? _imageListSmall;
     private ImageList? _imageListState;
     private ImageList? _imageListGroup;
+    private readonly Dictionary<int, Color> _darkModeGroupBackgroundColors = [];
 
     private MouseButtons _downButton;
     private int _itemCount;
@@ -2848,18 +2935,12 @@ public partial class ListView : Control
                         && !OwnerDraw
                         && nmcd->dwItemType == NMLVCUSTOMDRAW_ITEM_TYPE.LVCDI_GROUP)
                     {
-                        COLORREF textColor = (COLORREF)ColorTranslator.ToWin32(BackColor);
-                        COLORREF textBackColor = (COLORREF)ColorTranslator.ToWin32(BackColor);
-                        nmcd->clrText = textColor;
-                        nmcd->clrTextBk = textBackColor;
+                        // In dark mode we fully custom draw group header/subtitle/footer overlay,
+                        // so skip native group drawing to avoid native artifacts and hover repaint flicker.
+                        COLORREF textBackColor = nmcd->clrTextBk;
+                        _darkModeGroupBackgroundColors[(int)nmcd->nmcd.dwItemSpec] = ColorTranslator.FromWin32((int)(uint)textBackColor);
 
-                        if (!nmcd->nmcd.hdc.IsNull)
-                        {
-                            PInvokeCore.SetTextColor(nmcd->nmcd.hdc, textColor);
-                            PInvokeCore.SetBkColor(nmcd->nmcd.hdc, textBackColor);
-                        }
-
-                        m.ResultInternal = (LRESULT)(nint)PInvoke.CDRF_NEWFONT;
+                        m.ResultInternal = (LRESULT)(nint)PInvoke.CDRF_SKIPDEFAULT;
                         return;
                     }
 
@@ -6273,9 +6354,15 @@ public partial class ListView : Control
             }
             else if (nmlvcd->nmcd.dwDrawStage == NMCUSTOMDRAW_DRAW_STAGE.CDDS_ITEMPREPAINT)
             {
-                Color textColor = nmlvcd->dwItemType == NMLVCUSTOMDRAW_ITEM_TYPE.LVCDI_GROUP
-                    ? BackColor
-                    : ForeColor;
+                Color textColor;
+                if (nmlvcd->dwItemType == NMLVCUSTOMDRAW_ITEM_TYPE.LVCDI_GROUP)
+                {
+                    textColor = nmlvcd->clrTextBk;
+                }
+                else
+                {
+                    textColor = ForeColor;
+                }
 
                 PInvokeCore.SetTextColor(nmlvcd->nmcd.hdc, textColor);
 
@@ -7335,6 +7422,18 @@ public partial class ListView : Control
                 {
                     OnMouseUp(new MouseEventArgs(_downButton, 1, PARAM.ToPoint(m.LParamInternal)));
                     _listViewState[LISTVIEWSTATE_mouseUpFired] = true;
+                }
+
+                if (Application.IsDarkModeEnabled && GroupsDisplayed && !OwnerDraw && IsHandleCreated)
+                {
+                    // Suppress native hover processing in dark mode group overlay mode.
+                    // Native hover invalidates group headers while mouse moves over items,
+                    // causing unrelated group repaint/flicker.
+                    if (!HoverSelection && !HotTracking)
+                    {
+                        Capture = false;
+                        return;
+                    }
                 }
 
                 Capture = false;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
@@ -102,6 +102,10 @@ public partial class ListView : Control
     private const uint LVM_SETGROUPMETRICS = PInvoke.LVM_FIRST + 155;
     private const uint LVGMF_TEXTCOLOR = 0x00000004;
 
+    /// <summary>
+    ///  Managed counterpart of the Win32 <c>LVGROUPMETRICS</c> structure used with <see cref="LVM_SETGROUPMETRICS"/>
+    ///  to customize group rendering metrics (margins and header/footer text colors).
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     private struct LVGROUPMETRICS
     {
@@ -119,6 +123,17 @@ public partial class ListView : Control
         public COLORREF crFooter;
     }
 
+    /// <summary>
+    ///  Retrieves the bounding rectangle of a group identified by <paramref name="groupId"/> by sending
+    ///  <c>LVM_GETGROUPRECT</c> to the native ListView control.
+    /// </summary>
+    /// <param name="groupId">The identifier of the group to query.</param>
+    /// <param name="rectType">
+    ///  The portion of the group to retrieve (for example <see cref="PInvoke.LVGGR_GROUP"/> or
+    ///  <see cref="PInvoke.LVGGR_HEADER"/>).
+    /// </param>
+    /// <param name="rect">When this method returns, contains the requested rectangle, or <see cref="Rectangle.Empty"/> if not found.</param>
+    /// <returns><see langword="true"/> if the rectangle was retrieved successfully; otherwise, <see langword="false"/>.</returns>
     private unsafe bool TryGetGroupRect(int groupId, uint rectType, out Rectangle rect)
     {
         RECT nativeRect = default;
@@ -134,6 +149,18 @@ public partial class ListView : Control
         return true;
     }
 
+    /// <summary>
+    ///  Renders the dark-mode overlay for each group, including the header, subtitle, footer, chevron, and the
+    ///  hover/selection background. This compensates for the native ListView's poor visual contrast for group
+    ///  headers when running in dark mode.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   The overlay is painted on top of the native control after <see cref="PInvokeCore.WM_PAINT"/> has been
+    ///   handled by the base class. The method is a no-op when dark mode is disabled, groups are not displayed,
+    ///   the control is owner drawn, or the handle has not been created.
+    ///  </para>
+    /// </remarks>
     private void DrawDarkModeGroupSubtitleAndFooterOverlay()
     {
         if (!Application.IsDarkModeEnabled || !GroupsEnabled || !GroupsDisplayed || OwnerDraw || !IsHandleCreated)
@@ -386,6 +413,22 @@ public partial class ListView : Control
         }
     }
 
+    /// <summary>
+    ///  Draws the dark-mode expand/collapse chevron at the right side of a group header along with the divider
+    ///  line that visually separates the header text from the chevron.
+    /// </summary>
+    /// <param name="g">The <see cref="Graphics"/> surface used for drawing.</param>
+    /// <param name="headerRect">The full header rectangle of the group.</param>
+    /// <param name="headerTextRect">The rectangle that contains the header text.</param>
+    /// <param name="headerText">The header text used to determine where the divider line should start.</param>
+    /// <param name="headerFont">The font used to render the header text.</param>
+    /// <param name="collapsed">
+    ///  <see langword="true"/> to draw a chevron pointing to the right (collapsed state);
+    ///  <see langword="false"/> to draw a chevron pointing down (expanded state).
+    /// </param>
+    /// <param name="lineColor">The color of the divider line between the header text and the chevron.</param>
+    /// <param name="chevronColor">The color used to draw the chevron strokes.</param>
+    /// <param name="backgroundColor">The background color used to clear the native chevron area before redrawing.</param>
     private static void DrawDarkModeGroupChevron(
         Graphics g,
         Rectangle headerRect,
@@ -5093,6 +5136,16 @@ public partial class ListView : Control
         }
     }
 
+    /// <summary>
+    ///  Pushes dark-mode friendly group text colors to the native ListView by sending
+    ///  <see cref="LVM_SETGROUPMETRICS"/> with the <see cref="LVGMF_TEXTCOLOR"/> mask.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   The native control would otherwise draw group header/footer text in colors optimized for light mode,
+    ///   which produces poor contrast on dark backgrounds.
+    ///  </para>
+    /// </remarks>
     private unsafe void UpdateDarkModeGroupTextColors()
     {
         if (!IsHandleCreated || !GroupsEnabled || OwnerDraw)
@@ -6810,6 +6863,17 @@ public partial class ListView : Control
         return lvhi;
     }
 
+    /// <summary>
+    ///  Returns the identifier of the group whose interactive header area (header, subtitle, footer or chevron)
+    ///  is currently under the mouse cursor, or <c>-1</c> if no such group is hovered.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Falls back to a manual hit test against <see cref="TryGetDarkModeGroupInteractionRect"/> when the native
+    ///   <c>LVM_HITTEST</c> message does not report a group hit (for example, when hovering over the custom
+    ///   subtitle or footer overlay).
+    ///  </para>
+    /// </remarks>
     private int GetDarkModeGroupHeaderHitId()
     {
         if (!IsHandleCreated || !GroupsDisplayed)
@@ -6840,6 +6904,16 @@ public partial class ListView : Control
         return groupHeaderHovered || groupChevronHovered ? groupId : -1;
     }
 
+    /// <summary>
+    ///  Computes the interactive rectangle that covers the dark-mode group header overlay (header, optional
+    ///  subtitle and, for collapsed/empty groups, the footer) used for hit-testing and invalidation.
+    /// </summary>
+    /// <param name="group">The group whose interactive rectangle should be computed.</param>
+    /// <param name="interactionRect">
+    ///  When this method returns, contains the rectangle clipped to the group bounds, or
+    ///  <see cref="Rectangle.Empty"/> if it cannot be determined.
+    /// </param>
+    /// <returns><see langword="true"/> if a non-empty rectangle could be computed; otherwise, <see langword="false"/>.</returns>
     private bool TryGetDarkModeGroupInteractionRect(ListViewGroup group, out Rectangle interactionRect)
     {
         interactionRect = Rectangle.Empty;
@@ -6877,6 +6951,14 @@ public partial class ListView : Control
         return !interactionRect.IsEmpty;
     }
 
+    /// <summary>
+    ///  Invalidates the interactive area of the dark-mode group header identified by <paramref name="groupId"/>
+    ///  so that the hover/selection overlay is repainted.
+    /// </summary>
+    /// <param name="groupId">
+    ///  The group identifier to invalidate. Negative values and identifiers that do not match any existing
+    ///  group are ignored.
+    /// </param>
     private void InvalidateDarkModeGroupHeader(int groupId)
     {
         if (groupId < 0 || !IsHandleCreated)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
@@ -51,6 +51,16 @@ public partial class ListView : Control
     private static readonly object s_groupCollapsedStateChangedEvent = new();
     private static readonly object s_groupTaskLinkClickEvent = new();
 
+    // Colors and blend alphas used by the dark-mode group overlay
+    // (see DrawDarkModeGroupSubtitleAndFooterOverlay). Centralized so the palette
+    // can be tuned in one place if the Windows dark-mode accent guidance evolves.
+    // The selected/hovered overlays are blended on top of SystemColors so they
+    // automatically follow the user's active accent; the header/chevron tones are
+    // the Win11 dark-mode accent blues, which currently have no SystemColors analogue.
+    private static readonly Color s_darkModeGroupHeaderColor = SystemColors.MenuHighlight;
+    private const int DarkModeGroupSelectedOverlayAlpha = 64;
+    private const int DarkModeGroupHoveredOverlayAlpha = 28;
+
     private ItemActivation _activation = ItemActivation.Standard;
     private ListViewAlignment _alignStyle = ListViewAlignment.Top;
     private BorderStyle _borderStyle = BorderStyle.Fixed3D;
@@ -129,8 +139,8 @@ public partial class ListView : Control
     /// </summary>
     /// <param name="groupId">The identifier of the group to query.</param>
     /// <param name="rectType">
-    ///  The portion of the group to retrieve (for example <see cref="PInvoke.LVGGR_GROUP"/> or
-    ///  <see cref="PInvoke.LVGGR_HEADER"/>).
+    ///  The portion of the group to retrieve (for example <c>LVGGR_GROUP</c> or
+    ///  <c>LVGGR_HEADER</c>).
     /// </param>
     /// <param name="rect">When this method returns, contains the requested rectangle, or <see cref="Rectangle.Empty"/> if not found.</param>
     /// <returns><see langword="true"/> if the rectangle was retrieved successfully; otherwise, <see langword="false"/>.</returns>
@@ -171,8 +181,8 @@ public partial class ListView : Control
         using Graphics g = CreateGraphicsInternal();
         Rectangle clipRect = Rectangle.Ceiling(g.VisibleClipBounds);
         Color textColor = ForeColor;
-        Color headerColor = Color.FromArgb(120, 180, 255);
-        Color chevronColor = Color.FromArgb(80, 170, 255);
+        Color headerColor = s_darkModeGroupHeaderColor;
+        Color chevronColor = s_darkModeGroupHeaderColor;
         using Font headerFont = new(Font, FontStyle.Bold);
 
         static Rectangle TrimOverlayRect(Rectangle rect, int firstItemTop)
@@ -243,8 +253,8 @@ public partial class ListView : Control
             bool isSelected = _darkModeSelectedGroupId == group.ID
                 || (groupDrawState & (NMCUSTOMDRAW_DRAW_STATE_FLAGS.CDIS_SELECTED | NMCUSTOMDRAW_DRAW_STATE_FLAGS.CDIS_FOCUS)) != 0;
             Color groupInteractionOverlayColor = isSelected
-                ? Color.FromArgb(64, 90, 150, 255)
-                : (isHovered ? Color.FromArgb(28, 255, 255, 255) : Color.Empty);
+                ? Color.FromArgb(DarkModeGroupSelectedOverlayAlpha, SystemColors.Highlight)
+                : (isHovered ? Color.FromArgb(DarkModeGroupHoveredOverlayAlpha, SystemColors.Highlight) : Color.Empty);
             Color groupContentBackgroundColor = groupInteractionOverlayColor.IsEmpty
                 ? groupBackgroundColor
                 : BlendColor(groupBackgroundColor, groupInteractionOverlayColor);
@@ -264,26 +274,7 @@ public partial class ListView : Control
                 headerTextWidth,
                 headerFont.Height + headerVerticalPadding);
 
-            int interactionBottom = headerRect.Bottom;
-            if (!string.IsNullOrEmpty(group.Subtitle))
-            {
-                interactionBottom = headerRect.Top + Font.Height + verticalSpacing + Font.Height + headerVerticalPadding;
-            }
-
-            if (!string.IsNullOrEmpty(group.Footer) && (collapsed || group.Items.Count == 0))
-            {
-                int subtitleOffset = string.IsNullOrEmpty(group.Subtitle) ? 1 : 2;
-                int collapsedFooterY = headerRect.Top + (Font.Height * subtitleOffset) + footerCollapsedAdditionalOffset;
-                interactionBottom = Math.Min(interactionBottom, Math.Max(headerRect.Top, collapsedFooterY - LogicalToDeviceUnits(1)));
-            }
-
-            Rectangle interactionRect = Rectangle.Intersect(
-                groupRect,
-                new Rectangle(
-                    groupRect.Left,
-                    headerRect.Top,
-                    groupRect.Width,
-                    Math.Max(0, interactionBottom - headerRect.Top)));
+            TryGetDarkModeGroupInteractionRect(group, out Rectangle interactionRect);
 
             Rectangle interactionCoverRect = TrimOverlayRect(interactionRect, firstItemTop);
             if (!interactionCoverRect.IsEmpty)
@@ -429,7 +420,7 @@ public partial class ListView : Control
     /// <param name="lineColor">The color of the divider line between the header text and the chevron.</param>
     /// <param name="chevronColor">The color used to draw the chevron strokes.</param>
     /// <param name="backgroundColor">The background color used to clear the native chevron area before redrawing.</param>
-    private static void DrawDarkModeGroupChevron(
+    private void DrawDarkModeGroupChevron(
         Graphics g,
         Rectangle headerRect,
         Rectangle headerTextRect,
@@ -440,13 +431,23 @@ public partial class ListView : Control
         Color chevronColor,
         Color backgroundColor)
     {
-        int centerX = headerRect.Right - 9;
-        int centerY = headerTextRect.Top + (headerTextRect.Height / 2) + 1;
+        int chevronAreaWidth = LogicalToDeviceUnits(28);
+        int chevronCenterInset = LogicalToDeviceUnits(9);
+        int chevronOffsetSmall = LogicalToDeviceUnits(2);
+        int chevronOffsetMedium = LogicalToDeviceUnits(3);
+        int chevronOffsetLarge = LogicalToDeviceUnits(5);
+        int dividerLeftPadding = LogicalToDeviceUnits(8);
+        int dividerHorizontalSpacing = LogicalToDeviceUnits(6);
+        int verticalOpticalNudge = LogicalToDeviceUnits(1);
+        float chevronPenWidth = 2.6f;
+
+        int centerX = headerRect.Right - chevronCenterInset;
+        int centerY = headerTextRect.Top + (headerTextRect.Height / 2) + verticalOpticalNudge;
 
         Rectangle nativeChevronRect = new(
-            headerRect.Right - 28,
+            headerRect.Right - chevronAreaWidth,
             headerRect.Top,
-            28,
+            chevronAreaWidth,
             headerRect.Height);
         using (Brush backgroundBrush = new SolidBrush(backgroundColor))
         {
@@ -454,10 +455,14 @@ public partial class ListView : Control
         }
 
         Point[] points = collapsed
-            ? [new Point(centerX - 3, centerY - 5), new Point(centerX + 2, centerY), new Point(centerX - 3, centerY + 5)]
-            : [new Point(centerX - 5, centerY - 2), new Point(centerX, centerY + 3), new Point(centerX + 5, centerY - 2)];
+            ? [new Point(centerX - chevronOffsetMedium, centerY - chevronOffsetLarge),
+               new Point(centerX + chevronOffsetSmall, centerY),
+               new Point(centerX - chevronOffsetMedium, centerY + chevronOffsetLarge)]
+            : [new Point(centerX - chevronOffsetLarge, centerY - chevronOffsetSmall),
+               new Point(centerX, centerY + chevronOffsetMedium),
+               new Point(centerX + chevronOffsetLarge, centerY - chevronOffsetSmall)];
 
-        using Pen chevronPen = new(chevronColor, 2.6f)
+        using Pen chevronPen = new(chevronColor, chevronPenWidth)
         {
             StartCap = Drawing.Drawing2D.LineCap.Round,
             EndCap = Drawing.Drawing2D.LineCap.Round,
@@ -467,7 +472,7 @@ public partial class ListView : Control
         g.DrawLines(chevronPen, points);
 
         int lineY = centerY;
-        int lineStartX = headerRect.Left + 8;
+        int lineStartX = headerRect.Left + dividerLeftPadding;
 
         if (!string.IsNullOrEmpty(headerText))
         {
@@ -478,13 +483,12 @@ public partial class ListView : Control
                 Size.Empty,
                 TextFormatFlags.SingleLine | TextFormatFlags.NoPrefix | TextFormatFlags.NoPadding).Width;
 
-            const int dividerTextSpacing = 6;
             lineStartX = Math.Max(
                 lineStartX,
-                headerTextRect.Left + Math.Min(measuredHeaderTextWidth, headerTextRect.Width) + dividerTextSpacing);
+                headerTextRect.Left + Math.Min(measuredHeaderTextWidth, headerTextRect.Width) + dividerHorizontalSpacing);
         }
 
-        int lineEndX = nativeChevronRect.Left - 6;
+        int lineEndX = nativeChevronRect.Left - dividerHorizontalSpacing;
         if (lineEndX > lineStartX)
         {
             using Pen linePen = new(lineColor, 1f)
@@ -6481,6 +6485,10 @@ public partial class ListView : Control
                 Color textColor;
                 if (nmlvcd->dwItemType == NMLVCUSTOMDRAW_ITEM_TYPE.LVCDI_GROUP)
                 {
+                    // For LVCDI_GROUP items, clrTextBk carries the value we previously pushed
+                    // via LVGROUPMETRICS.crHeader (= BackColor). Forwarding it to SetTextColor
+                    // makes the native group header text invisible, so our managed overlay in
+                    // DrawDarkModeGroupSubtitleAndFooterOverlay can render the visible text.
                     textColor = nmlvcd->clrTextBk;
                 }
                 else
@@ -7555,6 +7563,7 @@ public partial class ListView : Control
 
     protected override void WndProc(ref Message m)
     {
+        int oldHoveredGroupId = _darkModeHoveredGroupId;
         switch (m.MsgInternal)
         {
             case MessageId.WM_REFLECT_NOTIFY:
@@ -7677,7 +7686,6 @@ public partial class ListView : Control
 
                 if (Application.IsDarkModeEnabled && GroupsDisplayed && !OwnerDraw && IsHandleCreated)
                 {
-                    int oldHoveredGroupId = _darkModeHoveredGroupId;
                     int hoveredGroupId = GetDarkModeGroupHeaderHitId();
                     if (_darkModeHoveredGroupId != hoveredGroupId)
                     {
@@ -7696,7 +7704,6 @@ public partial class ListView : Control
                     if (!allowNativeHover)
                     {
                         Capture = false;
-                        return;
                     }
                 }
 
@@ -7749,7 +7756,6 @@ public partial class ListView : Control
                 _prevHoveredItem = null;
                 if (_darkModeHoveredGroupId != -1)
                 {
-                    int oldHoveredGroupId = _darkModeHoveredGroupId;
                     _darkModeHoveredGroupId = -1;
                     InvalidateDarkModeGroupHeader(oldHoveredGroupId);
                 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14198 


## Proposed changes

- In Dark Mode, the ListView's internal theme has been switched from "Explorer" to "ItemsView" to ensure alignment with the column headers.
- After the Handle is created, call the new method `UpdateDarkModeGroupTextColors()` to set the group header and footer text colors using `LVM_SETGROUPMETRICS`.
- Add CDRF_NOTIFYITEMDRAW to enable the native control to send CDDS_ITEMPREPAINT notifications for group items.
- Added a 'group' branch to `CDDS_ITEMPREPAINT`: In dark mode, return `CDRF_SKIPDEFAULT` to skip native group painting, and cache `clrTextBk` and `uItemState` in a dictionary for use during the overlay phase.
- In Dark Mode, force the HDC text color to equal ForeColor, and set the group text of the header control to use clrTextBk.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Improve visual contrast of the Group Headers in ListView control in dark.

## Regression? 

- No

## Risk

- Min

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<img width="782" height="591" alt="image" src="https://github.com/user-attachments/assets/c33c371d-cfae-4311-a2fb-381447d1ab33" />

### After

https://github.com/user-attachments/assets/1ad2c8da-7c82-4d0e-aec4-d65fe5fa258c

## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.100-preview.5.26227.104


<!-- Mention language, UI scaling, or anything else that might be relevant -->
