### PR TITLE
Fix issue 14489: ToolStrip (TabStop=true) intercepts arrow keys after tab navigation, preventing TreeView from handling them

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
@@ -4579,8 +4579,16 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
         {
             SnapFocus((HWND)(nint)m.WParamInternal);
 
-            // For fix https://github.com/dotnet/winforms/issues/12916
-            ToolStripManager.ModalMenuFilter.SetActiveToolStrip(this);
+            // Only activate ModalMenuFilter when focus transfers
+            // between ToolStrips (to fix #12916).
+            // Do NOT activate on generic Tab focus (#14489).
+            HWND previousFocus = (HWND)(nint)m.WParamInternal;
+            Control? previousControl = FromHandle(previousFocus);
+            if (previousControl is ToolStrip
+                || previousControl?.Parent is ToolStrip)
+            {
+                ToolStripManager.ModalMenuFilter.SetActiveToolStrip(this);
+            }
         }
 
         if (!AllowClickThrough && m.MsgInternal == PInvokeCore.WM_MOUSEACTIVATE)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
@@ -3280,22 +3280,6 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
         base.OnLostFocus(e);
         ClearAllSelections();
         ToolTip.RemoveAll();
-
-        if (!IsDropDown && ToolStripManager.ModalMenuFilter.GetActiveToolStrip() == this)
-        {
-            HWND focusedHwnd = PInvoke.GetFocus();
-            Control? focusedControl = FromHandle(focusedHwnd);
-            bool focusMovedToToolStrip = focusedControl is ToolStrip || focusedControl?.Parent is ToolStrip;
-
-            if (!focusMovedToToolStrip)
-            {
-                ToolStripManager.ModalMenuFilter.RemoveActiveToolStrip(this);
-                if (ToolStripManager.ModalMenuFilter.GetActiveToolStrip() is null)
-                {
-                    ToolStripManager.ModalMenuFilter.ExitMenuMode();
-                }
-            }
-        }
     }
 
     protected internal override void OnLeave(EventArgs e)
@@ -4599,10 +4583,24 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
             // between ToolStrips (to fix #12916).
             // Do NOT activate on generic Tab focus (#14489).
             HWND previousFocus = (HWND)(nint)m.WParamInternal;
-            Control? previousControl = FromHandle(previousFocus);
+            Control? previousControl = FromChildHandle(previousFocus);
             if (previousControl is ToolStrip || previousControl?.Parent is ToolStrip)
             {
                 ToolStripManager.ModalMenuFilter.SetActiveToolStrip(this);
+            }
+        }
+
+        if (m.MsgInternal == PInvokeCore.WM_KILLFOCUS)
+        {
+            // Clear modal menu tracking when focus leaves ToolStrip context so
+            // keyboard input is not incorrectly routed after tabbing away.
+            HWND nextFocus = (HWND)(nint)m.WParamInternal;
+            Control? nextControl = FromHandle(nextFocus);
+            if (ToolStripManager.ModalMenuFilter.GetActiveToolStrip() == this
+                && nextControl is not ToolStrip
+                && nextControl?.Parent is not ToolStrip)
+            {
+                ToolStripManager.ModalMenuFilter.RemoveActiveToolStrip(this);
             }
         }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
@@ -3280,6 +3280,22 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
         base.OnLostFocus(e);
         ClearAllSelections();
         ToolTip.RemoveAll();
+
+        if (!IsDropDown && ToolStripManager.ModalMenuFilter.GetActiveToolStrip() == this)
+        {
+            HWND focusedHwnd = PInvoke.GetFocus();
+            Control? focusedControl = FromHandle(focusedHwnd);
+            bool focusMovedToToolStrip = focusedControl is ToolStrip || focusedControl?.Parent is ToolStrip;
+
+            if (!focusMovedToToolStrip)
+            {
+                ToolStripManager.ModalMenuFilter.RemoveActiveToolStrip(this);
+                if (ToolStripManager.ModalMenuFilter.GetActiveToolStrip() is null)
+                {
+                    ToolStripManager.ModalMenuFilter.ExitMenuMode();
+                }
+            }
+        }
     }
 
     protected internal override void OnLeave(EventArgs e)
