### PR TITLE
Fix issue 14449: ToolStrip DPI change issue in .NET 10

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Control.cs
@@ -11583,6 +11583,7 @@ public unsafe partial class Control :
 
         Font localFont = GetCurrentFontAndDpi(out int fontDpi);
         DeviceDpiInternal = newDeviceDpi;
+        OriginalDeviceDpiInternal = oldDeviceDpi;
 
         if (fontDpi == DeviceDpiInternal)
         {
@@ -11615,7 +11616,7 @@ public unsafe partial class Control :
             // This flag is reset when scaling is done on Container in "OnParentFontChanged".
             container?.IsDpiChangeScalingRequired = true;
 
-            RescaleConstantsForDpi(oldDeviceDpi, DeviceDpiInternal);
+            RescaleConstantsForDpi(OriginalDeviceDpiInternal, DeviceDpiInternal);
         }
 
         OnDpiChangedBeforeParent(EventArgs.Empty);

--- a/src/System.Windows.Forms/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Control.cs
@@ -469,7 +469,9 @@ public unsafe partial class Control :
     {
         get
         {
-            return s_originalDeviceDpiInternal;
+            return Properties.GetValueOrDefault(
+                s_originalDeviceDpiInternal,
+                DeviceDpiInternal);
         }
 
         set
@@ -11562,6 +11564,7 @@ public unsafe partial class Control :
         DefWndProc(ref m);
 
         OriginalDeviceDpiInternal = DeviceDpiInternal;
+        int oldDeviceDpi = DeviceDpiInternal;
 
         // In order to support tests, will be querying Dpi from the message first.
         int newDeviceDpi = (short)m.WParamInternal.LOWORD;
@@ -11612,7 +11615,7 @@ public unsafe partial class Control :
             // This flag is reset when scaling is done on Container in "OnParentFontChanged".
             container?.IsDpiChangeScalingRequired = true;
 
-            RescaleConstantsForDpi(OriginalDeviceDpiInternal, DeviceDpiInternal);
+            RescaleConstantsForDpi(oldDeviceDpi, DeviceDpiInternal);
         }
 
         OnDpiChangedBeforeParent(EventArgs.Empty);

--- a/src/System.Windows.Forms/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Control.cs
@@ -11563,6 +11563,7 @@ public unsafe partial class Control :
     {
         DefWndProc(ref m);
 
+        // Cache the current DPI before updating DeviceDpiInternal.
         OriginalDeviceDpiInternal = DeviceDpiInternal;
         int oldDeviceDpi = DeviceDpiInternal;
 
@@ -11583,6 +11584,7 @@ public unsafe partial class Control :
 
         Font localFont = GetCurrentFontAndDpi(out int fontDpi);
         DeviceDpiInternal = newDeviceDpi;
+        // Preserve the old DPI as the "original" DPI for subsequent scaling logic.
         OriginalDeviceDpiInternal = oldDeviceDpi;
 
         if (fontDpi == DeviceDpiInternal)

--- a/src/System.Windows.Forms/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Control.cs
@@ -469,9 +469,7 @@ public unsafe partial class Control :
     {
         get
         {
-            return Properties.GetValueOrDefault(
-                s_originalDeviceDpiInternal,
-                DeviceDpiInternal);
+            return s_originalDeviceDpiInternal;
         }
 
         set

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ControlTests.Internals.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ControlTests.Internals.cs
@@ -421,4 +421,41 @@ public partial class ControlTests
             Assert.NotNull(control.TestAccessor.Dynamic.ReflectParent);
         }
     }
+
+    [WinFormsFact]
+    public void Control_WndProc_WmDpiChangedBeforeParent_DpiChanged_RescaleConstantsForDpiReceivesDistinctValues()
+    {
+        using IDisposable dpiScope = ScaleHelper.EnterDpiAwarenessScope(DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+        using DpiRescaleTrackingControl control = new();
+        Assert.NotEqual(IntPtr.Zero, control.Handle);
+
+        int newDpi = control.DeviceDpi == 96 ? 120 : 96;
+        Message message = Message.Create((HWND)control.Handle, PInvokeCore.WM_DPICHANGED_BEFOREPARENT, (WPARAM)newDpi, (LPARAM)0);
+
+        control.WndProc(ref message);
+
+        Assert.Equal(1, control.RescaleConstantsForDpiCallCount);
+        Assert.Equal(newDpi, control.DeviceDpiNew);
+        Assert.NotEqual(control.DeviceDpiOld, control.DeviceDpiNew);
+    }
+
+    private sealed class DpiRescaleTrackingControl : Control
+    {
+        public int DeviceDpiOld { get; private set; }
+
+        public int DeviceDpiNew { get; private set; }
+
+        public int RescaleConstantsForDpiCallCount { get; private set; }
+
+        protected override void RescaleConstantsForDpi(int deviceDpiOld, int deviceDpiNew)
+        {
+            DeviceDpiOld = deviceDpiOld;
+            DeviceDpiNew = deviceDpiNew;
+            RescaleConstantsForDpiCallCount++;
+
+            base.RescaleConstantsForDpi(deviceDpiOld, deviceDpiNew);
+        }
+
+        public new void WndProc(ref Message m) => base.WndProc(ref m);
+    }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14449 

This issue was introduced by PR [#13582](https://github.com/dotnet/winforms/pull/13582), when we drag the ToolStrip control on screens with different DPI settings, the call stack history is [WmDpiChangedBeforeParent](https://github.com/dotnet/winforms/blob/5d71425a3fecf8f72a57679b53bd2b5035ca0059/src/System.Windows.Forms/System/Windows/Forms/Control.cs#L11562) -> [RescaleConstantsForDpi](https://github.com/dotnet/winforms/blob/5d71425a3fecf8f72a57679b53bd2b5035ca0059/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs#L3725). However, within the WmDpiChangedBeforeParent method, [OriginalDeviceDpiInternal](https://github.com/dotnet/winforms/blob/5d71425a3fecf8f72a57679b53bd2b5035ca0059/src/System.Windows.Forms/System/Windows/Forms/Control.cs#L470-L475) and DeviceDpiInternal retrieve the same value, which will cause the RescaleConstantsForDpi method in the ToolStrip class to fail to execute as expected.

## Proposed changes

-  OriginalDeviceDpiInternal = DeviceDpiInternal; is effectively a no-op in the common case: the setter uses DeviceDpiInternal as the default value to remove the stored property, so after DeviceDpiInternal is updated later in this method, OriginalDeviceDpiInternal will again resolve to the new DPI. This means other code that relies on OriginalDeviceDpiInternal != DeviceDpiInternal during/after the DPI-change path will still observe them as equal. So consider capturing oldDeviceDpi first, updating DeviceDpiInternal to the new DPI, and then assigning OriginalDeviceDpiInternal = oldDeviceDpi so it is persisted (mirroring how Form sets OriginalDeviceDpiInternal = e.DeviceDpiOld).

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- ToolStrip DPI change correctly in .NET 10.

## Regression? 

- Yes

## Risk

-Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<img width="420" height="228" alt="image" src="https://github.com/user-attachments/assets/4e4fd80b-508f-45a5-b162-8d449822e848" />

### After

<img width="495" height="326" alt="image" src="https://github.com/user-attachments/assets/7f852860-6de8-47b5-825f-23617772549e" />
<img width="1258" height="790" alt="image" src="https://github.com/user-attachments/assets/d2380fe4-9467-469f-8740-cabca91657a8" />



## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.100-preview.3.26170.106


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14454)