### PR TITLE
Updating TFM for .NET Framework assembly from net472 to net481

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,7 @@
     <Copyright>$(CopyrightNetFoundation)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/dotnet/winforms</PackageProjectUrl>
+    <NetFxTFM>net481</NetFxTFM>
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
     <LangVersion Condition="'$(LangVersion)' == ''">preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/pkg/Microsoft.Private.Windows.Core/Microsoft.Private.Windows.Core.Package.csproj
+++ b/pkg/Microsoft.Private.Windows.Core/Microsoft.Private.Windows.Core.Package.csproj
@@ -49,8 +49,8 @@
 
   <PropertyGroup>
     <_SourceProjectName>Microsoft.Private.Windows.Core</_SourceProjectName>
-    <_SourceRefDir>$(ArtifactsObjDir)$(_SourceProjectName)\$(Configuration)\net472\ref\</_SourceRefDir>
-    <_SourceBinDir>$(ArtifactsBinDir)$(_SourceProjectName)\$(Configuration)\net472\</_SourceBinDir>
+    <_SourceRefDir>$(ArtifactsObjDir)$(_SourceProjectName)\$(Configuration)\$(NetFxTFM)\ref\</_SourceRefDir>
+    <_SourceBinDir>$(ArtifactsBinDir)$(_SourceProjectName)\$(Configuration)\$(NetFxTFM)\</_SourceBinDir>
 
     <!-- Call custom target when creating the package -->
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddPackageContent</TargetsForTfmSpecificContentInPackage>
@@ -59,8 +59,8 @@
   <!-- Include implementation and reference assemblies in the package -->
   <Target Name="AddPackageContent">
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(_SourceBinDir)$(_SourceProjectName).dll" PackagePath="lib/net472" />
-      <TfmSpecificPackageFile Include="$(_SourceRefDir)$(_SourceProjectName).dll" PackagePath="ref/net472" />
+      <TfmSpecificPackageFile Include="$(_SourceBinDir)$(_SourceProjectName).dll" PackagePath="lib/$(NetFxTFM)" />
+      <TfmSpecificPackageFile Include="$(_SourceRefDir)$(_SourceProjectName).dll" PackagePath="ref/$(NetFxTFM)" />
     </ItemGroup>
   </Target>
 

--- a/pkg/Microsoft.Private.Windows.Core/Microsoft.Private.Windows.Core.Package.csproj
+++ b/pkg/Microsoft.Private.Windows.Core/Microsoft.Private.Windows.Core.Package.csproj
@@ -5,7 +5,7 @@
   -->
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>$(NetFxTFM)</TargetFramework>
 
     <!-- Suppress some nuget warnings that are breaking our build until https://github.com/dotnet/arcade/issues/4337 is resolved -->
     <NoWarn>$(NoWarn);NU5100;NU5131;NU5128</NoWarn>

--- a/src/System.Private.Windows.Core/src/Microsoft.Private.Windows.Core.csproj
+++ b/src/System.Private.Windows.Core/src/Microsoft.Private.Windows.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>Microsoft.Private.Windows.Core</AssemblyName>
-    <TargetFrameworks>net472</TargetFrameworks>
+    <TargetFrameworks>$(NetFxTFM)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <!--

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System.Windows.Forms.Design.Tests.csproj
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System.Windows.Forms.Design.Tests.csproj
@@ -57,10 +57,10 @@
 
   <ItemGroup>
     <Reference Include="AxInterop.WMPLib">
-      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\net472\AxInterop.WMPLib.dll</HintPath>
+      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\$(NetFxTFM)\AxInterop.WMPLib.dll</HintPath>
     </Reference>
     <Reference Include="Interop.WMPLib">
-      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\net472\Interop.WMPLib.dll</HintPath>
+      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\$(NetFxTFM)\Interop.WMPLib.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/src/test/integration/WinformsControlsTest/WinformsControlsTest.csproj
+++ b/src/test/integration/WinformsControlsTest/WinformsControlsTest.csproj
@@ -131,10 +131,10 @@
 
   <ItemGroup>
     <Reference Include="AxInterop.WMPLib">
-      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\net472\AxInterop.WMPLib.dll</HintPath>
+      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\$(NetFxTFM)\AxInterop.WMPLib.dll</HintPath>
     </Reference>
     <Reference Include="Interop.WMPLib">
