### PR TITLE
Fix stale ILLink substitution for removed non-existent PictureBox method “LoadImageViaWebClient”

### DIFF
--- a/src/System.Windows.Forms/ILLink.Substitutions.xml
+++ b/src/System.Windows.Forms/ILLink.Substitutions.xml
@@ -4,7 +4,6 @@
 		<type fullname="System.Windows.Forms.PictureBox" feature="System.Windows.Forms.PictureBox.UseWebRequest" featurevalue="false">
 			<method signature="System.Boolean UseWebRequest()" body="stub" value="false" />
 			<method signature="System.Void StartLoadViaWebRequest()" body="stub" />
-			<method signature="System.Void LoadImageViaWebClient()" body="stub" />
 		</type>
 	</assembly>
 </linker>


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14508

## Root Cause
The ILLink substitutions file still contained an old method signature after the related implementation had been removed.
When the feature switch is disabled (for trimming/NativeAOT scenarios), ILLink attempts to resolve that signature and fails with IL2009.

## Proposed changes

- Removed the obsolete substitution entry for `System.Void LoadImageViaWebClient()`.
- Kept valid substitutions (`UseWebRequest`, `StartLoadViaWebRequest`) unchanged.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Prevents linker failure (`IL2009`) in NativeAOT/trimming scenarios.  No runtime behavior change for `PictureBox`, this is a linker-config correctness fix.

## Regression? 

- No

## Risk

- Low
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14511)