### PR TITLE
[Backport to release/10.0]: Clipboard.GetText(TextDataFormat.Rtf) does not retrieve RTF that lacks a null terminating character

### DIFF
--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/Composition.NativeToManagedAdapter.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/Composition.NativeToManagedAdapter.cs
@@ -104,8 +104,8 @@ internal unsafe partial class Composition<TOleServices, TNrbfSerializer, TDataFo
 
             object? value = request.Format switch
             {
-                DataFormatNames.Text or DataFormatNames.Rtf or DataFormatNames.OemText =>
-                    ReadStringFromHGLOBAL(hglobal, unicode: false),
+                DataFormatNames.Text or DataFormatNames.OemText => ReadStringFromHGLOBAL(hglobal, unicode: false),
+                DataFormatNames.Rtf => ReadRegisteredFormatStringFromHGLOBAL(hglobal, Encoding.Default),
                 DataFormatNames.Html or DataFormatNames.Xaml => ReadUtf8StringFromHGLOBAL(hglobal),
                 DataFormatNames.UnicodeText => ReadStringFromHGLOBAL(hglobal, unicode: true),
                 DataFormatNames.FileDrop => ReadFileListFromHDROP((HDROP)(nint)hglobal),
@@ -181,10 +181,6 @@ internal unsafe partial class Composition<TOleServices, TNrbfSerializer, TDataFo
             //
             // CF_TEXT, CF_OEMTEXT, CF_UNICODETEXT, and CFSTR_FILENAME are supposed to have a null terminator.
             // If we cannot find one in the buffer, assume it is corrupted and return an empty string.
-            //
-            // Can't find the explicit docs for CF_RTF, but we've always treated it as null terminated.
-            // The RichText control itself null terminates but looks like it doesn't require it.
-            // Given our prior and "normal" behavior, we'll continue to expect a null terminator.
 
             try
             {
@@ -219,6 +215,40 @@ internal unsafe partial class Composition<TOleServices, TNrbfSerializer, TDataFo
 
                     return new string((sbyte*)buffer, 0, nullIndex);
                 }
+            }
+            finally
+            {
+                PInvokeCore.GlobalUnlock(hglobal);
+            }
+        }
+
+        private static unsafe string ReadRegisteredFormatStringFromHGLOBAL(HGLOBAL hglobal, Encoding encoding)
+        {
+            void* buffer = PInvokeCore.GlobalLock(hglobal);
+            if (buffer is null)
+            {
+                throw new Win32Exception();
+            }
+
+            try
+            {
+                int size = checked((int)PInvokeCore.GlobalSize(hglobal));
+                if (size == 0)
+                {
+                    throw new Win32Exception();
+                }
+
+                ReadOnlySpan<byte> bytes = new((byte*)buffer, size);
+
+                // Registered format strings may be null-terminated, but the terminator is optional.
+                // If present, stop at the first null byte rather than decoding the entire allocation.
+                int nullIndex = bytes.IndexOf((byte)0);
+                if (nullIndex >= 0)
+                {
+                    bytes = bytes[..nullIndex];
+                }
+
+                return bytes.IsEmpty ? string.Empty : encoding.GetString(bytes);
             }
             finally
             {

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Private/Windows/Ole/NativeToManagedAdapterTests.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Private/Windows/Ole/NativeToManagedAdapterTests.cs
@@ -15,6 +15,7 @@ using Composition = System.Private.Windows.Ole.Composition<
     System.Private.Windows.Nrbf.CoreNrbfSerializer,
     System.Private.Windows.Ole.TestFormat>;
 using DataFormats = System.Private.Windows.Ole.DataFormatsCore<System.Private.Windows.Ole.TestFormat>;
+using System.Text;
 
 namespace System.Private.Windows.Ole;
 
@@ -94,6 +95,19 @@ public unsafe class NativeToManagedAdapterTests
         var composition = Composition.Create(ComHelpers.GetComPointer<IDataObject>(dataObject));
         composition.TryGetData(nameof(NativeToManagedAdapterTests), out SerializationRecord? data).Should().BeTrue();
         data!.TypeName.AssemblyQualifiedName.Should().Be("System.Int32[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
+    }
+
+    [Fact]
+    public void GetData_RtfWithoutNullTerminator_ReturnsRtfText()
+    {
+        const string rtf = "{\\rtf1\\ansi Test}";
+        MemoryStream stream = new(Encoding.Default.GetBytes(rtf));
+        using HGlobalNativeDataObject dataObject = new(stream, (ushort)DataFormats.GetOrAddFormat(DataFormatNames.Rtf).Id);
+
+        var composition = Composition.Create(ComHelpers.GetComPointer<IDataObject>(dataObject));
+        object? data = composition.GetData(DataFormatNames.Rtf);
+
+        data.Should().Be(rtf);
     }
 
     [Fact]


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Backport https://github.com/dotnet/winforms/pull/14461 to release/10.0

Fixes #14458 

In ReadStringFromHGLOBAL method requires a null terminator to determine string length. The format dispatch switch groups RTF (a registered format) with CF_TEXT and CF_OEMTEXT (standard formats), routing RTF through this null-termination-required path.Composition.NativeToManagedAdapterReadStringFromHGLOBAL()

When external applications (PowerPoint, etc.) place RTF on the clipboard without a null terminator — which is valid per the Windows clipboard spec — the method returns instead of the actual RTF content.string.Empty

## Proposed changes

- Add a new method ReadRegisteredFormatStringFromHGLOBAL(HGLOBAL, Encoding) to handle the CF_RTF format without a null terminator.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Clipboard.GetText(TextDataFormat.Rtf) can retrieve RTF that lacks a null terminating character.

## Regression? 

- Yes- regression PR https://github.com/dotnet/winforms/pull/13949.

## Risk

- Minimal

<!-- end TELL-MODE -->

 

## Test methodology <!-- Remove any that don't apply -->

- Manual testing
- Unit test


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14527)