### PR TITLE
Fix PropertyGrid Tab navigation regression caused by ToolStrip keyboard focus changes

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridToolStrip.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridToolStrip.cs
@@ -35,8 +35,7 @@ internal partial class PropertyGridToolStrip : ToolStrip
 
     /// <summary>
     ///  Overrides WndProc to avoid keeping this inner ToolStrip as the active ToolStrip
-    ///  in ModalMenuFilter when it receives focus. This isolates PropertyGrid keyboard
-    ///  navigation from global ToolStrip menu mode handling introduced in PR #13034.
+    ///  in ModalMenuFilter when it receives focus. 
     /// </summary>
     /// <param name="m">The window message to process.</param>
     protected override void WndProc(ref Message m)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridToolStrip.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridToolStrip.cs
@@ -32,4 +32,27 @@ internal partial class PropertyGridToolStrip : ToolStrip
     /// <returns>The accessibility object for this control.</returns>
     protected override AccessibleObject CreateAccessibilityInstance()
         => new PropertyGridToolStripAccessibleObject(this, _parentPropertyGrid);
+
+    /// <summary>
+    ///  Overrides WndProc to avoid keeping this inner ToolStrip as the active ToolStrip
+    ///  in ModalMenuFilter when it receives focus. This isolates PropertyGrid keyboard
+    ///  navigation from global ToolStrip menu mode handling introduced in PR #13034.
+    /// </summary>
+    /// <param name="m">The window message to process.</param>
+    protected override void WndProc(ref Message m)
+    {
+        base.WndProc(ref m);
+
+        if (m.MsgInternal == PInvokeCore.WM_SETFOCUS)
+        {
+            bool exitMenuMode = ToolStripManager.ModalMenuFilter.GetActiveToolStrip() == this;
+
+            ToolStripManager.ModalMenuFilter.RemoveActiveToolStrip(this);
+
+            if (exitMenuMode && ToolStripManager.ModalMenuFilter.GetActiveToolStrip() is null)
+            {
+                ToolStripManager.ModalMenuFilter.ExitMenuMode();
+            }
+        }
+    }
 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridToolStrip.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGridToolStrip.cs
@@ -35,7 +35,7 @@ internal partial class PropertyGridToolStrip : ToolStrip
 
     /// <summary>
     ///  Overrides WndProc to avoid keeping this inner ToolStrip as the active ToolStrip
-    ///  in ModalMenuFilter when it receives focus. 
+    ///  in ModalMenuFilter when it receives focus.
     /// </summary>
     /// <param name="m">The window message to process.</param>
     protected override void WndProc(ref Message m)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14421

## Root cause

- PR [13034 ](https://github.com/dotnet/winforms/pull/13034) changed `ToolStrip` so that whenever a `ToolStrip` receives focus (`WM_SETFOCUS`), it becomes the active ToolStrip in `ToolStripManager.ModalMenuFilter`.
- For normal top-level menu/toolbar strips this is desired (to fix [12916](https://github.com/dotnet/winforms/issues/12916)), but for the inner `PropertyGridToolStrip `it means:
   - Entering / staying in menu mode when focus moves to the `PropertyGrid `toolbar.
   - Dialog-level focus routing and Tab handling start to respect this active ToolStrip state.
- With a `PropertyGrid` on the form, this extra menu-mode/ActiveToolStrip state causes the second and subsequent Tab cycles to be biased toward the PropertyGrid and its toolbar, so some sibling controls (e.g. Button, ComboBox) are skipped — a regression vs .NET Framework and .NET 8/9.

## Proposed changes

- In `PropertyGridToolStrip` (the inner ToolStrip used by PropertyGrid), override` WndProc` and, on `WM_SETFOCUS`, remove this ToolStrip from `ToolStripManager.ModalMenuFilter’s` active ToolStrip list and exit menu mode if it was the active one.
- This isolates PropertyGrid’s internal toolbar from the global menu-mode / ActiveToolStrip mechanics introduced in PR [13034 ](https://github.com/dotnet/winforms/pull/13034), while leaving all other ToolStrips (including the ones involved in [12916](https://github.com/dotnet/winforms/issues/12916)) using the existing behavior unchanged.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- PropertyGrid no longer interferes with the form’s Tab cycle, all TabStop controls (Buttons, ComboBox, PropertyGrid, etc.) are visited in order on every Tab cycle

## Regression? 

- Yes 

## Risk

- minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
- First Tab cycle: all controls are reachable ✔
- Second and subsequent cycles:
> Some controls (e.g., ComboBox, one Button) are skipped ❌
> Focus repeatedly lands on PropertyGrid and a subset of controls ❌

https://github.com/user-attachments/assets/64bc10ff-8743-4910-aaa6-c7209b98cf17


### After
All TabStop controls (Buttons, PropertyGrid, etc.) are visited in order on every Tab cycle

https://github.com/user-attachments/assets/740edd73-910a-4efb-bc4e-3e4cd2986ebf

## Test methodology <!-- How did you ensure quality? -->

- Manually
 

## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-preview.3.26174.112


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14434)