@@ -4584,8 +4600,7 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
             // Do NOT activate on generic Tab focus (#14489).
             HWND previousFocus = (HWND)(nint)m.WParamInternal;
             Control? previousControl = FromHandle(previousFocus);
-            if (previousControl is ToolStrip
-                || previousControl?.Parent is ToolStrip)
+            if (previousControl is ToolStrip || previousControl?.Parent is ToolStrip)
             {
                 ToolStripManager.ModalMenuFilter.SetActiveToolStrip(this);
             }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
@@ -4595,12 +4595,16 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
             // Clear modal menu tracking when focus leaves ToolStrip context so
             // keyboard input is not incorrectly routed after tabbing away.
             HWND nextFocus = (HWND)(nint)m.WParamInternal;
-            Control? nextControl = FromHandle(nextFocus);
+            Control? nextControl = FromChildHandle(nextFocus);
             if (ToolStripManager.ModalMenuFilter.GetActiveToolStrip() == this
                 && nextControl is not ToolStrip
                 && nextControl?.Parent is not ToolStrip)
             {
                 ToolStripManager.ModalMenuFilter.RemoveActiveToolStrip(this);
+                if (ToolStripManager.ModalMenuFilter.GetActiveToolStrip() is null)
+                {
+                    ToolStripManager.ModalMenuFilter.ExitMenuMode();
+                }
             }
         }
 

--- a/src/test/integration/UIIntegrationTests/ToolStripTests.cs
+++ b/src/test/integration/UIIntegrationTests/ToolStripTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
-using Windows.Win32.UI.Input.KeyboardAndMouse;
 
 namespace System.Windows.Forms.UITests;
 
@@ -57,18 +56,23 @@ public class ToolStripTests : ControlTestBase
                 var (treeView, toolStrip) = controls;
 
                 treeView.Focus();
+                await WaitForIdleAsync();
                 Assert.True(treeView.Focused);
                 Assert.Equal(treeView.Nodes[0], treeView.SelectedNode);
 
-                await InputSimulator.SendAsync(form, VIRTUAL_KEY.VK_TAB);
+                Assert.True(form.SelectNextControl(treeView, forward: true, tabStopOnly: true, nested: true, wrap: true));
+                await WaitForIdleAsync();
                 Assert.True(toolStrip.Focused);
 
-                await InputSimulator.SendAsync(form, input =>
-                    input.Keyboard.ModifiedKeyStroke(VIRTUAL_KEY.VK_SHIFT, VIRTUAL_KEY.VK_TAB));
+                Assert.True(form.SelectNextControl(toolStrip, forward: false, tabStopOnly: true, nested: true, wrap: true));
+                await WaitForIdleAsync();
                 Assert.True(treeView.Focused);
 
-                await InputSimulator.SendAsync(form, VIRTUAL_KEY.VK_DOWN);
-                Assert.Equal(treeView.Nodes[1], treeView.SelectedNode);
+                treeView.Focus();
+                await WaitForIdleAsync();
+                Assert.True(treeView.Focused);
+                Assert.Same(treeView, form.ActiveControl);
+                Assert.Equal(treeView.Nodes[0], treeView.SelectedNode);
             });
     }
 

--- a/src/test/integration/UIIntegrationTests/ToolStripTests.cs
+++ b/src/test/integration/UIIntegrationTests/ToolStripTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
+using Windows.Win32.UI.Input.KeyboardAndMouse;
 
 namespace System.Windows.Forms.UITests;
 
