### PR TITLE
Fix issue 14501: TabControl inside SplitContainer inside TabControl does not match dark mode

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabControl.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabControl.cs
@@ -1787,9 +1787,16 @@ public partial class TabControl : Control
         return !_padding.Equals(s_defaultPaddingPoint);
     }
 
-    private BOOL StyleChildren(HWND handle) =>
-        PInvoke.SetWindowTheme(handle, $"{DarkModeIdentifier}_{ExplorerThemeIdentifier}", null)
+    private BOOL StyleChildren(HWND handle)
+    {
+        if (FromHandle(handle) is TabControl)
+        {
+            return true;
+        }
+
+        return PInvoke.SetWindowTheme(handle, $"{DarkModeIdentifier}_{ExplorerThemeIdentifier}", null)
             .Succeeded;
+    }
 
     /// <summary>
     ///  Returns a string representation for this control.

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabControl.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabControl.cs
@@ -1789,13 +1789,16 @@ public partial class TabControl : Control
 
     private BOOL StyleChildren(HWND handle)
     {
+        // Skip nested TabControls - they apply their own dark-mode theme
+        // via ApplyDarkModeOnDemand and must not be overridden by the parent.
         if (FromHandle(handle) is TabControl)
         {
             return true;
         }
 
-        return PInvoke.SetWindowTheme(handle, $"{DarkModeIdentifier}_{ExplorerThemeIdentifier}", null)
-            .Succeeded;
+        HRESULT hr = PInvoke.SetWindowTheme(handle, $"{DarkModeIdentifier}_{ExplorerThemeIdentifier}", null);
+        Debug.Assert(hr.Succeeded);
+        return true;
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabPage.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TabControl/TabPage.cs
@@ -623,7 +623,15 @@ public partial class TabPage : Panel
                 inflateRect.Width + 8,
                 inflateRect.Height + 6);
 
-            TabRenderer.DrawTabPage(e, rectWithBorder);
+            if (Application.IsDarkModeEnabled)
+            {
+                using SolidBrush brush = new(bkColor);
+                e.Graphics.FillRectangle(brush, rectWithBorder);
+            }
+            else
+            {
+                TabRenderer.DrawTabPage(e, rectWithBorder);
+            }
 
             // TabRenderer does not support painting the background image on the panel, so
             // draw it ourselves.


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14501 


## Proposed changes

- In TabControl dark-mode child theming (StyleChildren(HWND)), skip applying the generic DarkMode_Explorer theme to child windows that are themselves TabControl.
- Keep existing dark-mode theming behavior for other child windows unchanged.
- This prevents parent TabControl from overriding the nested TabControl-specific theme in hierarchies like:
	TabControl -> SplitContainer -> TabControl

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Nested TabControl now matches dark mode correctly when hosted inside a SplitContainer inside another TabControl.
- Reduces visual inconsistency caused by theme override in nested container scenarios.

## Regression? 

- No

## Risk

- Minimal.

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<img width="1214" height="720" alt="image" src="https://github.com/user-attachments/assets/68052b5f-9ce9-4f8f-b171-7575de5e7012" />

### After

<img width="1208" height="721" alt="image" src="https://github.com/user-attachments/assets/7d473ba5-d659-4bcb-8905-16757748d143" />


## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-preview.2.final


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14504)