### PR TITLE
Pin System.Formats.Nrbf and its transitive dependencies to 10.0.4 release for .NET Framework

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -74,12 +74,11 @@
     <VsWherePackageVersion>2.6.7</VsWherePackageVersion>
     <!-- Pin transitive dependency to avoid vulnerable 8.0.0 version. -->
     <SystemFormatsAsn1PackageVersion>8.0.1</SystemFormatsAsn1PackageVersion>
+    <!-- Pin versions consumed on .NET Framework to the .NET 10 servicing release. -->
+    <SystemFormatsNrbfNetFxPackageVersion>10.0.4</SystemFormatsNrbfNetFxPackageVersion>
+    <SystemCollectionsImmutableNetFxPackageVersion>10.0.4</SystemCollectionsImmutableNetFxPackageVersion>
+    <SystemReflectionMetadataNetFxPackageVersion>10.0.4</SystemReflectionMetadataNetFxPackageVersion>
+    <SystemResourcesExtensionsNetFxPackageVersion>10.0.4</SystemResourcesExtensionsNetFxPackageVersion>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net481' or '$(TargetFramework)' == 'net472'">
-    <PackageReference Update="System.Collections.Immutable" VersionOverride="10.0.3" />
-    <PackageReference Update="System.Resources.Extensions" VersionOverride="10.0.3" />
-    <PackageReference Update="System.Formats.Nrbf" VersionOverride="10.0.3" />
-  </ItemGroup>
 
 </Project>

--- a/src/System.Private.Windows.Core/src/Microsoft.Private.Windows.Core.csproj
+++ b/src/System.Private.Windows.Core/src/Microsoft.Private.Windows.Core.csproj
@@ -39,9 +39,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWin32" PrivateAssets="all" />
-    <PackageReference Include="System.Formats.Nrbf" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="System.ComponentModel.Annotations" />
+    <!-- Pin System.Formats.Nrbf and its transitive dependencies to the .NET 10. -->
+    <PackageReference Include="System.Formats.Nrbf" VersionOverride="$(SystemFormatsNrbfNetFxPackageVersion)" />
+    <PackageReference Include="System.Collections.Immutable" VersionOverride="$(SystemCollectionsImmutableNetFxPackageVersion)" PrivateAssets="all" />
+    <PackageReference Include="System.Reflection.Metadata" VersionOverride="$(SystemReflectionMetadataNetFxPackageVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change pins the runtime assemblies pulled in by the System.Formats.Nrbf reference to the 10.0.4 release for .NET Framework project Microsoft.Private.Windows.Core.csproj. This is required for consumption in Dev18 VS.

• System.Formats.Nrbf → 10.0.4
• System.Collections.Immutable → 10.0.4 (transitive, now explicitly referenced with PrivateAssets="all") 
• System.Reflection.Metadata → 10.0.4 (transitive, now explicitly referenced with PrivateAssets="all")

Without these pins, restore was resolving the .NET 11 preview (11.0.0-preview.4.26215.121) for these packages.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14487)