### PR TITLE
Fix issue 14458: Clipboard.GetText(TextDataFormat.Rtf) does not retrieve RTF that lacks a null terminating character

### DIFF
--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/Composition.NativeToManagedAdapter.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/Composition.NativeToManagedAdapter.cs
@@ -245,20 +245,33 @@ internal unsafe partial class Composition<TOleServices, TNrbfSerializer, TDataFo
         private static unsafe string ReadRegisteredFormatStringFromHGLOBAL(HGLOBAL hglobal, Encoding encoding)
         {
             void* buffer = PInvokeCore.GlobalLock(hglobal);
-            if (buffer is null) throw new Win32Exception();
+            if (buffer is null)
+            {
+                throw new Win32Exception();
+            }
+
             try
             {
                 int size = checked((int)PInvokeCore.GlobalSize(hglobal));
-                if (size == 0) throw new Win32Exception();
+                if (size == 0)
+                {
+                    throw new Win32Exception();
+                }
+
                 ReadOnlySpan<byte> bytes = new((byte*)buffer, size);
 
                 // Trim trailing null bytes (optional for registered formats)
                 while (bytes.Length > 0 && bytes[^1] == 0)
+                {
                     bytes = bytes[..^1];
+                }
 
                 return bytes.IsEmpty ? string.Empty : encoding.GetString(bytes);
             }
-            finally { PInvokeCore.GlobalUnlock(hglobal); }
+            finally
+            {
+                PInvokeCore.GlobalUnlock(hglobal);
+            }
         }
 
         private static string ReadUtf8StringFromHGLOBAL(HGLOBAL hglobal)

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/Composition.NativeToManagedAdapter.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/Composition.NativeToManagedAdapter.cs
@@ -197,10 +197,6 @@ internal unsafe partial class Composition<TOleServices, TNrbfSerializer, TDataFo
             //
             // CF_TEXT, CF_OEMTEXT, CF_UNICODETEXT, and CFSTR_FILENAME are supposed to have a null terminator.
             // If we cannot find one in the buffer, assume it is corrupted and return an empty string.
