### PR TITLE
Fix PageSetupDialog margin unit conversion mismatch

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Printing/PageSetupDialog.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Printing/PageSetupDialog.cs
@@ -287,7 +287,7 @@ public sealed class PageSetupDialog : CommonDialog
             fixed (char* pBuffer = buffer)
             {
                 result = PInvoke.GetLocaleInfoEx(
-                    PInvoke.LOCALE_NAME_SYSTEM_DEFAULT,
+                    string.Empty, // empty string == LOCALE_NAME_USER_DEFAULT, matches what the native PageSetupDlg dialog uses
                     PInvoke.LOCALE_IMEASURE,
                     pBuffer,
                     buffer.Length);
@@ -297,6 +297,19 @@ public sealed class PageSetupDialog : CommonDialog
             {
                 toUnit = PrinterUnit.HundredthsOfAMillimeter;
             }
+        }
+
+        // Explicitly pass the unit flag to the native dialog so it operates in the same unit system
+        // that WinForms used when converting margins above. This ensures that the values written into
+        // rtMargin/rtMinMargin and the values read back in UpdateSettings are always in the same unit,
+        // regardless of how system-level and user-level locale settings may differ.
+        if (toUnit == PrinterUnit.HundredthsOfAMillimeter)
+        {
+            dialogSettings.Flags |= PAGESETUPDLG_FLAGS.PSD_INHUNDREDTHSOFMILLIMETERS;
+        }
+        else
+        {
+            dialogSettings.Flags |= PAGESETUPDLG_FLAGS.PSD_INTHOUSANDTHSOFINCHES;
         }
 
         if (MinMargins is not null)

--- a/src/System.Windows.Forms/System/Windows/Forms/Printing/PageSetupDialog.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Printing/PageSetupDialog.cs
@@ -293,23 +293,27 @@ public sealed class PageSetupDialog : CommonDialog
                     buffer.Length);
             }
 
-            if (result > 0 && int.Parse(buffer, NumberStyles.Integer, CultureInfo.InvariantCulture) == 0)
+            if (result > 0)
             {
-                toUnit = PrinterUnit.HundredthsOfAMillimeter;
+                ReadOnlySpan<char> actualValue = buffer[..(result - 1)];
+                if (int.TryParse(actualValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out int value) && value == 0)
+                {
+                    toUnit = PrinterUnit.HundredthsOfAMillimeter;
+                }
             }
-        }
 
-        // Explicitly pass the unit flag to the native dialog so it operates in the same unit system
-        // that WinForms used when converting margins above. This ensures that the values written into
-        // rtMargin/rtMinMargin and the values read back in UpdateSettings are always in the same unit,
-        // regardless of how system-level and user-level locale settings may differ.
-        if (toUnit == PrinterUnit.HundredthsOfAMillimeter)
-        {
-            dialogSettings.Flags |= PAGESETUPDLG_FLAGS.PSD_INHUNDREDTHSOFMILLIMETERS;
-        }
-        else
-        {
-            dialogSettings.Flags |= PAGESETUPDLG_FLAGS.PSD_INTHOUSANDTHSOFINCHES;
+            // Explicitly pass the unit flag to the native dialog so it operates in the unit selected
+            // by toUnit. This keeps the values written into rtMargin/rtMinMargin below and the values read
+            // back in UpdateSettings in the same unit, regardless of how system-level and user-level locale
+            // settings may differ.
+            if (toUnit == PrinterUnit.HundredthsOfAMillimeter)
+            {
+                dialogSettings.Flags |= PAGESETUPDLG_FLAGS.PSD_INHUNDREDTHSOFMILLIMETERS;
+            }
+            else
+            {
+                dialogSettings.Flags |= PAGESETUPDLG_FLAGS.PSD_INTHOUSANDTHSOFINCHES;
+            }
         }
 
         if (MinMargins is not null)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14482

## Root Cause
PageSetupDialog converts pageSettings.Margins and minMargins into rtMargin and rtMinMargin before calling the native dialog.
Previously:
1. Unit selection could come from system locale.
2. Input unit flags were not explicitly set for the native dialog.

This could lead to mismatched interpretation between values written into rtMargin and values read back in UpdateSettings.

## Proposed changes

1. Use user locale for measurement detection when EnableMetric is enabled.
   - Changed GetLocaleInfoEx locale argument to user default locale semantics by passing an empty locale name.
   - This aligns unit selection with the user measurement preference.
2. Explicitly set the native unit flag before opening Page Setup dialog.
   - If toUnit is HundredthsOfAMillimeter, set PSD_INHUNDREDTHSOFMILLIMETERS.
   - Otherwise, set PSD_INTHOUSANDTHSOFINCHES.
   - This guarantees the same unit system is used for:
      - writing rtMargin and rtMinMargin
      - reading values back in UpdateSettings

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- EnableMetric false: No behavior change intended.
- EnableMetric true: 
   - Unit choice now tracks user measurement settings.
   - Native dialog interpretation is explicitly aligned with WinForms conversion units.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

- In some locale combinations (for example, system locale = US, user locale = Metric), opening Page Setup and clicking OK repeatedly could make margins get smaller each time.
- Even with EnableMetric = true, the dialog could still show Margins (inches) in those mixed-locale setups.

### After

**Note:** This requires user verification; we have been unable to reproduce this issue.

- Reopening Page Setup without changing margins no longer shrinks margin values.
- With EnableMetric = true, the dialog now follows the user’s measurement preference consistently (for Metric users, it shows millimeters).
- Margin values remain stable and consistent across repeated open/close cycles.


## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-preview.4.26215.121

<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14494)