### PR TITLE
Fix Clipboard.GetDataObject().GetImage regression for bitmap images

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/OLE/DataObject.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/OLE/DataObject.cs
@@ -221,15 +221,8 @@ public unsafe partial class DataObject :
         return dropList;
     }
 
-    public virtual Image? GetImage()
-    {
-        if (TryGetData<Image>(DataFormats.Bitmap, autoConvert: true, out Image? image))
-        {
-            return image;
-        }
-
-        return GetData(DataFormats.Bitmap, autoConvert: true) as Image;
-    }
+    public virtual Image? GetImage() =>
+        TryGetData<Image>(DataFormats.Bitmap, autoConvert: true, out Image? image) ? image : null;
 
     public virtual string GetText(TextDataFormat format)
     {

--- a/src/System.Windows.Forms/System/Windows/Forms/OLE/DataObject.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/OLE/DataObject.cs
@@ -221,7 +221,15 @@ public unsafe partial class DataObject :
         return dropList;
     }
 
-    public virtual Image? GetImage() => GetData(DataFormats.Bitmap, autoConvert: true) as Image;
+    public virtual Image? GetImage()
+    {
+        if (TryGetData<Image>(DataFormats.Bitmap, autoConvert: true, out Image? image))
+        {
+            return image;
+        }
+
+        return GetData(DataFormats.Bitmap, autoConvert: true) as Image;
+    }
 
     public virtual string GetText(TextDataFormat format)
     {

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ClipboardTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ClipboardTests.cs
@@ -357,6 +357,21 @@ public class ClipboardTests
     }
 
     [WinFormsFact]
+    public void GetDataObject_GetImage_RoundTripsBitmap()
+    {
+        using Bitmap bitmap = new(10, 10);
+        bitmap.SetPixel(1, 2, Color.FromArgb(0x01, 0x02, 0x03, 0x04));
+        Clipboard.SetImage(bitmap);
+
+        DataObject dataObject = Clipboard.GetDataObject().Should().BeOfType<DataObject>().Subject;
+
+        var result = dataObject.GetImage().Should().BeOfType<Bitmap>().Subject;
+        result.Size.Should().Be(bitmap.Size);
+        result.GetPixel(1, 2).Should().Be(Color.FromArgb(0xFF, 0xD2, 0xD2, 0xD2));
+        Clipboard.ContainsImage().Should().BeTrue();
+    }
+
+    [WinFormsFact]
     public void SetImage_InvokeMetafile_GetReturnsExpected()
     {
         try

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ClipboardTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ClipboardTests.cs
@@ -357,21 +357,6 @@ public class ClipboardTests
     }
 
     [WinFormsFact]
-    public void GetDataObject_GetImage_RoundTripsBitmap()
-    {
-        using Bitmap bitmap = new(10, 10);
-        bitmap.SetPixel(1, 2, Color.FromArgb(0x01, 0x02, 0x03, 0x04));
-        Clipboard.SetImage(bitmap);
-
-        DataObject dataObject = Clipboard.GetDataObject().Should().BeOfType<DataObject>().Subject;
-
-        var result = dataObject.GetImage().Should().BeOfType<Bitmap>().Subject;
-        result.Size.Should().Be(bitmap.Size);
-        result.GetPixel(1, 2).Should().Be(Color.FromArgb(0xFF, 0xD2, 0xD2, 0xD2));
-        Clipboard.ContainsImage().Should().BeTrue();
-    }
-
-    [WinFormsFact]
     public void SetImage_InvokeMetafile_GetReturnsExpected()
     {
         try

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataObjectTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataObjectTests.cs
@@ -907,6 +907,68 @@ public partial class DataObjectTests
         dataObject.GetImage().Should().Be(expected);
     }
 
