### PR TITLE
Fix issue 14422：PropertyGrid's SelectedTab no longer changes when the SelectedObject is assigned

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
@@ -3710,15 +3710,10 @@ public partial class PropertyGrid : ContainerControl, IComPropertyBrowser, IProp
 
     private bool SelectViewTabButtonDefault(ToolStripButton? button)
     {
-        if (button is null)
-        {
-            return false;
-        }
-
         // Is this tab button checked? If so, do nothing.
         if (button == _selectedTab?.Button)
         {
-            button.Checked = true;
+            button?.Checked = true;
             return true;
         }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
@@ -3750,7 +3750,6 @@ public partial class PropertyGrid : ContainerControl, IComPropertyBrowser, IProp
 
         // Select the first tab if we didn't find that one.
         _selectedTab = _tabs[PropertiesTabIndex];
-        Debug.Assert(_tabs[PropertiesTabIndex].Tab.GetType() == DefaultTabType, "First item is not property tab!");
         SelectViewTabButton(_tabs[PropertiesTabIndex].Button, updateSelection: false);
         return false;
     }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/PropertyGridTests.cs
@@ -2361,6 +2361,20 @@ public partial class PropertyGridTests
     }
 
     [WinFormsFact]
+    public void PropertyGrid_SelectedObject_SetAfterReplacingDefaultTab_UsesCustomTab()
+    {
+        using PropertyGrid control = new();
+        control.PropertyTabs.RemoveTabType(typeof(PropertiesTab));
+        control.PropertyTabs.AddTabType(typeof(ReplacementPropertyTab), PropertyTabScope.Static);
+
+        using Button selectedObject = new();
+        control.SelectedObject = selectedObject;
+
+        Assert.Equal(selectedObject, control.SelectedObject);
+        Assert.IsType<ReplacementPropertyTab>(control.SelectedTab);
+    }
+
+    [WinFormsFact]
     public void PropertyGrid_PropertyTabCollection_AddAndRemoveTabType_Success()
     {
         using PropertyGrid grid = new();
@@ -2380,6 +2394,27 @@ public partial class PropertyGridTests
         public override Bitmap Bitmap => new(10, 10);
 
         public override PropertyDescriptorCollection GetProperties(object component, Attribute[] attributes) => throw new NotImplementedException();
+    }
+
+    private class ReplacementPropertyTab : PropertyTab, IDisposable
+    {
+        private Bitmap _bitmap;
+
+        public override string TabName => "ReplacementPropertyTab";
+
+        public override Bitmap Bitmap => _bitmap ??= new(10, 10);
+
+        public override PropertyDescriptorCollection GetProperties(object component, Attribute[] attributes)
+            => TypeDescriptor.GetProperties(component, attributes);
+
+        public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object component, Attribute[] attributes)
+            => TypeDescriptor.GetProperties(component, attributes);
+
+        public override void Dispose()
+        {
+            _bitmap?.Dispose();
+            base.Dispose();
+        }
     }
 
     [WinFormsFact]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14422 


## Proposed changes

- Removed the null check for ToolStripButton, as it caused a short-circuit in tab state updates, leading to a regression where the selected tab would not switch after SelectedObject was set.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- PropertyGrid's SelectedTab can correctly change when the SelectedObject is assigned.

## Regression? 

- Yes

## Risk

- Min

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
It was expected that only the Text property would be displayed, but instead, all the default properties are shown.
<img width="1057" height="690" alt="image" src="https://github.com/user-attachments/assets/fbd6ae3a-1519-47f1-8e22-92a78f65c71f" />

### After
Successfully only displayed the Text property.
<img width="1057" height="689" alt="image" src="https://github.com/user-attachments/assets/abc08695-58d3-4fe3-b394-f7a3cb77c928" />


## Test methodology <!-- How did you ensure quality? -->

- Manual, Test Instance: [PropertyGridSelectedTabRegression](https://github.com/chirndlerks/PropertyGridSelectedTabRegression)
 

## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.100-preview.3.26170.106


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14438)