-            //
-            // Can't find the explicit docs for CF_RTF, but we've always treated it as null terminated.
-            // The RichText control itself null terminates but looks like it doesn't require it.
-            // Given our prior and "normal" behavior, we'll continue to expect a null terminator.
 
             try
             {
@@ -260,10 +256,12 @@ internal unsafe partial class Composition<TOleServices, TNrbfSerializer, TDataFo
 
                 ReadOnlySpan<byte> bytes = new((byte*)buffer, size);
 
-                // Trim trailing null bytes (optional for registered formats)
-                while (bytes.Length > 0 && bytes[^1] == 0)
+                // Registered format strings may be null-terminated, but the terminator is optional.
+                // If present, stop at the first null byte rather than decoding the entire allocation.
+                int nullIndex = bytes.IndexOf((byte)0);
+                if (nullIndex >= 0)
                 {
-                    bytes = bytes[..^1];
+                    bytes = bytes[..nullIndex];
                 }
 
                 return bytes.IsEmpty ? string.Empty : encoding.GetString(bytes);

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/Composition.NativeToManagedAdapter.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/Composition.NativeToManagedAdapter.cs
@@ -114,8 +114,8 @@ internal unsafe partial class Composition<TOleServices, TNrbfSerializer, TDataFo
 
             object? value = request.Format switch
             {
-                DataFormatNames.Text or DataFormatNames.Rtf or DataFormatNames.OemText =>
-                    ReadStringFromHGLOBAL(hglobal, unicode: false),
+                DataFormatNames.Text or DataFormatNames.OemText => ReadStringFromHGLOBAL(hglobal, unicode: false),
+                DataFormatNames.Rtf => ReadRegisteredFormatStringFromHGLOBAL(hglobal, Encoding.Default),
                 DataFormatNames.Html or DataFormatNames.Xaml => ReadUtf8StringFromHGLOBAL(hglobal),
                 DataFormatNames.UnicodeText => ReadStringFromHGLOBAL(hglobal, unicode: true),
                 DataFormatNames.FileDrop => ReadFileListFromHDROP((HDROP)(nint)hglobal),
@@ -240,6 +240,25 @@ internal unsafe partial class Composition<TOleServices, TNrbfSerializer, TDataFo
             {
                 PInvokeCore.GlobalUnlock(hglobal);
             }
+        }
+
+        private static unsafe string ReadRegisteredFormatStringFromHGLOBAL(HGLOBAL hglobal, Encoding encoding)
+        {
+            void* buffer = PInvokeCore.GlobalLock(hglobal);
+            if (buffer is null) throw new Win32Exception();
+            try
+            {
+                int size = checked((int)PInvokeCore.GlobalSize(hglobal));
+                if (size == 0) throw new Win32Exception();
+                ReadOnlySpan<byte> bytes = new((byte*)buffer, size);
+
+                // Trim trailing null bytes (optional for registered formats)
+                while (bytes.Length > 0 && bytes[^1] == 0)
+                    bytes = bytes[..^1];
+
+                return bytes.IsEmpty ? string.Empty : encoding.GetString(bytes);
+            }
+            finally { PInvokeCore.GlobalUnlock(hglobal); }
         }
 
         private static string ReadUtf8StringFromHGLOBAL(HGLOBAL hglobal)

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Private/Windows/Ole/NativeToManagedAdapterTests.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Private/Windows/Ole/NativeToManagedAdapterTests.cs
@@ -4,6 +4,7 @@
 using System.ComponentModel;
 using System.Formats.Nrbf;
 using System.Private.Windows.BinaryFormat;
+
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.System.Com;
@@ -18,6 +19,8 @@ using Composition = System.Private.Windows.Ole.Composition<
     System.Private.Windows.Nrbf.CoreNrbfSerializer,
     System.Private.Windows.Ole.TestFormat>;
 using DataFormats = System.Private.Windows.Ole.DataFormatsCore<System.Private.Windows.Ole.TestFormat>;
+
+using System.Text;
 
 namespace System.Private.Windows.Ole;
 
@@ -103,7 +106,7 @@ public unsafe class NativeToManagedAdapterTests
     public void GetData_RtfWithoutNullTerminator_ReturnsRtfText()
     {
         const string rtf = "{\\rtf1\\ansi Test}";
-        MemoryStream stream = new("{\\rtf1\\ansi Test}"u8.ToArray());
+        MemoryStream stream = new(Encoding.Default.GetBytes(rtf));
         using HGlobalNativeDataObject dataObject = new(stream, (ushort)DataFormats.GetOrAddFormat(DataFormatNames.Rtf).Id);
 
         var composition = Composition.Create(ComHelpers.GetComPointer<IDataObject>(dataObject));

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Private/Windows/Ole/NativeToManagedAdapterTests.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Private/Windows/Ole/NativeToManagedAdapterTests.cs
@@ -99,6 +99,19 @@ public unsafe class NativeToManagedAdapterTests
         data!.TypeName.AssemblyQualifiedName.Should().Be("System.Int32[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
     }
 
+    [Fact]
+    public void GetData_RtfWithoutNullTerminator_ReturnsRtfText()
+    {
+        const string rtf = "{\\rtf1\\ansi Test}";
+        MemoryStream stream = new("{\\rtf1\\ansi Test}"u8.ToArray());
+        using HGlobalNativeDataObject dataObject = new(stream, (ushort)DataFormats.GetOrAddFormat(DataFormatNames.Rtf).Id);
+
+        var composition = Composition.Create(ComHelpers.GetComPointer<IDataObject>(dataObject));
+        object? data = composition.GetData(DataFormatNames.Rtf);
+
+        data.Should().Be(rtf);
+    }
+
 #if NET
     [Fact]
     public void GetData_CustomType_BinaryFormattedJson_AsSerializationRecord()


### PR DESCRIPTION


<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14458 

In ReadStringFromHGLOBAL method requires a null terminator to determine string length. The format dispatch switch groups RTF (a registered format) with CF_TEXT and CF_OEMTEXT (standard formats), routing RTF through this null-termination-required path.Composition.NativeToManagedAdapterReadStringFromHGLOBAL()

When external applications (PowerPoint, etc.) place RTF on the clipboard without a null terminator — which is valid per the Windows clipboard spec — the method returns instead of the actual RTF content.string.Empty

## Proposed changes

- Add a new method ReadRegisteredFormatStringFromHGLOBAL(HGLOBAL, Encoding) to handle the CF_RTF format without a null terminator.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Clipboard.GetText(TextDataFormat.Rtf) can retrieve RTF that lacks a null terminating character.

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<img width="2433" height="1135" alt="image" src="https://github.com/user-attachments/assets/07409e73-9c85-46d3-bfbc-0f7477f3ec23" />

### After

<img width="2424" height="1081" alt="image" src="https://github.com/user-attachments/assets/53452163-07cb-43bd-8842-68e08dd046c9" />


## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.100-preview.3.26170.106


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14461)