-      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\net472\Interop.WMPLib.dll</HintPath>
+      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\$(NetFxTFM)\Interop.WMPLib.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/src/test/unit/.NET Framework/AxHosts/AxHosts.csproj
+++ b/src/test/unit/.NET Framework/AxHosts/AxHosts.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>$(NetFxTFM)</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <LangVersion>10</LangVersion>

--- a/src/test/unit/.NET Framework/UnsupportedTypes/UnsupportedTypes.csproj
+++ b/src/test/unit/.NET Framework/UnsupportedTypes/UnsupportedTypes.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>$(NetFxTFM)</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <LangVersion>preview</LangVersion>

--- a/src/test/unit/System.Windows.Forms/ComDisabled/ComDisabled.Tests.csproj
+++ b/src/test/unit/System.Windows.Forms/ComDisabled/ComDisabled.Tests.csproj
@@ -27,19 +27,19 @@
 
   <ItemGroup>
     <Reference Include="AxInterop.WMPLib">
-      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\net472\AxInterop.WMPLib.dll</HintPath>
+      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\$(NetFxTFM)\AxInterop.WMPLib.dll</HintPath>
     </Reference>
     <Reference Include="Interop.WMPLib">
-      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\net472\Interop.WMPLib.dll</HintPath>
+      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\$(NetFxTFM)\Interop.WMPLib.dll</HintPath>
     </Reference>
   </ItemGroup>
 
   <ItemGroup>
     <Reference Include="AxInterop.SystemMonitor">
-      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\net472\AxInterop.SystemMonitor.dll</HintPath>
+      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\$(NetFxTFM)\AxInterop.SystemMonitor.dll</HintPath>
     </Reference>
     <Reference Include="Interop.SystemMonitor">
-      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\net472\Interop.SystemMonitor.dll</HintPath>
+      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\$(NetFxTFM)\Interop.SystemMonitor.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/src/test/unit/System.Windows.Forms/System.Windows.Forms.Tests.csproj
+++ b/src/test/unit/System.Windows.Forms/System.Windows.Forms.Tests.csproj
@@ -47,34 +47,34 @@
 
   <ItemGroup>
     <Reference Include="AxInterop.WMPLib">
-      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\net472\AxInterop.WMPLib.dll</HintPath>
+      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\$(NetFxTFM)\AxInterop.WMPLib.dll</HintPath>
     </Reference>
     <Reference Include="Interop.WMPLib">
-      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\net472\Interop.WMPLib.dll</HintPath>
+      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\$(NetFxTFM)\Interop.WMPLib.dll</HintPath>
     </Reference>
   </ItemGroup>
 
   <ItemGroup>
     <Reference Include="AxInterop.SystemMonitor">
-      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\net472\AxInterop.SystemMonitor.dll</HintPath>
+      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\$(NetFxTFM)\AxInterop.SystemMonitor.dll</HintPath>
     </Reference>
     <Reference Include="Interop.SystemMonitor">
-      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\net472\Interop.SystemMonitor.dll</HintPath>
+      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\$(NetFxTFM)\Interop.SystemMonitor.dll</HintPath>
     </Reference>
   </ItemGroup>
 
   <ItemGroup>
     <Reference Include="AxInterop.SHDocVw">
-      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\net472\AxInterop.SHDocVw.dll</HintPath>
+      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\$(NetFxTFM)\AxInterop.SHDocVw.dll</HintPath>
     </Reference>
     <Reference Include="Interop.SHDocVw">
-      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\net472\Interop.SHDocVw.dll</HintPath>
+      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\$(NetFxTFM)\Interop.SHDocVw.dll</HintPath>
     </Reference>
   </ItemGroup>
 
   <ItemGroup>
     <Reference Include="UnsupportedTypes">
-      <HintPath>$(ArtifactsBinDir)\UnsupportedTypes\$(Configuration)\net472\UnsupportedTypes.dll</HintPath>
+      <HintPath>$(ArtifactsBinDir)\UnsupportedTypes\$(Configuration)\$(NetFxTFM)\UnsupportedTypes.dll</HintPath>
     </Reference>
   </ItemGroup>
 


### PR DESCRIPTION
Added a new `NetFxTFM` property set to `net481` in `Directory.build.props` and referencing that in the required .NET Framework projects.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14450)