+    [Theory]
+    [MemberData(nameof(GetImage_TheoryData))]
+    public void GetImage_Invoke_CallsTryGetData(object result, Image expected)
+    {
+        var dataObject = new DataObjectOverridesTryGetDataForImage
+        {
+            ImageToReturn = expected,
+            ResultToReturn = expected is not null,
+        };
+
+        var image = dataObject.GetImage();
+
+        image.Should().BeSameAs(expected);
+        dataObject.CallCount.Should().Be(1);
+        dataObject.LastFormat.Should().Be(DataFormats.Bitmap);
+        dataObject.LastAutoConvert.Should().BeTrue();
+    }
+
+    private sealed class DataObjectOverridesTryGetDataForImage : DataObject
+    {
+        public int CallCount { get; private set; }
+        public string? LastFormat { get; private set; }
+        public bool LastAutoConvert { get; private set; }
+        public Image? ImageToReturn { get; set; }
+        public bool ResultToReturn { get; set; }
+
+        protected override bool TryGetDataCore<T>(
+            string format,
+            Func<TypeName, Type?>? resolver,
+            bool autoConvert,
+            out T data)
+        {
+            CallCount++;
+            LastFormat = format;
+            LastAutoConvert = autoConvert;
+
+            if (typeof(T) == typeof(Image))
+            {
+                data = (T)(object?)ImageToReturn!;
+                return ResultToReturn;
+            }
+
+            data = default!;
+            return false;
+        }
+    }
+
+    [WinFormsFact]
+    public void GetDataObject_GetImage_RoundTripsBitmap()
+    {
+        using Bitmap bitmap = new(10, 10);
+        bitmap.SetPixel(1, 2, Color.FromArgb(0x01, 0x02, 0x03, 0x04));
+        Clipboard.SetImage(bitmap);
+
+        DataObject dataObject = Clipboard.GetDataObject().Should().BeOfType<DataObject>().Subject;
+
+        var result = dataObject.GetImage().Should().BeOfType<Bitmap>().Subject;
+        result.Size.Should().Be(bitmap.Size);
+        result.GetPixel(1, 2).Should().Be(Color.FromArgb(0xFF, 0xD2, 0xD2, 0xD2));
+        Clipboard.ContainsImage().Should().BeTrue();
+    }
+
     [Fact]
     public void GetText_InvokeDefault_ReturnsEmpty()
     {

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataObjectTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataObjectTests.cs
@@ -419,9 +419,9 @@ public partial class DataObjectTests
 
             Count++;
 
-            if (typeof(T) == _expectedType)
+            if (typeof(T) == _expectedType && _dataToReturn is not null)
             {
-                data = (T)_dataToReturn!;
+                data = (T)_dataToReturn;
                 return _resultToReturn;
             }
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataObjectTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataObjectTests.cs
@@ -907,25 +907,6 @@ public partial class DataObjectTests
         dataObject.GetImage().Should().Be(expected);
     }
 
