### PR TITLE
Fix issue 14471: The WinformsControlTest project exited when clicking Column2 header after clicked the Change DGV font button

### DIFF
--- a/src/test/integration/WinformsControlsTest/DataGridViewTest.cs
+++ b/src/test/integration/WinformsControlsTest/DataGridViewTest.cs
@@ -24,9 +24,9 @@ public partial class DataGridViewTest : Form
         InitializeComponent();
 
         dataGridView1.Rows.Add(new DataGridViewRow() { Visible = false });
-        dataGridView1.Rows.Add("DefaultCellStyle", dataGridView1.DefaultCellStyle.Font.ToString());
-        dataGridView1.Rows.Add("ColumnHeadersDefaultCellStyle", dataGridView1.ColumnHeadersDefaultCellStyle.Font.ToString());
-        dataGridView1.Rows.Add("RowHeadersDefaultCellStyle", dataGridView1.RowHeadersDefaultCellStyle.Font.ToString());
+        dataGridView1.Rows.Add("DefaultCellStyle", dataGridView1.DefaultCellStyle.Font);
+        dataGridView1.Rows.Add("ColumnHeadersDefaultCellStyle", dataGridView1.ColumnHeadersDefaultCellStyle.Font);
+        dataGridView1.Rows.Add("RowHeadersDefaultCellStyle", dataGridView1.RowHeadersDefaultCellStyle.Font);
         column6.Image = Image.FromFile("Images\\SmallA.bmp");
 
         int i = 1;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14471 


## Proposed changes

- Update WinformsControlTest, since Comparer(object? a, object? b) method needs the params neither a nor b implements the System.IComparable interface. -or- a and b are of different types and neither one can handle comparisons with the other.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- WinformsControlTest run correctly.

## Regression? 

- No

## Risk

- Min

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

https://private-user-images.githubusercontent.com/38325459/578436539-549214cb-b478-4f9b-a442-5242054f16d6.mp4?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzYzMTAyMDIsIm5iZiI6MTc3NjMwOTkwMiwicGF0aCI6Ii8zODMyNTQ1OS81Nzg0MzY1MzktNTQ5MjE0Y2ItYjQ3OC00ZjliLWE0NDItNTI0MjA1NGYxNmQ2Lm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjA0MTYlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwNDE2VDAzMjUwMlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWNmZWVjYmY2OGY4YWE5YmY1ZDNkODgzYTc2YjIyNzdmMDg5M2Y3NWI4MWI0NWI0YzIzYTU0MTI4ZDU5MmRkYmQmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JnJlc3BvbnNlLWNvbnRlbnQtdHlwZT12aWRlbyUyRm1wNCJ9.yyjQjqRuJgjuD6Vs4Tqgv1txNBtQE2FA52iwI9gODy8

### After


https://github.com/user-attachments/assets/133ef667-c276-40ad-8369-fe2fb6de298d




## Test methodology <!-- How did you ensure quality? -->

- Manually
 

## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.100-preview.3.26170.106


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14477)