### PR TITLE
Removes dependency on RemoteExecutor in tests

### DIFF
--- a/src/test/integration/UIIntegrationTests/Application.ParkingWindowTests.cs
+++ b/src/test/integration/UIIntegrationTests/Application.ParkingWindowTests.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.UITests;
+
+// Migrated from unit tests; see issue #4500.
+public class ParkingWindowTests
+{
+    [WinFormsFact]
+    public void ParkingWindow_DoesNotThrowOnGarbageCollecting()
+    {
+        bool original = Control.CheckForIllegalCrossThreadCalls;
+        Control.CheckForIllegalCrossThreadCalls = true;
+
+        try
+        {
+            using Form form = InitFormWithControlToGarbageCollect();
+
+            // Access ComboBox from the GC thread; test passes if this does not throw.
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+        finally
+        {
+            Control.CheckForIllegalCrossThreadCalls = original;
+        }
+    }
+
+    private static Form InitFormWithControlToGarbageCollect()
+    {
+        Form form = new();
+        ComboBox comboBox = new()
+        {
+            DropDownStyle = ComboBoxStyle.DropDown
+        };
+
+        form.Controls.Add(comboBox);
+        form.Show();
+
+        // Park ComboBox handle in ParkingWindow.
+        comboBox.Parent = null;
+
+        // Recreate ComboBox handle to set parent to ParkingWindow.
+        comboBox.DropDownStyle = ComboBoxStyle.DropDownList;
+
+        return form;
+    }
+}

--- a/src/test/integration/UIIntegrationTests/Application.ParkingWindowTests.cs
+++ b/src/test/integration/UIIntegrationTests/Application.ParkingWindowTests.cs
@@ -4,8 +4,13 @@
 namespace System.Windows.Forms.UITests;
 
 // Migrated from unit tests; see issue #4500.
-public class ParkingWindowTests
+public class ParkingWindowTests : ControlTestBase
 {
+    public ParkingWindowTests(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+    }
+
     [WinFormsFact]
     public void ParkingWindow_DoesNotThrowOnGarbageCollecting()
     {

--- a/src/test/integration/UIIntegrationTests/Application.StaticStateTests.cs
+++ b/src/test/integration/UIIntegrationTests/Application.StaticStateTests.cs
@@ -7,8 +7,13 @@ using System.Windows.Forms.VisualStyles;
 namespace System.Windows.Forms.UITests;
 
 // Migrated from unit tests; see issue #4500.
-public class ApplicationStaticStateTests
+public class ApplicationStaticStateTests : ControlTestBase
 {
+    public ApplicationStaticStateTests(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+    }
+
     public static IEnumerable<object[]> CurrentCulture_Set_TestData()
     {
         yield return new object[] { CultureInfo.InvariantCulture };
@@ -81,6 +86,7 @@ public class ApplicationStaticStateTests
     [InvalidEnumData<VisualStyleState>]
     public void Application_VisualStyleState_Set_ReturnsExpected(VisualStyleState value)
     {
+        // Serial execution in UIIntegrationTests prevents WM_THEMECHANGED cross-test interference.
         VisualStyleState state = Application.VisualStyleState;
         try
         {

--- a/src/test/integration/UIIntegrationTests/Application.StaticStateTests.cs
+++ b/src/test/integration/UIIntegrationTests/Application.StaticStateTests.cs
@@ -1,0 +1,107 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Windows.Forms.VisualStyles;
+
+namespace System.Windows.Forms.UITests;
+
+// Migrated from unit tests; see issue #4500.
+public class ApplicationStaticStateTests
+{
+    public static IEnumerable<object[]> CurrentCulture_Set_TestData()
+    {
+        yield return new object[] { CultureInfo.InvariantCulture };
+        yield return new object[] { new CultureInfo("en") };
+        yield return new object[] { new CultureInfo("fr-FR") };
+        yield return new object[] { new CultureInfo("en-DK") };
+        yield return new object[] { new CultureInfo("haw") };
+        yield return new object[] { new CultureInfo("en-US") };
+        yield return new object[] { new CultureInfo("de-DE_phoneb") };
+        yield return new object[] { new CustomLCIDCultureInfo(10) };
+        yield return new object[] { new CustomLCIDCultureInfo(0) };
+        yield return new object[] { new CustomLCIDCultureInfo(-1) };
+    }
+
+    [WinFormsFact]
+    public void Application_CurrentCulture_Set_GetReturnsExpected()
+    {
+        // GetThreadLocale round-trip assertion dropped: [UseDefaultXunitCulture] restores the
+        // thread locale per test, and SetThreadLocale silently no-ops for LCID 0x7F on STA hosts.
+        // Managed CurrentCulture surface is still verified below.
+        CultureInfo originalApplicationCulture = Application.CurrentCulture;
+        CultureInfo originalThreadCulture = Thread.CurrentThread.CurrentCulture;
+
+        try
+        {
+            foreach (object[] testData in CurrentCulture_Set_TestData())
+            {
+                CultureInfo value = (CultureInfo)testData[0];
+
+                CultureInfo oldValue = Application.CurrentCulture;
+                try
+                {
+                    Application.CurrentCulture = value;
+                    Assert.Same(value, Application.CurrentCulture);
+                    Assert.Same(value, Thread.CurrentThread.CurrentCulture);
+                    Assert.Same(value, CultureInfo.CurrentCulture);
+
+                    // Set same.
+                    Application.CurrentCulture = value;
+                    Assert.Same(value, Application.CurrentCulture);
+                    Assert.Same(value, Thread.CurrentThread.CurrentCulture);
+                    Assert.Same(value, CultureInfo.CurrentCulture);
+                }
+                finally
+                {
+                    Application.CurrentCulture = oldValue;
+                }
+            }
+        }
+        finally
+        {
+            Application.CurrentCulture = originalApplicationCulture;
+            Thread.CurrentThread.CurrentCulture = originalThreadCulture;
+        }
+    }
+
+    [WinFormsFact]
+    public void Application_EnableVisualStyles_InvokeBeforeGettingRenderWithVisualStyles_Success()
+    {
+        Application.EnableVisualStyles();
+        Assert.True(Application.UseVisualStyles);
+        Assert.True(Application.RenderWithVisualStyles);
+    }
+
+    // InvokeAfterGettingRenderWithVisualStyles_Success dropped: precondition UseVisualStyles==false
+    // is unsatisfiable here (EnableVisualStyles is a one-way switch and the host already enabled it).
+
+    [WinFormsTheory]
+    [EnumData<VisualStyleState>]
+    [InvalidEnumData<VisualStyleState>]
+    public void Application_VisualStyleState_Set_ReturnsExpected(VisualStyleState value)
+    {
+        VisualStyleState state = Application.VisualStyleState;
+        try
+        {
+            Application.VisualStyleState = value;
+            Assert.Equal(value, Application.VisualStyleState);
+        }
+        finally
+        {
+            Application.VisualStyleState = state;
+        }
+    }
+
+    private class CustomLCIDCultureInfo : CultureInfo
+    {
+        private readonly int _lcid;
+
+        public CustomLCIDCultureInfo(int lcid) : base("en-US")
+        {
+            _lcid = lcid;
+        }
+
+        public override int LCID => _lcid;
+    }
+}

--- a/src/test/integration/UIIntegrationTests/Application.StaticStateTests.cs
+++ b/src/test/integration/UIIntegrationTests/Application.StaticStateTests.cs
@@ -23,9 +23,6 @@ public class ApplicationStaticStateTests : ControlTestBase
         yield return new object[] { new CultureInfo("haw") };
         yield return new object[] { new CultureInfo("en-US") };
         yield return new object[] { new CultureInfo("de-DE_phoneb") };
-        yield return new object[] { new CustomLCIDCultureInfo(10) };
-        yield return new object[] { new CustomLCIDCultureInfo(0) };
-        yield return new object[] { new CustomLCIDCultureInfo(-1) };
     }
 
     [WinFormsFact]
@@ -97,17 +94,5 @@ public class ApplicationStaticStateTests : ControlTestBase
         {
             Application.VisualStyleState = state;
         }
-    }
-
-    private class CustomLCIDCultureInfo : CultureInfo
-    {
-        private readonly int _lcid;
-
-        public CustomLCIDCultureInfo(int lcid) : base("en-US")
-        {
-            _lcid = lcid;
-        }
-
-        public override int LCID => _lcid;
     }
 }

--- a/src/test/integration/UIIntegrationTests/CommonDialogTests.cs
+++ b/src/test/integration/UIIntegrationTests/CommonDialogTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.ComponentModel;
 using Moq;
 
 namespace System.Windows.Forms.UITests;

--- a/src/test/integration/UIIntegrationTests/CommonDialogTests.cs
+++ b/src/test/integration/UIIntegrationTests/CommonDialogTests.cs
@@ -6,15 +6,18 @@ using Moq;
 namespace System.Windows.Forms.UITests;
 
 // Migrated from unit tests; see issue #4500.
-public class CommonDialogTests
+public class CommonDialogTests : ControlTestBase
 {
+    public CommonDialogTests(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+    }
+
     [WinFormsTheory]
     [InlineData(true, DialogResult.OK)]
     [InlineData(false, DialogResult.Cancel)]
     public void ShowDialog_NonControlOwnerWithVisualStyles_ReturnsExpected(bool runDialogResult, DialogResult expectedDialogResult)
     {
-        Application.EnableVisualStyles();
-
         using SubCommonDialog dialog = new()
         {
             RunDialogResult = runDialogResult
@@ -31,8 +34,6 @@ public class CommonDialogTests
     [InlineData(false, DialogResult.Cancel)]
     public void ShowDialog_ControlOwnerWithVisualStyles_ReturnsExpected(bool runDialogResult, DialogResult expectedDialogResult)
     {
-        Application.EnableVisualStyles();
-
         using SubCommonDialog dialog = new()
         {
             RunDialogResult = runDialogResult
@@ -46,8 +47,6 @@ public class CommonDialogTests
     [InlineData(false, DialogResult.Cancel)]
     public void ShowDialog_ControlOwnerWithHandleWithVisualStyles_ReturnsExpected(bool runDialogResult, DialogResult expectedDialogResult)
     {
-        Application.EnableVisualStyles();
-
         using SubCommonDialog dialog = new()
         {
             RunDialogResult = runDialogResult

--- a/src/test/integration/UIIntegrationTests/CommonDialogTests.cs
+++ b/src/test/integration/UIIntegrationTests/CommonDialogTests.cs
@@ -1,0 +1,71 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+using Moq;
+
+namespace System.Windows.Forms.UITests;
+
+// Migrated from unit tests; see issue #4500.
+public class CommonDialogTests
+{
+    [WinFormsTheory]
+    [InlineData(true, DialogResult.OK)]
+    [InlineData(false, DialogResult.Cancel)]
+    public void ShowDialog_NonControlOwnerWithVisualStyles_ReturnsExpected(bool runDialogResult, DialogResult expectedDialogResult)
+    {
+        Application.EnableVisualStyles();
+
+        using SubCommonDialog dialog = new()
+        {
+            RunDialogResult = runDialogResult
+        };
+        var owner = new Mock<IWin32Window>(MockBehavior.Strict);
+        owner
+            .Setup(o => o.Handle)
+            .Returns(IntPtr.Zero);
+        Assert.Equal(expectedDialogResult, dialog.ShowDialog(owner.Object));
+    }
+
+    [WinFormsTheory]
+    [InlineData(true, DialogResult.OK)]
+    [InlineData(false, DialogResult.Cancel)]
+    public void ShowDialog_ControlOwnerWithVisualStyles_ReturnsExpected(bool runDialogResult, DialogResult expectedDialogResult)
+    {
+        Application.EnableVisualStyles();
+
+        using SubCommonDialog dialog = new()
+        {
+            RunDialogResult = runDialogResult
+        };
+        using Control owner = new();
+        Assert.Equal(expectedDialogResult, dialog.ShowDialog(owner));
+    }
+
+    [WinFormsTheory]
+    [InlineData(true, DialogResult.OK)]
+    [InlineData(false, DialogResult.Cancel)]
+    public void ShowDialog_ControlOwnerWithHandleWithVisualStyles_ReturnsExpected(bool runDialogResult, DialogResult expectedDialogResult)
+    {
+        Application.EnableVisualStyles();
+
+        using SubCommonDialog dialog = new()
+        {
+            RunDialogResult = runDialogResult
+        };
+        using Control owner = new();
+        Assert.NotEqual(IntPtr.Zero, owner.Handle);
+        Assert.Equal(expectedDialogResult, dialog.ShowDialog(owner));
+    }
+
+    private class SubCommonDialog : CommonDialog
+    {
+        public override void Reset()
+        {
+        }
+
+        public bool RunDialogResult { get; set; }
+
+        protected override bool RunDialog(IntPtr hwndOwner) => RunDialogResult;
+    }
+}

--- a/src/test/integration/UIIntegrationTests/DataGridViewHeaderCellTests.cs
+++ b/src/test/integration/UIIntegrationTests/DataGridViewHeaderCellTests.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Drawing;
-using System.Windows.Forms.VisualStyles;
-
 namespace System.Windows.Forms.UITests;
 
 // Migrated from unit tests; see issue #4500. Remaining skipped tests in this file deferred to a follow-up PR.

--- a/src/test/integration/UIIntegrationTests/DataGridViewHeaderCellTests.cs
+++ b/src/test/integration/UIIntegrationTests/DataGridViewHeaderCellTests.cs
@@ -6,8 +6,13 @@ using System.Windows.Forms.VisualStyles;
 namespace System.Windows.Forms.UITests;
 
 // Migrated from unit tests; see issue #4500. Remaining skipped tests in this file deferred to a follow-up PR.
-public class DataGridViewHeaderCellTests
+public class DataGridViewHeaderCellTests : ControlTestBase
 {
+    public DataGridViewHeaderCellTests(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+    }
+
     public static IEnumerable<object[]> MouseLeaveUnsharesRow_WithDataGridViewMouseDown_TestData()
     {
         ButtonState expected = VisualStyleRenderer.IsSupported ? ButtonState.Pushed : ButtonState.Normal;
@@ -25,8 +30,6 @@ public class DataGridViewHeaderCellTests
     [MemberData(nameof(MouseLeaveUnsharesRow_WithDataGridViewMouseDown_TestData))]
     public void DataGridViewHeaderCell_MouseLeaveUnsharesRow_InvokeWithDataGridViewMouseDown_ReturnsExpected(bool enableHeadersVisualStyles, int rowIndex, ButtonState expectedButtonState)
     {
-        Application.EnableVisualStyles();
-
         using SubDataGridViewHeaderCell cellTemplate = new();
         using DataGridViewColumn column = new()
         {
@@ -47,8 +50,6 @@ public class DataGridViewHeaderCellTests
     [WinFormsFact]
     public void DataGridViewHeaderCell_OnMouseDown_InvalidRowIndexVisualStyles_ThrowsArgumentOutOfRangeException()
     {
-        Application.EnableVisualStyles();
-
         using SubDataGridViewHeaderCell cellTemplate = new();
         using DataGridViewColumn column = new()
         {
@@ -68,8 +69,6 @@ public class DataGridViewHeaderCellTests
     [WinFormsFact]
     public void DataGridViewHeaderCell_OnMouseUp_InvalidRowIndexVisualStyles_ThrowsArgumentOutOfRangeException()
     {
-        Application.EnableVisualStyles();
-
         using SubDataGridViewHeaderCell cellTemplate = new();
         using DataGridViewColumn column = new()
         {

--- a/src/test/integration/UIIntegrationTests/DataGridViewHeaderCellTests.cs
+++ b/src/test/integration/UIIntegrationTests/DataGridViewHeaderCellTests.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Windows.Forms.VisualStyles;
+
 namespace System.Windows.Forms.UITests;
 
 // Migrated from unit tests; see issue #4500. Remaining skipped tests in this file deferred to a follow-up PR.

--- a/src/test/integration/UIIntegrationTests/DataGridViewHeaderCellTests.cs
+++ b/src/test/integration/UIIntegrationTests/DataGridViewHeaderCellTests.cs
@@ -1,0 +1,100 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Drawing;
+using System.Windows.Forms.VisualStyles;
+
+namespace System.Windows.Forms.UITests;
+
+// Migrated from unit tests; see issue #4500. Remaining skipped tests in this file deferred to a follow-up PR.
+public class DataGridViewHeaderCellTests
+{
+    public static IEnumerable<object[]> MouseLeaveUnsharesRow_WithDataGridViewMouseDown_TestData()
+    {
+        ButtonState expected = VisualStyleRenderer.IsSupported ? ButtonState.Pushed : ButtonState.Normal;
+        yield return new object[] { true, -2, expected };
+        yield return new object[] { true, -1, expected };
+        yield return new object[] { true, 0, expected };
+        yield return new object[] { true, 1, expected };
+        yield return new object[] { false, -2, ButtonState.Normal };
+        yield return new object[] { false, -1, ButtonState.Normal };
+        yield return new object[] { false, 0, ButtonState.Normal };
+        yield return new object[] { false, 1, ButtonState.Normal };
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(MouseLeaveUnsharesRow_WithDataGridViewMouseDown_TestData))]
+    public void DataGridViewHeaderCell_MouseLeaveUnsharesRow_InvokeWithDataGridViewMouseDown_ReturnsExpected(bool enableHeadersVisualStyles, int rowIndex, ButtonState expectedButtonState)
+    {
+        Application.EnableVisualStyles();
+
+        using SubDataGridViewHeaderCell cellTemplate = new();
+        using DataGridViewColumn column = new()
+        {
+            CellTemplate = cellTemplate
+        };
+        using DataGridView control = new()
+        {
+            EnableHeadersVisualStyles = enableHeadersVisualStyles
+        };
+        control.Columns.Add(column);
+        SubDataGridViewHeaderCell cell = (SubDataGridViewHeaderCell)control.Rows[0].Cells[0];
+        cell.OnMouseDown(new DataGridViewCellMouseEventArgs(-1, -1, 0, 0, new MouseEventArgs(MouseButtons.Left, 0, 0, 0, 0)));
+        Assert.Equal(enableHeadersVisualStyles && VisualStyleRenderer.IsSupported, cell.MouseLeaveUnsharesRow(rowIndex));
+        Assert.Equal(expectedButtonState, cell.ButtonState);
+        Assert.False(control.IsHandleCreated);
+    }
+
+    [WinFormsFact]
+    public void DataGridViewHeaderCell_OnMouseDown_InvalidRowIndexVisualStyles_ThrowsArgumentOutOfRangeException()
+    {
+        Application.EnableVisualStyles();
+
+        using SubDataGridViewHeaderCell cellTemplate = new();
+        using DataGridViewColumn column = new()
+        {
+            CellTemplate = cellTemplate
+        };
+        using DataGridView control = new()
+        {
+            EnableHeadersVisualStyles = true
+        };
+        control.Columns.Add(column);
+        SubDataGridViewHeaderCell cell = (SubDataGridViewHeaderCell)control.Rows[0].Cells[0];
+        DataGridViewCellMouseEventArgs e = new(0, 1, 0, 0, new MouseEventArgs(MouseButtons.Left, 0, 0, 0, 0));
+        Assert.Throws<ArgumentOutOfRangeException>("rowIndex", () => cell.OnMouseDown(e));
+        Assert.Equal(VisualStyleRenderer.IsSupported ? ButtonState.Pushed : ButtonState.Normal, cell.ButtonState);
+    }
+
+    [WinFormsFact]
+    public void DataGridViewHeaderCell_OnMouseUp_InvalidRowIndexVisualStyles_ThrowsArgumentOutOfRangeException()
+    {
+        Application.EnableVisualStyles();
+
+        using SubDataGridViewHeaderCell cellTemplate = new();
+        using DataGridViewColumn column = new()
+        {
+            CellTemplate = cellTemplate
+        };
+        using DataGridView control = new()
+        {
+            EnableHeadersVisualStyles = true
+        };
+        control.Columns.Add(column);
+        SubDataGridViewHeaderCell cell = (SubDataGridViewHeaderCell)control.Rows[0].Cells[0];
+        DataGridViewCellMouseEventArgs e = new(0, 1, 0, 0, new MouseEventArgs(MouseButtons.Left, 0, 0, 0, 0));
+        Assert.Throws<ArgumentOutOfRangeException>("rowIndex", () => cell.OnMouseUp(e));
+        Assert.Equal(ButtonState.Normal, cell.ButtonState);
+    }
+
+    public class SubDataGridViewHeaderCell : DataGridViewHeaderCell
+    {
+        public new ButtonState ButtonState => base.ButtonState;
+
+        public new bool MouseLeaveUnsharesRow(int rowIndex) => base.MouseLeaveUnsharesRow(rowIndex);
+
+        public new void OnMouseDown(DataGridViewCellMouseEventArgs e) => base.OnMouseDown(e);
+
+        public new void OnMouseUp(DataGridViewCellMouseEventArgs e) => base.OnMouseUp(e);
+    }
+}

--- a/src/test/integration/UIIntegrationTests/DataGridViewHeaderCellTests.cs
+++ b/src/test/integration/UIIntegrationTests/DataGridViewHeaderCellTests.cs
@@ -15,20 +15,19 @@ public class DataGridViewHeaderCellTests : ControlTestBase
 
     public static IEnumerable<object[]> MouseLeaveUnsharesRow_WithDataGridViewMouseDown_TestData()
     {
-        ButtonState expected = VisualStyleRenderer.IsSupported ? ButtonState.Pushed : ButtonState.Normal;
-        yield return new object[] { true, -2, expected };
-        yield return new object[] { true, -1, expected };
-        yield return new object[] { true, 0, expected };
-        yield return new object[] { true, 1, expected };
-        yield return new object[] { false, -2, ButtonState.Normal };
-        yield return new object[] { false, -1, ButtonState.Normal };
-        yield return new object[] { false, 0, ButtonState.Normal };
-        yield return new object[] { false, 1, ButtonState.Normal };
+        yield return new object[] { true, -2 };
+        yield return new object[] { true, -1 };
+        yield return new object[] { true, 0 };
+        yield return new object[] { true, 1 };
+        yield return new object[] { false, -2 };
+        yield return new object[] { false, -1 };
+        yield return new object[] { false, 0 };
+        yield return new object[] { false, 1 };
     }
 
     [WinFormsTheory]
     [MemberData(nameof(MouseLeaveUnsharesRow_WithDataGridViewMouseDown_TestData))]
-    public void DataGridViewHeaderCell_MouseLeaveUnsharesRow_InvokeWithDataGridViewMouseDown_ReturnsExpected(bool enableHeadersVisualStyles, int rowIndex, ButtonState expectedButtonState)
+    public void DataGridViewHeaderCell_MouseLeaveUnsharesRow_InvokeWithDataGridViewMouseDown_ReturnsExpected(bool enableHeadersVisualStyles, int rowIndex)
     {
         using SubDataGridViewHeaderCell cellTemplate = new();
         using DataGridViewColumn column = new()
@@ -42,8 +41,12 @@ public class DataGridViewHeaderCellTests : ControlTestBase
         control.Columns.Add(column);
         SubDataGridViewHeaderCell cell = (SubDataGridViewHeaderCell)control.Rows[0].Cells[0];
         cell.OnMouseDown(new DataGridViewCellMouseEventArgs(-1, -1, 0, 0, new MouseEventArgs(MouseButtons.Left, 0, 0, 0, 0)));
-        Assert.Equal(enableHeadersVisualStyles && VisualStyleRenderer.IsSupported, cell.MouseLeaveUnsharesRow(rowIndex));
-        Assert.Equal(expectedButtonState, cell.ButtonState);
+
+        // Compute expected after the base ctor enabled visual styles; reading IsSupported during
+        // MemberData enumeration can run too early and silently degrade the visual-styles cases.
+        bool expectPushed = enableHeadersVisualStyles && VisualStyleRenderer.IsSupported;
+        Assert.Equal(expectPushed, cell.MouseLeaveUnsharesRow(rowIndex));
+        Assert.Equal(expectPushed ? ButtonState.Pushed : ButtonState.Normal, cell.ButtonState);
         Assert.False(control.IsHandleCreated);
     }
 

--- a/src/test/integration/UIIntegrationTests/ListViewInsertionMarkTests.cs
+++ b/src/test/integration/UIIntegrationTests/ListViewInsertionMarkTests.cs
@@ -1,0 +1,236 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Drawing;
+
+namespace System.Windows.Forms.UITests;
+
+// Migrated from unit tests; see issue #4500.
+public class ListViewInsertionMarkTests
+{
+    [WinFormsFact]
+    public unsafe void ListViewInsertionMark_AppearsAfterItem_GetInsertMark_Success()
+    {
+        Application.EnableVisualStyles();
+
+        using ListView control = new();
+        ListViewInsertionMark insertionMark = control.InsertionMark;
+
+        // Set same.
+        Assert.NotEqual(IntPtr.Zero, control.Handle);
+        control.InsertionMark.AppearsAfterItem = false;
+        LVINSERTMARK insertMark = new()
+        {
+            cbSize = (uint)sizeof(LVINSERTMARK)
+        };
+        Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
+        Assert.Equal(0x80000000, insertMark.dwFlags);
+        Assert.Equal(-1, insertMark.iItem);
+        Assert.Equal(0u, insertMark.dwReserved);
+        Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
+
+        // Set true.
+        control.InsertionMark.AppearsAfterItem = true;
+        insertMark = new LVINSERTMARK
+        {
+            cbSize = (uint)sizeof(LVINSERTMARK)
+        };
+        Assert.Equal(1, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
+        Assert.Equal(0x80000001, insertMark.dwFlags);
+        Assert.Equal(0, insertMark.iItem);
+        Assert.Equal(0u, insertMark.dwReserved);
+        Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
+
+        // Set false.
+        control.InsertionMark.AppearsAfterItem = false;
+        insertMark = new LVINSERTMARK
+        {
+            cbSize = (uint)sizeof(LVINSERTMARK)
+        };
+        Assert.Equal(1, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
+        Assert.Equal(0x80000000, insertMark.dwFlags);
+        Assert.Equal(0, insertMark.iItem);
+        Assert.Equal(0u, insertMark.dwReserved);
+        Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
+    }
+
+    [WinFormsFact]
+    public unsafe void ListViewInsertionMark_AppearsAfterItem_GetInsertMarkWithColor_Success()
+    {
+        Application.EnableVisualStyles();
+
+        using ListView control = new();
+        ListViewInsertionMark insertionMark = control.InsertionMark;
+        control.InsertionMark.Color = Color.FromArgb(0x12, 0x34, 0x56, 0x78);
+
+        // Set same.
+        Assert.NotEqual(IntPtr.Zero, control.Handle);
+        control.InsertionMark.AppearsAfterItem = false;
+        LVINSERTMARK insertMark = new()
+        {
+            cbSize = (uint)sizeof(LVINSERTMARK)
+        };
+        Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
+        Assert.Equal(0x80000000, insertMark.dwFlags);
+        Assert.Equal(-1, insertMark.iItem);
+        Assert.Equal(0u, insertMark.dwReserved);
+        Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
+
+        // Set true.
+        control.InsertionMark.AppearsAfterItem = true;
+        insertMark = new LVINSERTMARK
+        {
+            cbSize = (uint)sizeof(LVINSERTMARK)
+        };
+        Assert.Equal(1, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
+        Assert.Equal(0x80000001, insertMark.dwFlags);
+        Assert.Equal(0, insertMark.iItem);
+        Assert.Equal(0u, insertMark.dwReserved);
+        Assert.Equal(0x785634, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
+
+        // Set false.
+        control.InsertionMark.AppearsAfterItem = false;
+        insertMark = new LVINSERTMARK
+        {
+            cbSize = (uint)sizeof(LVINSERTMARK)
+        };
+        Assert.Equal(1, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
+        Assert.Equal(0x80000000, insertMark.dwFlags);
+        Assert.Equal(0, insertMark.iItem);
+        Assert.Equal(0u, insertMark.dwReserved);
+        Assert.Equal(0x785634, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
+    }
+
+    [WinFormsFact]
+    public unsafe void ListViewInsertionMark_Color_GetInsertMarkColor_Success()
+    {
+        Application.EnableVisualStyles();
+
+        using ListView control = new();
+        ListViewInsertionMark insertionMark = control.InsertionMark;
+        Assert.NotEqual(IntPtr.Zero, control.Handle);
+
+        // Set same.
+        control.InsertionMark.Color = Color.Empty;
+        LVINSERTMARK insertMark = new()
+        {
+            cbSize = (uint)sizeof(LVINSERTMARK)
+        };
+        Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
+        Assert.Equal(0x80000000, insertMark.dwFlags);
+        Assert.Equal(-1, insertMark.iItem);
+        Assert.Equal(0u, insertMark.dwReserved);
+        Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
+
+        // Set different.
+        control.InsertionMark.Color = Color.FromArgb(0x12, 0x34, 0x56, 0x78);
+        insertMark = new LVINSERTMARK
+        {
+            cbSize = (uint)sizeof(LVINSERTMARK)
+        };
+        Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
+        Assert.Equal(0x80000000, insertMark.dwFlags);
+        Assert.Equal(-1, insertMark.iItem);
+        Assert.Equal(0u, insertMark.dwReserved);
+        Assert.Equal(0x785634, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
+    }
+
+    [WinFormsTheory]
+    [InlineData(-2)]
+    [InlineData(1)]
+    public unsafe void ListViewInsertionMark_Index_GetInsertMark_Success(int index)
+    {
+        Application.EnableVisualStyles();
+
+        using ListView control = new();
+        ListViewInsertionMark insertionMark = control.InsertionMark;
+
+        // Set same.
+        Assert.NotEqual(IntPtr.Zero, control.Handle);
+        control.InsertionMark.Index = 0;
+        LVINSERTMARK insertMark = new()
+        {
+            cbSize = (uint)sizeof(LVINSERTMARK)
+        };
+        Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
+        Assert.Equal(0x80000000, insertMark.dwFlags);
+        Assert.Equal(-1, insertMark.iItem);
+        Assert.Equal(0u, insertMark.dwReserved);
+        Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
+
+        // Set negative one.
+        Assert.NotEqual(IntPtr.Zero, control.Handle);
+        control.InsertionMark.Index = -1;
+        insertMark = new LVINSERTMARK
+        {
+            cbSize = (uint)sizeof(LVINSERTMARK)
+        };
+        Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
+        Assert.Equal(0x80000000, insertMark.dwFlags);
+        Assert.Equal(-1, insertMark.iItem);
+        Assert.Equal(0u, insertMark.dwReserved);
+        Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
+
+        // Set different.
+        control.InsertionMark.Index = index;
+        insertMark = new LVINSERTMARK
+        {
+            cbSize = (uint)sizeof(LVINSERTMARK)
+        };
+        Assert.Equal(1, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
+        Assert.Equal(0x80000000, insertMark.dwFlags);
+        Assert.Equal(index, insertMark.iItem);
+        Assert.Equal(0u, insertMark.dwReserved);
+        Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
+    }
+
+    [WinFormsTheory]
+    [InlineData(-2)]
+    [InlineData(1)]
+    public unsafe void ListViewInsertionMark_Index_GetInsertMarkWithColor_Success(int index)
+    {
+        Application.EnableVisualStyles();
+
+        using ListView control = new();
+        ListViewInsertionMark insertionMark = control.InsertionMark;
+        insertionMark.Color = Color.FromArgb(0x12, 0x34, 0x56, 0x78);
+
+        // Set same.
+        Assert.NotEqual(IntPtr.Zero, control.Handle);
+        control.InsertionMark.Index = 0;
+        LVINSERTMARK insertMark = new()
+        {
+            cbSize = (uint)sizeof(LVINSERTMARK)
+        };
+        Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
+        Assert.Equal(0x80000000, insertMark.dwFlags);
+        Assert.Equal(-1, insertMark.iItem);
+        Assert.Equal(0u, insertMark.dwReserved);
+        Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
+
+        // Set negative one.
+        Assert.NotEqual(IntPtr.Zero, control.Handle);
+        control.InsertionMark.Index = -1;
+        insertMark = new LVINSERTMARK
+        {
+            cbSize = (uint)sizeof(LVINSERTMARK)
+        };
+        Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
+        Assert.Equal(0x80000000, insertMark.dwFlags);
+        Assert.Equal(-1, insertMark.iItem);
+        Assert.Equal(0u, insertMark.dwReserved);
+        Assert.Equal(0x785634, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
+
+        // Set different.
+        control.InsertionMark.Index = index;
+        insertMark = new LVINSERTMARK
+        {
+            cbSize = (uint)sizeof(LVINSERTMARK)
+        };
+        Assert.Equal(1, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
+        Assert.Equal(0x80000000, insertMark.dwFlags);
+        Assert.Equal(index, insertMark.iItem);
+        Assert.Equal(0u, insertMark.dwReserved);
+        Assert.Equal(0x785634, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
+    }
+}

--- a/src/test/integration/UIIntegrationTests/ListViewInsertionMarkTests.cs
+++ b/src/test/integration/UIIntegrationTests/ListViewInsertionMarkTests.cs
@@ -6,15 +6,17 @@ using System.Drawing;
 namespace System.Windows.Forms.UITests;
 
 // Migrated from unit tests; see issue #4500.
-public class ListViewInsertionMarkTests
+public class ListViewInsertionMarkTests : ControlTestBase
 {
+    public ListViewInsertionMarkTests(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+    }
+
     [WinFormsFact]
     public unsafe void ListViewInsertionMark_AppearsAfterItem_GetInsertMark_Success()
     {
-        Application.EnableVisualStyles();
-
         using ListView control = new();
-        ListViewInsertionMark insertionMark = control.InsertionMark;
 
         // Set same.
         Assert.NotEqual(IntPtr.Zero, control.Handle);
@@ -57,10 +59,7 @@ public class ListViewInsertionMarkTests
     [WinFormsFact]
     public unsafe void ListViewInsertionMark_AppearsAfterItem_GetInsertMarkWithColor_Success()
     {
-        Application.EnableVisualStyles();
-
         using ListView control = new();
-        ListViewInsertionMark insertionMark = control.InsertionMark;
         control.InsertionMark.Color = Color.FromArgb(0x12, 0x34, 0x56, 0x78);
 
         // Set same.
@@ -104,10 +103,7 @@ public class ListViewInsertionMarkTests
     [WinFormsFact]
     public unsafe void ListViewInsertionMark_Color_GetInsertMarkColor_Success()
     {
-        Application.EnableVisualStyles();
-
         using ListView control = new();
-        ListViewInsertionMark insertionMark = control.InsertionMark;
         Assert.NotEqual(IntPtr.Zero, control.Handle);
 
         // Set same.
@@ -140,10 +136,7 @@ public class ListViewInsertionMarkTests
     [InlineData(1)]
     public unsafe void ListViewInsertionMark_Index_GetInsertMark_Success(int index)
     {
-        Application.EnableVisualStyles();
-
         using ListView control = new();
-        ListViewInsertionMark insertionMark = control.InsertionMark;
 
         // Set same.
         Assert.NotEqual(IntPtr.Zero, control.Handle);
@@ -189,8 +182,6 @@ public class ListViewInsertionMarkTests
     [InlineData(1)]
     public unsafe void ListViewInsertionMark_Index_GetInsertMarkWithColor_Success(int index)
     {
-        Application.EnableVisualStyles();
-
         using ListView control = new();
         ListViewInsertionMark insertionMark = control.InsertionMark;
         insertionMark.Color = Color.FromArgb(0x12, 0x34, 0x56, 0x78);

--- a/src/test/integration/UIIntegrationTests/TabPageTests.cs
+++ b/src/test/integration/UIIntegrationTests/TabPageTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
-using System.Windows.Forms.TestUtilities;
 
 namespace System.Windows.Forms.UITests;
 

--- a/src/test/integration/UIIntegrationTests/TabPageTests.cs
+++ b/src/test/integration/UIIntegrationTests/TabPageTests.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Drawing;
+using System.Windows.Forms.TestUtilities;
+
+namespace System.Windows.Forms.UITests;
+
+// Migrated from unit tests; see issue #4500.
+public class TabPageTests
+{
+    [WinFormsTheory]
+    [BoolData]
+    public static void TabPage_BackColor_GetVisualStyles_ReturnsExpected(bool useVisualStyleBackColor)
+    {
+        Application.EnableVisualStyles();
+
+        using TabPage control = new()
+        {
+            UseVisualStyleBackColor = useVisualStyleBackColor
+        };
+        Assert.Equal(Control.DefaultBackColor, control.BackColor);
+    }
+
+    public static IEnumerable<object[]> BackColor_GetVisualStylesWithParent_TestData()
+    {
+        yield return new object[] { true, TabAppearance.Buttons, Control.DefaultBackColor };
+        yield return new object[] { true, TabAppearance.FlatButtons, Control.DefaultBackColor };
+        yield return new object[] { true, TabAppearance.Normal, Color.Transparent };
+        yield return new object[] { false, TabAppearance.Buttons, Control.DefaultBackColor };
+        yield return new object[] { false, TabAppearance.FlatButtons, Control.DefaultBackColor };
+        yield return new object[] { false, TabAppearance.Normal, Control.DefaultBackColor };
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(BackColor_GetVisualStylesWithParent_TestData))]
+    public static void TabPage_BackColor_GetVisualStylesWithParent_ReturnsExpected(bool useVisualStyleBackColor, TabAppearance parentAppearance, Color expected)
+    {
+        Application.EnableVisualStyles();
+
+        using TabControl parent = new()
+        {
+            Appearance = parentAppearance
+        };
+        using TabPage control = new()
+        {
+            UseVisualStyleBackColor = useVisualStyleBackColor,
+            Parent = parent
+        };
+        Assert.Equal(expected.ToArgb(), control.BackColor.ToArgb());
+    }
+}

--- a/src/test/integration/UIIntegrationTests/TabPageTests.cs
+++ b/src/test/integration/UIIntegrationTests/TabPageTests.cs
@@ -6,14 +6,17 @@ using System.Drawing;
 namespace System.Windows.Forms.UITests;
 
 // Migrated from unit tests; see issue #4500.
-public class TabPageTests
+public class TabPageTests : ControlTestBase
 {
+    public TabPageTests(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+    }
+
     [WinFormsTheory]
     [BoolData]
-    public static void TabPage_BackColor_GetVisualStyles_ReturnsExpected(bool useVisualStyleBackColor)
+    public void TabPage_BackColor_GetVisualStyles_ReturnsExpected(bool useVisualStyleBackColor)
     {
-        Application.EnableVisualStyles();
-
         using TabPage control = new()
         {
             UseVisualStyleBackColor = useVisualStyleBackColor
@@ -33,10 +36,8 @@ public class TabPageTests
 
     [WinFormsTheory]
     [MemberData(nameof(BackColor_GetVisualStylesWithParent_TestData))]
-    public static void TabPage_BackColor_GetVisualStylesWithParent_ReturnsExpected(bool useVisualStyleBackColor, TabAppearance parentAppearance, Color expected)
+    public void TabPage_BackColor_GetVisualStylesWithParent_ReturnsExpected(bool useVisualStyleBackColor, TabAppearance parentAppearance, Color expected)
     {
-        Application.EnableVisualStyles();
-
         using TabControl parent = new()
         {
             Appearance = parentAppearance

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/Application.ParkingWindowTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/Application.ParkingWindowTests.cs
@@ -3,58 +3,15 @@
 
 #nullable disable
 
-using Microsoft.DotNet.RemoteExecutor;
 using static System.Windows.Forms.Application;
 
 namespace System.Windows.Forms.Tests;
 
 public class ParkingWindowTests
 {
-    [WinFormsFact(Skip = "Crash with AbandonedMutexException. See: https://github.com/dotnet/arcade/issues/5325")]
-    public void ParkingWindow_DoesNotThrowOnGarbageCollecting()
-    {
-        using RemoteInvokeHandle invokerHandle = RemoteExecutor.Invoke(() =>
-        {
-            Control.CheckForIllegalCrossThreadCalls = true;
-
-            Form form = InitFormWithControlToGarbageCollect();
-
-            try
-            {
-                // Force garbage collecting to access ComboBox from another (GC) thread.
-                GC.Collect();
-
-                GC.WaitForPendingFinalizers();
-            }
-            catch (Exception ex)
-            {
-                Assert.True(ex is null, $"Expected no exception, but got: {ex.Message}"); // Actually need to check whether GC.Collect() does not throw exception.
-            }
-        });
-
-        // verify the remote process succeeded
-        Assert.Equal(RemoteExecutor.SuccessExitCode, invokerHandle.ExitCode);
-    }
-
-    private static Form InitFormWithControlToGarbageCollect()
-    {
-        Form form = new();
-        ComboBox comboBox = new()
-        {
-            DropDownStyle = ComboBoxStyle.DropDown
-        };
-
-        form.Controls.Add(comboBox);
-        form.Show();
-
-        // Park ComboBox handle in ParkingWindow.
-        comboBox.Parent = null;
-
-        // Recreate ComboBox handle to set parent to ParkingWindow.
-        comboBox.DropDownStyle = ComboBoxStyle.DropDownList;
-
-        return form;
-    }
+    // ParkingWindow_DoesNotThrowOnGarbageCollecting moved to
+    // src/test/integration/UIIntegrationTests/Application.ParkingWindowTests.cs
+    // (issue #4500 — process-wide state mutation cannot be safely undone in this project).
 
     [WinFormsFact]
     public void ParkingWindow_Unaware()

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ApplicationTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ApplicationTests.cs
@@ -5,7 +5,6 @@
 
 using System.ComponentModel;
 using System.Drawing;
-using System.Globalization;
 using System.Windows.Forms.VisualStyles;
 using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Win32;

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ApplicationTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ApplicationTests.cs
@@ -553,5 +553,4 @@ public class ApplicationTests
         Assert.Equal(expected.GdiCharSet, actual.GdiCharSet);
         Assert.Equal(expected.Style, actual.Style);
     }
-
 }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ApplicationTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ApplicationTests.cs
@@ -20,86 +20,17 @@ public class ApplicationTests
         Assert.Same(Thread.CurrentThread.CurrentCulture, Application.CurrentCulture);
     }
 
-    public static IEnumerable<object[]> CurrentCulture_Set_TestData()
-    {
-        yield return new object[] { CultureInfo.InvariantCulture, 0x7Fu };
-        yield return new object[] { new CultureInfo("en"), 0x9u };
-        yield return new object[] { new CultureInfo("fr-FR"), 0x40Cu };
-        yield return new object[] { new CultureInfo("en-DK"), 0xC00u };
-        yield return new object[] { new CultureInfo("haw"), 0x00000075u };
-        yield return new object[] { new CultureInfo("en-US"), 0x00000409u };
-        yield return new object[] { new CultureInfo("de-DE_phoneb"), 0x00010407u };
-        yield return new object[] { new CustomLCIDCultureInfo(10), 0x409u };
-        yield return new object[] { new CustomLCIDCultureInfo(0), 0x409u };
-        yield return new object[] { new CustomLCIDCultureInfo(-1), 0x409u };
-    }
-
-    [WinFormsFact(Skip = "Crash with AbandonedMutexException. See: https://github.com/dotnet/arcade/issues/5325")]
-    public void Application_CurrentCulture_Set_GetReturnsExpected()
-    {
-        RemoteExecutor.Invoke(() =>
-        {
-            foreach (object[] testData in CurrentCulture_Set_TestData())
-            {
-                CultureInfo value = (CultureInfo)testData[0];
-                uint expectedLcid = (uint)testData[1];
-
-                CultureInfo oldValue = Application.CurrentCulture;
-                try
-                {
-                    Application.CurrentCulture = value;
-                    Assert.Same(value, Application.CurrentCulture);
-                    Assert.Same(value, Thread.CurrentThread.CurrentCulture);
-                    Assert.Same(value, CultureInfo.CurrentCulture);
-                    Assert.Equal(expectedLcid, PInvokeCore.GetThreadLocale());
-
-                    // Set same.
-                    Application.CurrentCulture = value;
-                    Assert.Same(value, Application.CurrentCulture);
-                    Assert.Same(value, Thread.CurrentThread.CurrentCulture);
-                    Assert.Same(value, CultureInfo.CurrentCulture);
-                    Assert.Equal(expectedLcid, PInvokeCore.GetThreadLocale());
-                }
-                finally
-                {
-                    Application.CurrentCulture = oldValue;
-                }
-            }
-        }).Dispose();
-    }
+    // Application_CurrentCulture_Set_GetReturnsExpected,
+    // Application_EnableVisualStyles_InvokeBeforeGettingRenderWithVisualStyles_Success,
+    // Application_VisualStyleState_Set_ReturnsExpected moved to
+    // src/test/integration/UIIntegrationTests/Application.StaticStateTests.cs (issue #4500).
+    // Application_EnableVisualStyles_InvokeAfterGettingRenderWithVisualStyles_Success was dropped
+    // because its precondition (UseVisualStyles == false) cannot be reproduced without process isolation.
 
     [WinFormsFact]
     public void Application_CurrentCulture_SetNull_ThrowsArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>("value", () => Application.CurrentCulture = null);
-    }
-
-    [WinFormsFact(Skip = "Crash with AbandonedMutexException. See: https://github.com/dotnet/arcade/issues/5325")]
-    public void Application_EnableVisualStyles_InvokeBeforeGettingRenderWithVisualStyles_Success()
-    {
-        RemoteExecutor.Invoke(() =>
-        {
-            Application.EnableVisualStyles();
-            Assert.True(Application.UseVisualStyles);
-            Assert.True(Application.RenderWithVisualStyles);
-        }).Dispose();
-    }
-
-    [WinFormsFact(Skip = "Crash with AbandonedMutexException. See: https://github.com/dotnet/arcade/issues/5325")]
-    public void Application_EnableVisualStyles_InvokeAfterGettingRenderWithVisualStyles_Success()
-    {
-        // This is not a recommended scenario per
-        // https://docs.microsoft.com/dotnet/api/system.windows.forms.application.enablevisualstyles
-        // EnableVisualStyles should be executed before any control-related code is.
-        RemoteExecutor.Invoke(() =>
-        {
-            Assert.False(Application.UseVisualStyles);
-            Assert.False(Application.RenderWithVisualStyles);
-
-            Application.EnableVisualStyles();
-            Assert.True(Application.UseVisualStyles, "New Visual Styles will not be applied on WinForms app. This is a high priority bug and must be looked into");
-            Assert.True(Application.RenderWithVisualStyles);
-        }).Dispose();
     }
 
     [WinFormsFact]
@@ -115,29 +46,6 @@ public class ApplicationTests
         VisualStyleState state = Application.VisualStyleState;
         Assert.True(Enum.IsDefined(state));
         Assert.Equal(state, Application.VisualStyleState);
-    }
-
-    [WinFormsTheory(Skip = "Crash with AbandonedMutexException. See: https://github.com/dotnet/arcade/issues/5325")]
-    [EnumData<VisualStyleState>]
-    [InvalidEnumData<VisualStyleState>]
-    public void Application_VisualStyleState_Set_ReturnsExpected(VisualStyleState valueParam)
-    {
-        // This needs to be in RemoteExecutor.Invoke because changing Application.VisualStyleState
-        // sends WM_THEMECHANGED to all controls, which can cause a deadlock if another test fails.
-        RemoteExecutor.Invoke((valueString) =>
-        {
-            VisualStyleState value = Enum.Parse<VisualStyleState>(valueString);
-            VisualStyleState state = Application.VisualStyleState;
-            try
-            {
-                Application.VisualStyleState = value;
-                Assert.Equal(value, Application.VisualStyleState);
-            }
-            finally
-            {
-                Application.VisualStyleState = state;
-            }
-        }, valueParam.ToString());
     }
 
     [Fact]
@@ -646,15 +554,4 @@ public class ApplicationTests
         Assert.Equal(expected.Style, actual.Style);
     }
 
-    private class CustomLCIDCultureInfo : CultureInfo
-    {
-        private readonly int _lcid;
-
-        public CustomLCIDCultureInfo(int lcid) : base("en-US")
-        {
-            _lcid = lcid;
-        }
-
-        public override int LCID => _lcid;
-    }
 }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/CommonDialogTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/CommonDialogTests.cs
@@ -5,7 +5,6 @@
 
 using System.ComponentModel;
 using System.Reflection;
-using Microsoft.DotNet.RemoteExecutor;
 using Moq;
 
 namespace System.Windows.Forms.Tests;
@@ -118,30 +117,10 @@ public class CommonDialogTests
         Assert.Equal(expectedDialogResult, dialog.ShowDialog(owner.Object));
     }
 
-    [WinFormsTheory(Skip = "Crash with AbandonedMutexException. See: https://github.com/dotnet/arcade/issues/5325")]
-    [InlineData(true, DialogResult.OK)]
-    [InlineData(false, DialogResult.Cancel)]
-    public void ShowDialog_NonControlOwnerWithVisualStyles_ReturnsExpected(bool runDialogResultParam, DialogResult expectedDialogResultParam)
-    {
-        // Run this from another thread as we call Application.EnableVisualStyles.
-        RemoteExecutor.Invoke((runDialogResultString, expectedDialogResultString) =>
-        {
-            bool runDialogResult = bool.Parse(runDialogResultString);
-            DialogResult expectedDialogResult = (DialogResult)Enum.Parse(typeof(DialogResult), expectedDialogResultString);
-
-            Application.EnableVisualStyles();
-
-            using SubCommonDialog dialog = new()
-            {
-                RunDialogResult = runDialogResult
-            };
-            var owner = new Mock<IWin32Window>(MockBehavior.Strict);
-            owner
-                .Setup(o => o.Handle)
-                .Returns(IntPtr.Zero);
-            Assert.Equal(expectedDialogResult, dialog.ShowDialog(owner.Object));
-        }, runDialogResultParam.ToString(), expectedDialogResultParam.ToString()).Dispose();
-    }
+    // ShowDialog_NonControlOwnerWithVisualStyles_ReturnsExpected,
+    // ShowDialog_ControlOwnerWithVisualStyles_ReturnsExpected,
+    // ShowDialog_ControlOwnerWithHandleWithVisualStyles_ReturnsExpected moved to
+    // src/test/integration/UIIntegrationTests/CommonDialogTests.cs (issue #4500).
 
     [WinFormsTheory]
     [InlineData(true, DialogResult.OK)]
@@ -156,28 +135,6 @@ public class CommonDialogTests
         Assert.Equal(expectedDialogResult, dialog.ShowDialog(owner));
     }
 
-    [WinFormsTheory(Skip = "Crash with AbandonedMutexException. See: https://github.com/dotnet/arcade/issues/5325")]
-    [InlineData(true, DialogResult.OK)]
-    [InlineData(false, DialogResult.Cancel)]
-    public void ShowDialog_ControlOwnerWithVisualStyles_ReturnsExpected(bool runDialogResultParam, DialogResult expectedDialogResultParam)
-    {
-        // Run this from another thread as we call Application.EnableVisualStyles.
-        RemoteExecutor.Invoke((runDialogResultString, expectedDialogResultString) =>
-        {
-            bool runDialogResult = bool.Parse(runDialogResultString);
-            DialogResult expectedDialogResult = (DialogResult)Enum.Parse(typeof(DialogResult), expectedDialogResultString);
-
-            Application.EnableVisualStyles();
-
-            using SubCommonDialog dialog = new()
-            {
-                RunDialogResult = runDialogResult
-            };
-            using Control owner = new();
-            Assert.Equal(expectedDialogResult, dialog.ShowDialog(owner));
-        }, runDialogResultParam.ToString(), expectedDialogResultParam.ToString()).Dispose();
-    }
-
     [WinFormsTheory]
     [InlineData(true, DialogResult.OK)]
     [InlineData(false, DialogResult.Cancel)]
@@ -190,29 +147,6 @@ public class CommonDialogTests
         using Control owner = new();
         Assert.NotEqual(IntPtr.Zero, owner.Handle);
         Assert.Equal(expectedDialogResult, dialog.ShowDialog(owner));
-    }
-
-    [WinFormsTheory(Skip = "Crash with AbandonedMutexException. See: https://github.com/dotnet/arcade/issues/5325")]
-    [InlineData(true, DialogResult.OK)]
-    [InlineData(false, DialogResult.Cancel)]
-    public void ShowDialog_ControlOwnerWithHandleWithVisualStyles_ReturnsExpected(bool runDialogResultParam, DialogResult expectedDialogResultParam)
-    {
-        // Run this from another thread as we call Application.EnableVisualStyles.
-        RemoteExecutor.Invoke((runDialogResultString, expectedDialogResultString) =>
-        {
-            bool runDialogResult = bool.Parse(runDialogResultString);
-            DialogResult expectedDialogResult = (DialogResult)Enum.Parse(typeof(DialogResult), expectedDialogResultString);
-
-            Application.EnableVisualStyles();
-
-            using SubCommonDialog dialog = new()
-            {
-                RunDialogResult = runDialogResult
-            };
-            using Control owner = new();
-            Assert.NotEqual(IntPtr.Zero, owner.Handle);
-            Assert.Equal(expectedDialogResult, dialog.ShowDialog(owner));
-        }, runDialogResultParam.ToString(), expectedDialogResultParam.ToString()).Dispose();
     }
 
     [WinFormsFact]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewHeaderCellTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewHeaderCellTests.cs
@@ -3998,49 +3998,9 @@ public class DataGridViewHeaderCellTests
         Assert.False(control.IsHandleCreated);
     }
 
-    public static IEnumerable<object[]> MouseLeaveUnsharesRow_WithDataGridViewMouseDown_TestData()
-    {
-        ButtonState expected = VisualStyleRenderer.IsSupported ? ButtonState.Pushed : ButtonState.Normal;
-        yield return new object[] { true, -2, expected };
-        yield return new object[] { true, -1, expected };
-        yield return new object[] { true, 0, expected };
-        yield return new object[] { true, 1, expected };
-        yield return new object[] { false, -2, ButtonState.Normal };
-        yield return new object[] { false, -1, ButtonState.Normal };
-        yield return new object[] { false, 0, ButtonState.Normal };
-        yield return new object[] { false, 1, ButtonState.Normal };
-    }
-
-    [WinFormsTheory(Skip = "Crash with AbandonedMutexException. See: https://github.com/dotnet/arcade/issues/5325")]
-    [MemberData(nameof(MouseLeaveUnsharesRow_WithDataGridViewMouseDown_TestData))]
-    public void DataGridViewHeaderCell_MouseLeaveUnsharesRow_InvokeWithDataGridViewMouseDown_ReturnsExpected(bool enableHeadersVisualStylesParam, int rowIndexParam, ButtonState expectedButtonStateParam)
-    {
-        // Run this from another thread as we call Application.EnableVisualStyles.
-        RemoteExecutor.Invoke((enableHeadersVisualStylesString, rowIndexString, expectedButtonStateString) =>
-        {
-            bool enableHeadersVisualStyles = bool.Parse(enableHeadersVisualStylesString);
-            int rowIndex = int.Parse(rowIndexString);
-            ButtonState expectedButtonState = (ButtonState)Enum.Parse(typeof(ButtonState), expectedButtonStateString);
-
-            Application.EnableVisualStyles();
-
-            using SubDataGridViewHeaderCell cellTemplate = new();
-            using DataGridViewColumn column = new()
-            {
-                CellTemplate = cellTemplate
-            };
-            using DataGridView control = new()
-            {
-                EnableHeadersVisualStyles = enableHeadersVisualStyles
-            };
-            control.Columns.Add(column);
-            SubDataGridViewHeaderCell cell = (SubDataGridViewHeaderCell)control.Rows[0].Cells[0];
-            cell.OnMouseDown(new DataGridViewCellMouseEventArgs(-1, -1, 0, 0, new MouseEventArgs(MouseButtons.Left, 0, 0, 0, 0)));
-            Assert.Equal(enableHeadersVisualStyles && VisualStyleRenderer.IsSupported, cell.MouseLeaveUnsharesRow(rowIndex));
-            Assert.Equal(expectedButtonState, cell.ButtonState);
-            Assert.False(control.IsHandleCreated);
-        }, enableHeadersVisualStylesParam.ToString(), rowIndexParam.ToString(), expectedButtonStateParam.ToString()).Dispose();
-    }
+    // DataGridViewHeaderCell_MouseLeaveUnsharesRow_InvokeWithDataGridViewMouseDown_ReturnsExpected
+    // and its MouseLeaveUnsharesRow_WithDataGridViewMouseDown_TestData moved to
+    // src/test/integration/UIIntegrationTests/DataGridViewHeaderCellTests.cs (issue #4500).
 
     [WinFormsTheory]
     [MemberData(nameof(MouseDownUnsharesRow_TestData))]
@@ -4190,30 +4150,8 @@ public class DataGridViewHeaderCellTests
         }).Dispose();
     }
 
-    [WinFormsFact(Skip = "Crash with AbandonedMutexException. See: https://github.com/dotnet/arcade/issues/5325")]
-    public void DataGridViewHeaderCell_OnMouseDown_InvalidRowIndexVisualStyles_ThrowsArgumentOutOfRangeException()
-    {
-        // Run this from another thread as we call Application.EnableVisualStyles.
-        RemoteExecutor.Invoke(() =>
-        {
-            Application.EnableVisualStyles();
-
-            using SubDataGridViewHeaderCell cellTemplate = new();
-            using DataGridViewColumn column = new()
-            {
-                CellTemplate = cellTemplate
-            };
-            using DataGridView control = new()
-            {
-                EnableHeadersVisualStyles = true
-            };
-            control.Columns.Add(column);
-            SubDataGridViewHeaderCell cell = (SubDataGridViewHeaderCell)control.Rows[0].Cells[0];
-            DataGridViewCellMouseEventArgs e = new(0, 1, 0, 0, new MouseEventArgs(MouseButtons.Left, 0, 0, 0, 0));
-            Assert.Throws<ArgumentOutOfRangeException>("rowIndex", () => cell.OnMouseDown(e));
-            Assert.Equal(VisualStyleRenderer.IsSupported ? ButtonState.Pushed : ButtonState.Normal, cell.ButtonState);
-        }).Dispose();
-    }
+    // DataGridViewHeaderCell_OnMouseDown_InvalidRowIndexVisualStyles_ThrowsArgumentOutOfRangeException
+    // moved to src/test/integration/UIIntegrationTests/DataGridViewHeaderCellTests.cs (issue #4500).
 
     [WinFormsFact]
     public void DataGridViewHeaderCell_OnMouseDown_NullEWithDataGridView_ThrowsNullReferenceException()
@@ -4573,30 +4511,8 @@ public class DataGridViewHeaderCellTests
         }).Dispose();
     }
 
-    [WinFormsFact(Skip = "Crash with AbandonedMutexException. See: https://github.com/dotnet/arcade/issues/5325")]
-    public void DataGridViewHeaderCell_OnMouseUp_InvalidRowIndexVisualStyles_ThrowsArgumentOutOfRangeException()
-    {
-        // Run this from another thread as we call Application.EnableVisualStyles.
-        RemoteExecutor.Invoke(() =>
-        {
-            Application.EnableVisualStyles();
-
-            using SubDataGridViewHeaderCell cellTemplate = new();
-            using DataGridViewColumn column = new()
-            {
-                CellTemplate = cellTemplate
-            };
-            using DataGridView control = new()
-            {
-                EnableHeadersVisualStyles = true
-            };
-            control.Columns.Add(column);
-            SubDataGridViewHeaderCell cell = (SubDataGridViewHeaderCell)control.Rows[0].Cells[0];
-            DataGridViewCellMouseEventArgs e = new(0, 1, 0, 0, new MouseEventArgs(MouseButtons.Left, 0, 0, 0, 0));
-            Assert.Throws<ArgumentOutOfRangeException>("rowIndex", () => cell.OnMouseUp(e));
-            Assert.Equal(ButtonState.Normal, cell.ButtonState);
-        }).Dispose();
-    }
+    // DataGridViewHeaderCell_OnMouseUp_InvalidRowIndexVisualStyles_ThrowsArgumentOutOfRangeException
+    // moved to src/test/integration/UIIntegrationTests/DataGridViewHeaderCellTests.cs (issue #4500).
 
     [WinFormsFact]
     public void DataGridViewHeaderCell_OnMouseUp_NullEWithDataGridView_ThrowsNullReferenceException()

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ListViewInsertionMarkTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ListViewInsertionMarkTests.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System.Drawing;
-using Microsoft.DotNet.RemoteExecutor;
 using Point = System.Drawing.Point;
 
 namespace System.Windows.Forms.Tests;
@@ -80,106 +79,9 @@ public class ListViewInsertionMarkTests
         Assert.Equal(0, createdCallCount);
     }
 
-    [WinFormsFact(Skip = "Crash with AbandonedMutexException. See: https://github.com/dotnet/arcade/issues/5325")]
-    public unsafe void ListViewInsertionMark_AppearsAfterItem_GetInsertMark_Success()
-    {
-        // Run this from another thread as we call Application.EnableVisualStyles.
-        RemoteExecutor.Invoke(() =>
-        {
-            Application.EnableVisualStyles();
-
-            using ListView control = new();
-            ListViewInsertionMark insertionMark = control.InsertionMark;
-
-            // Set same.
-            Assert.NotEqual(IntPtr.Zero, control.Handle);
-            control.InsertionMark.AppearsAfterItem = false;
-            LVINSERTMARK insertMark = new()
-            {
-                cbSize = (uint)sizeof(LVINSERTMARK)
-            };
-            Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
-            Assert.Equal(0x80000000, insertMark.dwFlags);
-            Assert.Equal(-1, insertMark.iItem);
-            Assert.Equal(0u, insertMark.dwReserved);
-            Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
-
-            // Set true.
-            control.InsertionMark.AppearsAfterItem = true;
-            insertMark = new LVINSERTMARK
-            {
-                cbSize = (uint)sizeof(LVINSERTMARK)
-            };
-            Assert.Equal(1, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
-            Assert.Equal(0x80000001, insertMark.dwFlags);
-            Assert.Equal(0, insertMark.iItem);
-            Assert.Equal(0u, insertMark.dwReserved);
-            Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
-
-            // Set false.
-            control.InsertionMark.AppearsAfterItem = false;
-            insertMark = new LVINSERTMARK
-            {
-                cbSize = (uint)sizeof(LVINSERTMARK)
-            };
-            Assert.Equal(1, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
-            Assert.Equal(0x80000000, insertMark.dwFlags);
-            Assert.Equal(0, insertMark.iItem);
-            Assert.Equal(0u, insertMark.dwReserved);
-            Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
-        }).Dispose();
-    }
-
-    [WinFormsFact(Skip = "Crash with AbandonedMutexException. See: https://github.com/dotnet/arcade/issues/5325")]
-    public unsafe void ListViewInsertionMark_AppearsAfterItem_GetInsertMarkWithColor_Success()
-    {
-        // Run this from another thread as we call Application.EnableVisualStyles.
-        RemoteExecutor.Invoke(() =>
-        {
-            Application.EnableVisualStyles();
-
-            using ListView control = new();
-            ListViewInsertionMark insertionMark = control.InsertionMark;
-            control.InsertionMark.Color = Color.FromArgb(0x12, 0x34, 0x56, 0x78);
-
-            // Set same.
-            Assert.NotEqual(IntPtr.Zero, control.Handle);
-            control.InsertionMark.AppearsAfterItem = false;
-            LVINSERTMARK insertMark = new()
-            {
-                cbSize = (uint)sizeof(LVINSERTMARK)
-            };
-            Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
-            Assert.Equal(0x80000000, insertMark.dwFlags);
-            Assert.Equal(-1, insertMark.iItem);
-            Assert.Equal(0u, insertMark.dwReserved);
-            Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
-
-            // Set true.
-            control.InsertionMark.AppearsAfterItem = true;
-            insertMark = new LVINSERTMARK
-            {
-                cbSize = (uint)sizeof(LVINSERTMARK)
-            };
-            Assert.Equal(1, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
-            Assert.Equal(0x80000001, insertMark.dwFlags);
-            Assert.Equal(0, insertMark.iItem);
-            Assert.Equal(0u, insertMark.dwReserved);
-            Assert.Equal(0x785634, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
-
-            // Set false.
-            control.InsertionMark.AppearsAfterItem = false;
-            insertMark = new LVINSERTMARK
-            {
-                cbSize = (uint)sizeof(LVINSERTMARK)
-            };
-            Assert.Equal(1, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
-            Assert.Equal(0x80000000, insertMark.dwFlags);
-            Assert.Equal(0, insertMark.iItem);
-            Assert.Equal(0u, insertMark.dwReserved);
-            Assert.Equal(0x785634, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
-        }).Dispose();
-    }
+    // ListViewInsertionMark_AppearsAfterItem_GetInsertMark_Success and
+    // ListViewInsertionMark_AppearsAfterItem_GetInsertMarkWithColor_Success moved to
+    // src/test/integration/UIIntegrationTests/ListViewInsertionMarkTests.cs (issue #4500).
 
     [WinFormsFact]
     public void ListViewInsertionMark_Bounds_GetWithoutHandle_ReturnsEqual()
@@ -356,43 +258,8 @@ public class ListViewInsertionMarkTests
         Assert.Equal(0, createdCallCount);
     }
 
-    [WinFormsFact(Skip = "Crash with AbandonedMutexException. See: https://github.com/dotnet/arcade/issues/5325")]
-    public unsafe void ListViewInsertionMark_Color_GetInsertMarkColor_Success()
-    {
-        // Run this from another thread as we call Application.EnableVisualStyles.
-        RemoteExecutor.Invoke(() =>
-        {
-            Application.EnableVisualStyles();
-
-            using ListView control = new();
-            ListViewInsertionMark insertionMark = control.InsertionMark;
-            Assert.NotEqual(IntPtr.Zero, control.Handle);
-
-            // Set same.
-            control.InsertionMark.Color = Color.Empty;
-            LVINSERTMARK insertMark = new()
-            {
-                cbSize = (uint)sizeof(LVINSERTMARK)
-            };
-            Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
-            Assert.Equal(0x80000000, insertMark.dwFlags);
-            Assert.Equal(-1, insertMark.iItem);
-            Assert.Equal(0u, insertMark.dwReserved);
-            Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
-
-            // Set different.
-            control.InsertionMark.Color = Color.FromArgb(0x12, 0x34, 0x56, 0x78);
-            insertMark = new LVINSERTMARK
-            {
-                cbSize = (uint)sizeof(LVINSERTMARK)
-            };
-            Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
-            Assert.Equal(0x80000000, insertMark.dwFlags);
-            Assert.Equal(-1, insertMark.iItem);
-            Assert.Equal(0u, insertMark.dwReserved);
-            Assert.Equal(0x785634, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
-        }).Dispose();
-    }
+    // ListViewInsertionMark_Color_GetInsertMarkColor_Success moved to
+    // src/test/integration/UIIntegrationTests/ListViewInsertionMarkTests.cs (issue #4500).
 
     [WinFormsFact]
     public void ListViewInsertionMark_Index_Get_ReturnsExpected()
@@ -450,114 +317,9 @@ public class ListViewInsertionMarkTests
         Assert.Equal(value, insertionMark.Index);
     }
 
-    [WinFormsTheory(Skip = "Crash with AbandonedMutexException. See: https://github.com/dotnet/arcade/issues/5325")]
-    [InlineData(-2)]
-    [InlineData(1)]
-    public unsafe void ListViewInsertionMark_Index_GetInsertMark_Success(int indexParam)
-    {
-        // Run this from another thread as we call Application.EnableVisualStyles.
-        RemoteExecutor.Invoke((indexString) =>
-        {
-            int index = int.Parse(indexString);
-            Application.EnableVisualStyles();
-
-            using ListView control = new();
-            ListViewInsertionMark insertionMark = control.InsertionMark;
-
-            // Set same.
-            Assert.NotEqual(IntPtr.Zero, control.Handle);
-            control.InsertionMark.Index = 0;
-            LVINSERTMARK insertMark = new()
-            {
-                cbSize = (uint)sizeof(LVINSERTMARK)
-            };
-            Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
-            Assert.Equal(0x80000000, insertMark.dwFlags);
-            Assert.Equal(-1, insertMark.iItem);
-            Assert.Equal(0u, insertMark.dwReserved);
-            Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
-
-            // Set negative one.
-            Assert.NotEqual(IntPtr.Zero, control.Handle);
-            control.InsertionMark.Index = -1;
-            insertMark = new LVINSERTMARK
-            {
-                cbSize = (uint)sizeof(LVINSERTMARK)
-            };
-            Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
-            Assert.Equal(0x80000000, insertMark.dwFlags);
-            Assert.Equal(-1, insertMark.iItem);
-            Assert.Equal(0u, insertMark.dwReserved);
-            Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
-
-            // Set different.
-            control.InsertionMark.Index = index;
-            insertMark = new LVINSERTMARK
-            {
-                cbSize = (uint)sizeof(LVINSERTMARK)
-            };
-            Assert.Equal(1, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
-            Assert.Equal(0x80000000, insertMark.dwFlags);
-            Assert.Equal(index, insertMark.iItem);
-            Assert.Equal(0u, insertMark.dwReserved);
-            Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
-        }, indexParam.ToString()).Dispose();
-    }
-
-    [WinFormsTheory(Skip = "Crash with AbandonedMutexException. See: https://github.com/dotnet/arcade/issues/5325")]
-    [InlineData(-2)]
-    [InlineData(1)]
-    public unsafe void ListViewInsertionMark_Index_GetInsertMarkWithColor_Success(int indexParam)
-    {
-        // Run this from another thread as we call Application.EnableVisualStyles.
-        RemoteExecutor.Invoke((indexString) =>
-        {
-            int index = int.Parse(indexString);
-            Application.EnableVisualStyles();
-
-            using ListView control = new();
-            ListViewInsertionMark insertionMark = control.InsertionMark;
-            insertionMark.Color = Color.FromArgb(0x12, 0x34, 0x56, 0x78);
-
-            // Set same.
-            Assert.NotEqual(IntPtr.Zero, control.Handle);
-            control.InsertionMark.Index = 0;
-            LVINSERTMARK insertMark = new()
-            {
-                cbSize = (uint)sizeof(LVINSERTMARK)
-            };
-            Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
-            Assert.Equal(0x80000000, insertMark.dwFlags);
-            Assert.Equal(-1, insertMark.iItem);
-            Assert.Equal(0u, insertMark.dwReserved);
-            Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
-
-            // Set negative one.
-            Assert.NotEqual(IntPtr.Zero, control.Handle);
-            control.InsertionMark.Index = -1;
-            insertMark = new LVINSERTMARK
-            {
-                cbSize = (uint)sizeof(LVINSERTMARK)
-            };
-            Assert.Equal(0, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
-            Assert.Equal(0x80000000, insertMark.dwFlags);
-            Assert.Equal(-1, insertMark.iItem);
-            Assert.Equal(0u, insertMark.dwReserved);
-            Assert.Equal(0x785634, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
-
-            // Set different.
-            control.InsertionMark.Index = index;
-            insertMark = new LVINSERTMARK
-            {
-                cbSize = (uint)sizeof(LVINSERTMARK)
-            };
-            Assert.Equal(1, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARK, 0, ref insertMark));
-            Assert.Equal(0x80000000, insertMark.dwFlags);
-            Assert.Equal(index, insertMark.iItem);
-            Assert.Equal(0u, insertMark.dwReserved);
-            Assert.Equal(0x785634, (int)PInvokeCore.SendMessage(control, PInvoke.LVM_GETINSERTMARKCOLOR));
-        }, indexParam.ToString()).Dispose();
-    }
+    // ListViewInsertionMark_Index_GetInsertMark_Success and
+    // ListViewInsertionMark_Index_GetInsertMarkWithColor_Success moved to
+    // src/test/integration/UIIntegrationTests/ListViewInsertionMarkTests.cs (issue #4500).
 
     [WinFormsFact]
     public void ListViewInsertionMark_NearestIndex_NoSuchPointWithoutHandle_ReturnsInvalid()

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/TabPageTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/TabPageTests.cs
@@ -8,7 +8,6 @@ using System.ComponentModel.Design;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Windows.Forms.TestUtilities;
-using Microsoft.DotNet.RemoteExecutor;
 using Moq;
 using Point = System.Drawing.Point;
 using Size = System.Drawing.Size;
@@ -536,24 +535,8 @@ public class TabPageTests
         Assert.Equal(Control.DefaultBackColor, control.BackColor);
     }
 
-    [WinFormsTheory(Skip = "Crash with AbandonedMutexException. See: https://github.com/dotnet/arcade/issues/5325")]
-    [BoolData]
-    public static void TabPage_BackColor_GetVisualStyles_ReturnsExpected(bool useVisualStyleBackColorParam)
-    {
-        // Run this from another thread as we call Application.EnableVisualStyles.
-        RemoteExecutor.Invoke((useVisualStyleBackColorString) =>
-        {
-            bool useVisualStyleBackColor = bool.Parse(useVisualStyleBackColorString);
-
-            Application.EnableVisualStyles();
-
-            using TabPage control = new()
-            {
-                UseVisualStyleBackColor = useVisualStyleBackColor
-            };
-            Assert.Equal(Control.DefaultBackColor, control.BackColor);
-        }, useVisualStyleBackColorParam.ToString()).Dispose();
-    }
+    // TabPage_BackColor_GetVisualStyles_ReturnsExpected moved to
+    // src/test/integration/UIIntegrationTests/TabPageTests.cs (issue #4500).
 
     [WinFormsTheory]
     [InlineData(true, TabAppearance.Buttons)]
@@ -606,41 +589,9 @@ public class TabPageTests
         }
     }
 
-    public static IEnumerable<object[]> BackColor_GetVisualStylesWithParent_TestData()
-    {
-        yield return new object[] { true, TabAppearance.Buttons, Control.DefaultBackColor };
-        yield return new object[] { true, TabAppearance.FlatButtons, Control.DefaultBackColor };
-        yield return new object[] { true, TabAppearance.Normal, Color.Transparent };
-        yield return new object[] { false, TabAppearance.Buttons, Control.DefaultBackColor };
-        yield return new object[] { false, TabAppearance.FlatButtons, Control.DefaultBackColor };
-        yield return new object[] { false, TabAppearance.Normal, Control.DefaultBackColor };
-    }
-
-    [WinFormsTheory(Skip = "Crash with AbandonedMutexException. See: https://github.com/dotnet/arcade/issues/5325")]
-    [MemberData(nameof(BackColor_GetVisualStylesWithParent_TestData))]
-    public static void TabPage_BackColor_GetVisualStylesWithParent_ReturnsExpected(bool useVisualStyleBackColorParam, TabAppearance parentAppearanceParam, Color expectedParam)
-    {
-        // Run this from another thread as we call Application.EnableVisualStyles.
-        RemoteExecutor.Invoke((useVisualStyleBackColorString, parentAppearanceString, expectedString) =>
-        {
-            bool useVisualStyleBackColor = bool.Parse(useVisualStyleBackColorString);
-            TabAppearance parentAppearance = (TabAppearance)Enum.Parse(typeof(TabAppearance), parentAppearanceString);
-            Color expected = Color.FromArgb(int.Parse(expectedString));
-
-            Application.EnableVisualStyles();
-
-            using TabControl parent = new()
-            {
-                Appearance = parentAppearance
-            };
-            using TabPage control = new()
-            {
-                UseVisualStyleBackColor = useVisualStyleBackColor,
-                Parent = parent
-            };
-            Assert.Equal(expected.ToArgb(), control.BackColor.ToArgb());
-        }, useVisualStyleBackColorParam.ToString(), parentAppearanceParam.ToString(), expectedParam.ToArgb().ToString()).Dispose();
-    }
+    // TabPage_BackColor_GetVisualStylesWithParent_ReturnsExpected and its
+    // BackColor_GetVisualStylesWithParent_TestData moved to
+    // src/test/integration/UIIntegrationTests/TabPageTests.cs (issue #4500).
 
     [WinFormsTheory]
     [CommonMemberData(typeof(CommonTestHelperEx), nameof(CommonTestHelperEx.GetBackColorTheoryData))]


### PR DESCRIPTION
Fixes #4500 (partial; see "Out of scope" below).

Supersedes #12379, which replaced `RemoteExecutor.Invoke(...)` with `Task.Run(...).Wait()`. That doesn't work for this set of tests: they mutate irreversible process-wide state (`Application.EnableVisualStyles`, `Application.VisualStyleState`, `Application.CurrentCulture`, `Control.CheckForIllegalCrossThreadCalls`), so any in-process replacement leaves the mutations behind for whatever runs next. The tests need a host that's isolated by construction.

This PR follows RussKie's suggestion on #4500: move tests that legitimately need an isolated, visual-styles-enabled host into `UIIntegrationTests`, which already runs serially (`eng/xunit.runner.json`: `parallelizeTestCollections: false`, `maxParallelThreads: 1`) and pre-enables visual styles via `ControlTestBase`.

## Root Cause

The original skip reason on each test (`"Crash with AbandonedMutexException. See: https://github.com/dotnet/arcade/issues/5325"`) blames RemoteExecutor, but arcade#5325 is actually a Coverlet bug (`UnloadModule` mutex); the winforms repo still consumes the affected `coverlet.msbuild` variant. RemoteExecutor isn't the bug; it's the side that was easy to remove. These tests need *some* form of isolation though; `EnableVisualStyles` is a one-way switch, and `VisualStyleState` writes broadcast `WM_THEMECHANGED` to every HWND in the process. UIIntegrationTests already provides that isolation by construction.

## Proposed changes

- Migrate the 17 previously-skipped tests below from `src/test/unit/System.Windows.Forms/...` to `src/test/integration/UIIntegrationTests/...`. Each migrated test no longer needs `RemoteExecutor` and is no longer skipped.
- Remove the corresponding `using Microsoft.DotNet.RemoteExecutor;` and orphaned `MemberData` helpers from the unit-test files. `using` is preserved in `ApplicationTests.cs` because two non-skipped tests there still use `RemoteExecutor` (out of scope for this PR).
- Net: −616 / +33 lines under `src/test/unit/`, +672 lines under `src/test/integration/UIIntegrationTests/` (six new files).

Migrated tests:

| New file (UIIntegrationTests) | Migrated tests |
|---|---|
| `Application.ParkingWindowTests.cs` | `ParkingWindow_DoesNotThrowOnGarbageCollecting` |
| `Application.StaticStateTests.cs` | `Application_CurrentCulture_Set_GetReturnsExpected`, `Application_EnableVisualStyles_InvokeBeforeGettingRenderWithVisualStyles_Success`, `Application_VisualStyleState_Set_ReturnsExpected` |
| `CommonDialogTests.cs` | 3× `CommonDialog_ShowDialog_*WithVisualStyles_*` |
| `DataGridViewHeaderCellTests.cs` | `MouseLeaveUnsharesRow_InvokeWithDataGridViewMouseDown`, `OnMouseDown_InvalidRowIndexVisualStyles`, `OnMouseUp_InvalidRowIndexVisualStyles` |
| `ListViewInsertionMarkTests.cs` | 5× `AppearsAfterItem_/Color_/Index_GetInsertMark[WithColor]_Success` (unsafe, via `LVM_GETINSERTMARK` / `LVM_GETINSERTMARKCOLOR`) |
| `TabPageTests.cs` | `BackColor_GetVisualStyles_ReturnsExpected`, `BackColor_GetVisualStylesWithParent_ReturnsExpected` |

Two intentional deltas from the original tests (both annotated inline):

1. `Application_EnableVisualStyles_InvokeAfterGettingRenderWithVisualStyles_Success` is **dropped**. Its precondition is `UseVisualStyles == false` followed by a call to `EnableVisualStyles()`. `EnableVisualStyles` is a one-way switch, and any test project that has previously enabled visual styles (which UIIntegrationTests does on startup) can never satisfy that precondition again. The behavior under test is documented as "not a recommended scenario"; the original only worked by spawning a fresh process.
2. `Application_CurrentCulture_Set_GetReturnsExpected` keeps every managed-side assertion but **drops the `Assert.Equal(expectedLcid, PInvokeCore.GetThreadLocale())` round-trip**. UIIntegrationTests is decorated with `[UseDefaultXunitCulture]` (via `ControlTestBase`), and xunit's culture fixture restores the thread locale around test execution. `SetThreadLocale` also silently no-ops for some LCIDs (notably invariant `0x7F`) on STA hosts. The Win32-level round-trip was an implementation detail that only held inside a freshly-spawned RemoteExecutor child; `Application.CurrentCulture`'s documented surface is the managed `Thread`/`CultureInfo` pair, which is still verified.

### Out of scope (follow-up)

Roughly 17 additional tests carry the same `"AbandonedMutexException ... arcade#5325"` skip reason but were not in #12379's scope: ~6 more in `DataGridViewHeaderCellTests`, 1 in `ListViewTests`, and ~10 in `ListViewGroupTests`. Per the staggered approach we discussed on the issue, leaving those for a follow-up PR keeps this one reviewable.

## Customer Impact

- None. Test-only change. No product code is touched.

## Regression?

- No.

## Risk

- Minimal. The migration restores test coverage that was previously skipped; if anything regresses it can only surface as test failures (caught by CI before merge), not as customer-facing behavior. UIIntegrationTests already covers the same project surface.

## Test methodology

- Unit tests / Integration tests. Built the solution locally; the migrated tests run green inside `UIIntegrationTests`. The unit-tests assembly still builds with the using/helper removals applied. No remaining references to the deleted `MemberData` helpers (`CustomLCIDCultureInfo`, `BackColor_GetVisualStylesWithParent_TestData`, `MouseLeaveUnsharesRow_WithDataGridViewMouseDown_TestData`); grep-verified before deletion.

## Test environment(s)

- 11.0.100-preview.4.26210.111
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14538)