### PR TITLE
Fix AnchorLayoutV2 deferred anchor initialization when replacing anchored controls during suspended layout

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Layout/DefaultLayout.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Layout/DefaultLayout.cs
@@ -365,6 +365,11 @@ internal partial class DefaultLayout : LayoutEngine
                 continue;
             }
 
+            if (UseAnchorLayoutV2(element) && GetAnchorInfo(element) is null)
+            {
+                UpdateAnchorInfoV2((Control)element, ignoreParentSuspendState: true);
+            }
+
             Debug.Assert(GetAnchorInfo(element) is not null, "AnchorInfo should be initialized before LayoutAnchorControls().");
             SetCachedBounds(element, GetAnchorDestination(element, displayRectangle, measureOnly: false));
         }
@@ -823,7 +828,9 @@ internal partial class DefaultLayout : LayoutEngine
     ///  https://github.com/dotnet/winforms/blob/tree/main/docs/design/anchor-layout-changes-in-net80.md for more details.
     ///  Developers may opt-out of this new behavior using switch <see cref="AppContextSwitches.AnchorLayoutV2"/>.
     /// </devdoc>
-    internal static void UpdateAnchorInfoV2(Control control)
+    internal static void UpdateAnchorInfoV2(Control control) => UpdateAnchorInfoV2(control, ignoreParentSuspendState: false);
+
+    private static void UpdateAnchorInfoV2(Control control, bool ignoreParentSuspendState)
     {
         if (!CommonProperties.GetNeedsAnchorLayout(control))
         {
@@ -848,8 +855,9 @@ internal partial class DefaultLayout : LayoutEngine
             // outside of serialized source and happen only in design-time scenario. Hence, checking for
             // LayoutSuspendCount > 1.
             bool ancestorInDesignMode = control.IsAncestorSiteInDesignMode;
-            if ((ancestorInDesignMode && parent.LayoutSuspendCount > 1)
-                || (!ancestorInDesignMode && parent.LayoutSuspendCount != 0))
+            if (!ignoreParentSuspendState
+                && ((ancestorInDesignMode && parent.LayoutSuspendCount > 1)
+                    || (!ancestorInDesignMode && parent.LayoutSuspendCount != 0)))
             {
                 // Mark parent to indicate that one of its child control requires AnchorsInfo to be calculated.
                 parent._childControlsNeedAnchorLayout = true;

--- a/src/test/integration/UIIntegrationTests/AnchorLayoutTests.cs
+++ b/src/test/integration/UIIntegrationTests/AnchorLayoutTests.cs
@@ -202,6 +202,65 @@ public class AnchorLayoutTests : ControlTestBase
     }
 
     [WinFormsFact]
+    public void AnchorLayoutV2_ReplaceParentWhileAncestorLayoutSuspended_AnchorsRemainConsistent()
+    {
+        // Regression test for https://github.com/dotnet/winforms/issues/14500
+        using AnchorLayoutV2Scope scope = new(enable: true);
+        using Form form = new() { ClientSize = new Size(400, 300) };
+        using Panel originalPanel = new()
+        {
+            Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right,
+            Location = new Point(20, 30),
+            Size = new Size(100, 120)
+        };
+        using Panel replacementPanel = new();
+
+        form.Controls.Add(originalPanel);
+        form.ResumeLayout(performLayout: true);
+
+        form.ClientSize = new Size(500, 350);
+        Assert.Equal(new Rectangle(20, 30, 200, 170), originalPanel.Bounds);
+
+        ReplaceControl(originalPanel, replacementPanel);
+        Assert.Equal(originalPanel.Anchor, replacementPanel.Anchor);
+        Assert.Equal(new Rectangle(20, 30, 200, 170), replacementPanel.Bounds);
+
+        form.ClientSize = new Size(600, 400);
+        Assert.Equal(new Rectangle(20, 30, 300, 220), replacementPanel.Bounds);
+
+        static void ReplaceControl(Control controlToRemove, Control controlToAdd)
+        {
+            controlToRemove.SuspendLayout();
+            controlToAdd.SuspendLayout();
+            controlToAdd.Anchor = controlToRemove.Anchor;
+            controlToAdd.Dock = controlToRemove.Dock;
+            controlToAdd.Location = controlToRemove.Location;
+            controlToAdd.Size = controlToRemove.Size;
+            controlToRemove.ResumeLayout(true);
+            controlToAdd.ResumeLayout(true);
+
+            Control parentOfControlToRemove = controlToRemove.Parent!;
+            Control? parentOfControlToAdd = controlToAdd.Parent;
+            int index = parentOfControlToRemove.Controls.IndexOf(controlToRemove);
+            parentOfControlToRemove.SuspendLayout();
+            if (parentOfControlToAdd is { } parentToSuspend)
+            {
+                parentToSuspend.SuspendLayout();
+            }
+
+            parentOfControlToRemove.Controls.Remove(controlToRemove);
+            parentOfControlToRemove.Controls.Add(controlToAdd);
+            parentOfControlToRemove.Controls.SetChildIndex(controlToAdd, index);
+            parentOfControlToRemove.ResumeLayout(true);
+
+            if (parentOfControlToAdd is { } parentToResume)
+            {
+                parentToResume.ResumeLayout(true);
+            }
+        }
+    }
+
+    [WinFormsFact]
     public void SetBoundsOnAnchoredControl_BoundsChanged()
     {
         using AnchorLayoutV2Scope scope = new(enable: true);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14500

## Root Cause

Under `AnchorLayoutV2`, when an anchored control is replaced while its parent container is inside a `SuspendLayout` / `ResumeLayout` flow, anchor metadata initialization can be deferred.

During` ResumeLayout -> PerformLayout`, the parent temporarily sets `LayoutSuspendCount` to 1 as part of its internal layout execution. The existing AnchorLayoutV2 logic treated that state the same as an externally suspended layout state, so the newly added anchored control could still skip `AnchorInfo` initialization even though actual layout was already running.

## Proposed changes

- Ensure AnchorLayoutV2 initializes missing `AnchorInfo` for anchored children immediately before anchored layout is applied, if that metadata is still missing.
- Update the internal AnchorLayoutV2 path so that real layout execution can bypass the deferred-layout guard when it is running inside the framework’s internal layout pass.
- Add a regression test that matches the customer repro pattern of replacing a `Panel` at runtime and verifies that the replacement panel continues to resize with the form, in `AnchorLayoutTests.cs`.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- After this fix, apps using `AnchorLayoutV2` that replace an anchored control at runtime inside a `SuspendLayout / ResumeLayout` block will have the replacement control resize correctly with the form. The manual `Anchor` toggle workaround is no longer needed.

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

When using AnchorLayoutV2. resizing the window, one of the inner panels is resized incorrectly if replaced by an equivalent panel after the InitializeComponent().

https://github.com/user-attachments/assets/b8953bab-59f9-4036-9357-aebb915f00b7



### After
Replaced anchored controls continue to resize correctly with the form.

https://github.com/user-attachments/assets/a73816b7-a4ec-4247-b7ba-ca0a1f0efb74




## Test methodology <!-- How did you ensure quality? -->

- Manually and unit test


## Test environment(s) <!-- Remove any that don't apply -->

-  .net 11.0.0-preview.5.26227.104


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14505)