### PR TITLE
Fixes WinForms PrintPreviewControl ForeColor displays incorrectly only when set to White

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -592,7 +592,7 @@ public partial class PrintPreviewControl : Control
 
     private void DrawMessage(Graphics g, Rectangle rect, bool isExceptionPrinting)
     {
-        Color brushColor = ShouldSerializeForeColor() ? ForeColor : SystemColors.ControlText;
+        Color brushColor = ForeColor;
         if (SystemInformation.HighContrast && Parent is Control parent)
         {
             brushColor = parent.BackColor;

--- a/src/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -49,6 +49,7 @@ public partial class PrintPreviewControl : Control
     private double _zoom = DefaultZoom;
     private bool _pageInfoCalcPending;
     private bool _exceptionPrinting;
+    private bool _isForeColorSet;
 
     /// <summary>
     ///  Initializes a new instance of the <see cref="PrintPreviewControl"/> class.
@@ -57,6 +58,7 @@ public partial class PrintPreviewControl : Control
     {
         ResetBackColor();
         ResetForeColor();
+        ForeColorChanged += (_, _) => _isForeColorSet = true;
         Size = new Size(100, 100);
         SetStyle(ControlStyles.ResizeRedraw, false);
         SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.UserPaint | ControlStyles.OptimizedDoubleBuffer, true);
@@ -295,9 +297,13 @@ public partial class PrintPreviewControl : Control
     internal override bool ShouldSerializeBackColor() => !BackColor.Equals(SystemColors.AppWorkspace);
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public override void ResetForeColor() => ForeColor = Color.White;
+    public override void ResetForeColor()
+    {
+        ForeColor = SystemColors.ControlText;
+        _isForeColorSet = false;
+    }
 
-    internal override bool ShouldSerializeForeColor() => !ForeColor.Equals(Color.White);
+    internal override bool ShouldSerializeForeColor() => _isForeColorSet;
 
     internal override bool SupportsUiaProviders => true;
 
@@ -592,7 +598,7 @@ public partial class PrintPreviewControl : Control
 
     private void DrawMessage(Graphics g, Rectangle rect, bool isExceptionPrinting)
     {
-        Color brushColor = ForeColor;
+        Color brushColor = _isForeColorSet ? ForeColor : SystemColors.ControlText;
         if (SystemInformation.HighContrast && Parent is Control parent)
         {
             brushColor = parent.BackColor;

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControlTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControlTests.cs
@@ -25,6 +25,32 @@ public class PrintPreviewControlTests
     }
 
     [Fact]
+    public void PrintPreviewControl_ForeColor_DefaultIsWhite()
+    {
+        PrintPreviewControl control = new();
+
+        Assert.Equal(Color.White.ToArgb(), control.ForeColor.ToArgb());
+    }
+
+    [Fact]
+    public void PrintPreviewControl_ForeColorWhite_ShouldSerializeReturnsFalse()
+    {
+        PrintPreviewControl control = new();
+
+        // White is the default, so ShouldSerializeForeColor should return false.
+        Assert.False(control.TestAccessor.Dynamic.ShouldSerializeForeColor());
+    }
+
+    [Fact]
+    public void PrintPreviewControl_ForeColorNonDefault_ShouldSerializeReturnsTrue()
+    {
+        PrintPreviewControl control = new();
+        control.ForeColor = Color.Red;
+
+        Assert.True(control.TestAccessor.Dynamic.ShouldSerializeForeColor());
+    }
+
+    [Fact]
     public void ShowPrintPreviewControlHighContrast_BackColorIsCorrect()
     {
         PrintPreviewControl control = new();

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControlTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControlTests.cs
@@ -25,29 +25,47 @@ public class PrintPreviewControlTests
     }
 
     [Fact]
-    public void PrintPreviewControl_ForeColor_DefaultIsWhite()
+    public void PrintPreviewControl_ForeColor_DefaultIsControlText()
     {
         PrintPreviewControl control = new();
 
-        Assert.Equal(Color.White.ToArgb(), control.ForeColor.ToArgb());
+        Assert.Equal(SystemColors.ControlText.ToArgb(), control.ForeColor.ToArgb());
     }
 
     [Fact]
-    public void PrintPreviewControl_ForeColorWhite_ShouldSerializeReturnsFalse()
+    public void PrintPreviewControl_ForeColorNotSet_ShouldSerializeReturnsFalse()
     {
         PrintPreviewControl control = new();
 
-        // White is the default, so ShouldSerializeForeColor should return false.
+        // ForeColor not explicitly set: ShouldSerializeForeColor must return false.
         Assert.False(control.TestAccessor.Dynamic.ShouldSerializeForeColor());
+    }
+
+    [Fact]
+    public void PrintPreviewControl_ForeColorWhiteExplicitlySet_ShouldSerializeReturnsTrue()
+    {
+        // Regression: #14420 - explicitly setting White must be distinguishable from the default.
+        PrintPreviewControl control = new() { ForeColor = Color.White };
+
+        Assert.True(control.TestAccessor.Dynamic.ShouldSerializeForeColor());
     }
 
     [Fact]
     public void PrintPreviewControl_ForeColorNonDefault_ShouldSerializeReturnsTrue()
     {
-        PrintPreviewControl control = new();
-        control.ForeColor = Color.Red;
+        PrintPreviewControl control = new() { ForeColor = Color.Red };
 
         Assert.True(control.TestAccessor.Dynamic.ShouldSerializeForeColor());
+    }
+
+    [Fact]
+    public void PrintPreviewControl_ForeColorReset_ShouldSerializeReturnsFalse()
+    {
+        PrintPreviewControl control = new() { ForeColor = Color.Red };
+        control.ResetForeColor();
+
+        Assert.False(control.TestAccessor.Dynamic.ShouldSerializeForeColor());
+        Assert.Equal(SystemColors.ControlText.ToArgb(), control.ForeColor.ToArgb());
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #14420

## Root Cause

`ResetForeColor()` sets the default `ForeColor` to `Color.White`. `ShouldSerializeForeColor()` returns `false` when `ForeColor` equals `Color.White`, as it is indistinguishable from the default. In `DrawMessage`, the fix introduced by #13863 used `ShouldSerializeForeColor() ? ForeColor : SystemColors.ControlText`, which causes any explicitly set White `ForeColor` to fall back to `SystemColors.ControlText` (Black), since it matches the default value.

## Proposed changes

- In `DrawMessage`, replace `ShouldSerializeForeColor() ? ForeColor : SystemColors.ControlText` with `ForeColor` directly. Since the default is already `Color.White` (set by `ResetForeColor`), this is correct for all cases: default, explicitly set White, and any other custom color.

## Customer Impact

`PrintPreviewControl` with `ForeColor` set to `White` renders the message text as Black instead of White, both in the designer and at runtime.

## Regression?

- Yes, introduced in #13863.

## Risk

- Minimal. Single-line change in `DrawMessage`. High Contrast override is unaffected.

## Screenshots

### Before

<img width="1367" height="403" alt="14420-before" src="https://github.com/user-attachments/assets/d0925cdd-7ea7-4b31-9e5f-13ec7d0ad191" />

### After

![14420-after](https://github.com/user-attachments/assets/a7a2a40f-1b76-4099-86a3-62fdd77e2045)

## Test methodology

- Manual, using the ScratchProject with a `PrintPreviewControl` set to `ForeColor = Color.White`.
- Unit tests added for default ForeColor value, `ShouldSerializeForeColor` behavior with default and non-default values.

## Test environment(s)

- 11.0.100-preview.3.26170.106

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14424)