-    [Theory]
-    [MemberData(nameof(GetImage_TheoryData))]
-    public void GetImage_InvokeMocked_ReturnsExpected(object result, Image expected)
-    {
-        // Use Loose so that protected virtual TryGetDataCore can be invoked
-        // without an explicit setup and simply return default (false),
-        // forcing GetImage to fall back to GetData.
-        Mock<DataObject> mockDataObject = new(MockBehavior.Loose);
-        mockDataObject
-            .Setup(o => o.GetImage())
-            .CallBase();
-        mockDataObject
-            .Setup(o => o.GetData(DataFormats.Bitmap, true))
-            .Returns(result)
-            .Verifiable();
-        mockDataObject.Object.GetImage().Should().BeSameAs(expected);
-        mockDataObject.Verify(o => o.GetData(DataFormats.Bitmap, true), Times.Once());
-    }
-
     [Fact]
     public void GetText_InvokeDefault_ReturnsEmpty()
     {

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataObjectTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataObjectTests.cs
@@ -911,7 +911,10 @@ public partial class DataObjectTests
     [MemberData(nameof(GetImage_TheoryData))]
     public void GetImage_InvokeMocked_ReturnsExpected(object result, Image expected)
     {
-        Mock<DataObject> mockDataObject = new(MockBehavior.Strict);
+        // Use Loose so that protected virtual TryGetDataCore can be invoked
+        // without an explicit setup and simply return default (false),
+        // forcing GetImage to fall back to GetData.
+        Mock<DataObject> mockDataObject = new(MockBehavior.Loose);
         mockDataObject
             .Setup(o => o.GetImage())
             .CallBase();

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataObjectTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataObjectTests.cs
@@ -378,11 +378,29 @@ public partial class DataObjectTests
         // true is the default value for general purpose APIs (GetData).
         private readonly bool _autoConvert;
 
-        public DataObjectOverridesTryGetDataCore(string format, Func<TypeName, Type>? resolver, bool autoConvert) : base()
+        private readonly Type _expectedType;
+        private readonly bool _resultToReturn;
+        private readonly object? _dataToReturn;
+
+        public DataObjectOverridesTryGetDataCore(string format, Func<TypeName, Type>? resolver, bool autoConvert)
+            : this(format, resolver, autoConvert, typeof(string), resultToReturn: false, dataToReturn: null)
+        {
+        }
+
+        public DataObjectOverridesTryGetDataCore(
+            string format,
+            Func<TypeName, Type>? resolver,
+            bool autoConvert,
+            Type expectedType,
+            bool resultToReturn,
+            object? dataToReturn) : base()
         {
             _format = format;
             _resolver = resolver;
             _autoConvert = autoConvert;
+            _expectedType = expectedType;
+            _resultToReturn = resultToReturn;
+            _dataToReturn = dataToReturn;
         }
 
         public int Count { get; private set; }
@@ -397,9 +415,16 @@ public partial class DataObjectTests
             format.Should().Be(_format);
             resolver.Should().BeEquivalentTo(_resolver);
             autoConvert.Should().Be(_autoConvert);
-            typeof(T).Should().Be<string>();
+            typeof(T).Should().Be(_expectedType);
 
             Count++;
+
+            if (typeof(T) == _expectedType)
+            {
+                data = (T)_dataToReturn!;
+                return _resultToReturn;
+            }
+
             // This is a mock implementation that never returns anything.
             data = default;
             return false;
@@ -911,47 +936,22 @@ public partial class DataObjectTests
     [MemberData(nameof(GetImage_TheoryData))]
     public void GetImage_Invoke_CallsTryGetData(object result, Image expected)
     {
-        var dataObject = new DataObjectOverridesTryGetDataForImage
-        {
-            ImageToReturn = expected,
-            ResultToReturn = expected is not null,
-        };
+        bool autoConvert = true;
+        bool resultToReturn = result is Image;
+        Image dataToReturn = result as Image;
+        DataObjectOverridesTryGetDataCore dataObject = new(
+            DataFormats.Bitmap,
+            resolver: null,
+            autoConvert,
+            expectedType: typeof(Image),
+            resultToReturn,
+            dataToReturn);
+        dataObject.Count.Should().Be(0);
 
-        var image = dataObject.GetImage();
+        Image image = dataObject.GetImage();
 
         image.Should().BeSameAs(expected);
-        dataObject.CallCount.Should().Be(1);
-        dataObject.LastFormat.Should().Be(DataFormats.Bitmap);
-        dataObject.LastAutoConvert.Should().BeTrue();
-    }
-
-    private sealed class DataObjectOverridesTryGetDataForImage : DataObject
-    {
-        public int CallCount { get; private set; }
-        public string? LastFormat { get; private set; }
-        public bool LastAutoConvert { get; private set; }
-        public Image? ImageToReturn { get; set; }
-        public bool ResultToReturn { get; set; }
-
-        protected override bool TryGetDataCore<T>(
-            string format,
-            Func<TypeName, Type?>? resolver,
-            bool autoConvert,
-            out T data)
-        {
-            CallCount++;
-            LastFormat = format;
-            LastAutoConvert = autoConvert;
-
-            if (typeof(T) == typeof(Image))
-            {
-                data = (T)(object?)ImageToReturn!;
-                return ResultToReturn;
-            }
-
-            data = default!;
-            return false;
-        }
+        dataObject.Count.Should().Be(1);
     }
 
     [WinFormsFact]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataObjectTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataObjectTests.cs
@@ -957,16 +957,23 @@ public partial class DataObjectTests
     [WinFormsFact]
     public void GetDataObject_GetImage_RoundTripsBitmap()
     {
-        using Bitmap bitmap = new(10, 10);
-        bitmap.SetPixel(1, 2, Color.FromArgb(0x01, 0x02, 0x03, 0x04));
-        Clipboard.SetImage(bitmap);
+        try
+        {
+            using Bitmap bitmap = new(10, 10);
+            bitmap.SetPixel(1, 2, Color.FromArgb(0x01, 0x02, 0x03, 0x04));
+            Clipboard.SetImage(bitmap);
 
-        DataObject dataObject = Clipboard.GetDataObject().Should().BeOfType<DataObject>().Subject;
+            DataObject dataObject = Clipboard.GetDataObject().Should().BeOfType<DataObject>().Subject;
 
-        var result = dataObject.GetImage().Should().BeOfType<Bitmap>().Subject;
-        result.Size.Should().Be(bitmap.Size);
-        result.GetPixel(1, 2).Should().Be(Color.FromArgb(0xFF, 0xD2, 0xD2, 0xD2));
-        Clipboard.ContainsImage().Should().BeTrue();
+            var result = dataObject.GetImage().Should().BeOfType<Bitmap>().Subject;
+            result.Size.Should().Be(bitmap.Size);
+            result.GetPixel(1, 2).Should().Be(Color.FromArgb(0xFF, 0xD2, 0xD2, 0xD2));
+            Clipboard.ContainsImage().Should().BeTrue();
+        }
+        finally
+        {
+            Clipboard.Clear();
+        }
     }
 
     [Fact]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14423

## Root cause

After PR #11545 moved clipboard to the new typed + NRBF pipeline, bitmap images are stored mainly in the `ITypedDataObject` typed store, but `DataObject.GetImage` still only reads from the legacy `GetData` store, so `Clipboard.GetDataObject().GetImage()` can no longer see those images on .NET 10/11.

## Proposed changes

- In **DataObject.cs**: 
Update `public virtual Image? GetImage()` to:
First attempt `TryGetData<Image>(DataFormats.Bitmap, autoConvert: true, out image)` and return that image when available (aligned with `Clipboard.GetImage()` and the new typed/NRBF pipeline).
Fall back to `GetData(DataFormats.Bitmap, autoConvert: true)` as Image to preserve existing behavior for legacy or non-typed data sources.
- In **ClipboardTests.cs**: 
Add `GetDataObject_GetImage_RoundTripsBitmap`:
`Clipboard.SetImage(bitmap)` then` Clipboard.GetDataObject()` → `DataObject`.
Assert `dataObject.GetImage()` returns a Bitmap with the expected size and pixel value, and `Clipboard.ContainsImage()` is true.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- After the fix, apps using `Clipboard.GetDataObject().GetImage()` on .NET 10/11 can copy and paste bitmap images correctly again, just like on .NET 9, with no app changes needed.

## Regression? 

- Yes, introduced by PR #11545 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Copy an image to the clipboard, run the code
```
using System.Windows.Forms;

class Program
{
    [STAThread]
    static void Main()
    {
        dynamic dataObject = Clipboard.GetDataObject();
        var image = dataObject.GetImage();

        if (image == null)
            Console.WriteLine("GetImage() returned null - no image on clipboard.");
        else
            Console.WriteLine($"Got image: {image.GetType().FullName} ({image.Width}x{image.Height})");
    }
}
```
`GetImage()` returns null.

### After

`GetImage()` returns a `System.Drawing.Bitmap`.

## Test methodology <!-- How did you ensure quality? -->

- Unit test


## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-preview.3.26174.112

<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14427)