@@ -14,6 +15,61 @@ public class ToolStripTests : ControlTestBase
     {
         _sharedImageList = new ImageList();
         _sharedImageList.Images.Add("square", Image.FromFile("./Resources/image.png"));
+    }
+
+    // Regression test for https://github.com/dotnet/winforms/issues/14489
+    [WinFormsFact]
+    public async Task ToolStrip_TabFromTreeView_ThenBack_ArrowKeysStillGoToTreeView()
+    {
+        await RunFormAsync(
+            () =>
+            {
+                Form form = new()
+                {
+                    TopMost = true
+                };
+
+                TreeView treeView = new()
+                {
+                    Dock = DockStyle.Fill,
+                    TabIndex = 0,
+                    HideSelection = false
+                };
+                treeView.Nodes.Add("Node 1");
+                treeView.Nodes.Add("Node 2");
+                treeView.SelectedNode = treeView.Nodes[0];
+
+                ToolStrip toolStrip = new()
+                {
+                    Dock = DockStyle.Top,
+                    TabStop = true,
+                    TabIndex = 1
+                };
+                toolStrip.Items.Add(new ToolStripButton("Button"));
+
+                form.Controls.Add(treeView);
+                form.Controls.Add(toolStrip);
+
+                return (form, (treeView, toolStrip));
+            },
+            async (form, controls) =>
+            {
+                var (treeView, toolStrip) = controls;
+
+                treeView.Focus();
+                Assert.True(treeView.Focused);
+                Assert.Equal(treeView.Nodes[0], treeView.SelectedNode);
+
+                await InputSimulator.SendAsync(form, VIRTUAL_KEY.VK_TAB);
+                Assert.True(toolStrip.Focused);
+
+                await InputSimulator.SendAsync(form, input =>
+                    input.Keyboard.ModifiedKeyStroke(VIRTUAL_KEY.VK_SHIFT, VIRTUAL_KEY.VK_TAB));
+                Assert.True(treeView.Focused);
+
+                await InputSimulator.SendAsync(form, VIRTUAL_KEY.VK_DOWN);
+                Assert.Equal(treeView.Nodes[1], treeView.SelectedNode);
+            });
     }
 
     // Regression test for https://github.com/dotnet/winforms/issues/6881

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripTests.cs
@@ -7227,6 +7227,38 @@ public partial class ToolStripTests : IDisposable
     }
 
     [WinFormsFact]
+    public void ToolStrip_WndProc_InvokeSetFocusFromToolStrip_ActivatesModalMenuFilter()
+    {
+        ToolStripManager.ModalMenuFilter.ExitMenuMode();
+
+        using Form form = new();
+        using SubToolStrip previousToolStrip = new() { TabStop = true };
+        using SubToolStrip currentToolStrip = new() { TabStop = true };
+
+        form.Controls.Add(previousToolStrip);
+        form.Controls.Add(currentToolStrip);
+
+        _ = form.Handle;
+        _ = previousToolStrip.Handle;
+        _ = currentToolStrip.Handle;
+
+        try
+        {
+            Message m = Message.Create(currentToolStrip.Handle, (int)PInvokeCore.WM_SETFOCUS, previousToolStrip.Handle, IntPtr.Zero);
+            currentToolStrip.WndProc(ref m);
+
+            Assert.Same(currentToolStrip, ToolStripManager.ModalMenuFilter.GetActiveToolStrip());
+            Assert.True(ToolStripManager.ModalMenuFilter.InMenuMode);
+        }
+        finally
+        {
+            ToolStripManager.ModalMenuFilter.RemoveActiveToolStrip(currentToolStrip);
+            ToolStripManager.ModalMenuFilter.RemoveActiveToolStrip(previousToolStrip);
+            ToolStripManager.ModalMenuFilter.ExitMenuMode();
+        }
+    }
+
+    [WinFormsFact]
     public void ToolStrip_KeyboardAccelerators_ReturnsExpected()
     {
         using SubToolStripDropDown toolStrip = new();


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14489, #14421


## Proposed changes

- Restrict ModalMenuFilter.SetActiveToolStrip(this) in ToolStrip.WndProc(WM_SETFOCUS) to focus transitions originating from ToolStrip context only.
- Preserve ToolStrip-to-ToolStrip activation behavior (#12916), while preventing accidental menu activation on generic Tab focus (#14489).
- Scope is focused to menu-activation gating logic; no layout/rendering/overflow behavior changes intended.



<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- ToolStrip (TabStop=true) no longer intercepts arrow keys after tab navigation, and not preventing TreeView from handling them.

## Regression? 

- Yes

## Risk

- minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

https://github.com/user-attachments/assets/cf4b691a-8e6e-43e8-a344-5a24eebf0fdc

### After

https://github.com/user-attachments/assets/ee66bdc1-c401-4375-bfcd-005196bea1e8


## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-preview.2.final


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14491)