### PR TITLE
Fix ProgressBar dark mode rendering inconsistency across style variants

### DIFF
--- a/src/System.Windows.Forms/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/PublicAPI.Shipped.txt
@@ -1606,7 +1606,6 @@ override System.Windows.Forms.ProgressBar.DoubleBuffered.set -> void
 override System.Windows.Forms.ProgressBar.Font.get -> System.Drawing.Font!
 override System.Windows.Forms.ProgressBar.Font.set -> void
 override System.Windows.Forms.ProgressBar.OnBackColorChanged(System.EventArgs! e) -> void
-override System.Windows.Forms.ProgressBar.OnCreateControl() -> void
 override System.Windows.Forms.ProgressBar.OnForeColorChanged(System.EventArgs! e) -> void
 override System.Windows.Forms.ProgressBar.OnHandleCreated(System.EventArgs! e) -> void
 override System.Windows.Forms.ProgressBar.OnHandleDestroyed(System.EventArgs! e) -> void

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ProgressBar/ProgressBar.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ProgressBar/ProgressBar.cs
@@ -72,11 +72,6 @@ public partial class ProgressBar : Control
         }
     }
 
-    protected override void OnCreateControl()
-    {
-        base.OnCreateControl();
-    }
-
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public override bool AllowDrop
@@ -332,7 +327,6 @@ public partial class ProgressBar : Control
         base.OnBackColorChanged(e);
         if (IsHandleCreated)
         {
-            ApplyTheming();
             PInvokeCore.SendMessage(this, PInvoke.PBM_SETBKCOLOR, 0, GetEffectiveBackColor().ToWin32());
         }
     }
@@ -342,7 +336,6 @@ public partial class ProgressBar : Control
         base.OnForeColorChanged(e);
         if (IsHandleCreated)
         {
-            ApplyTheming();
             PInvokeCore.SendMessage(this, PInvoke.PBM_SETBARCOLOR, 0, GetEffectiveForeColor().ToWin32());
         }
     }
@@ -706,17 +699,12 @@ public partial class ProgressBar : Control
             return BackColor;
         }
 
-        return Application.IsDarkModeEnabled ? s_defaultDarkModeBackColor : SystemColors.Control;
+        return Application.IsDarkModeEnabled ? s_defaultDarkModeBackColor : BackColor;
     }
 
     private Color GetEffectiveForeColor()
     {
-        if (ShouldSerializeForeColor())
-        {
-            return ForeColor;
-        }
-
-        return s_defaultForeColor;
+        return ShouldSerializeForeColor() ? ForeColor : s_defaultForeColor;
     }
 
     private void ApplyTheming()
@@ -726,12 +714,17 @@ public partial class ProgressBar : Control
             return;
         }
 
-        if (Application.IsDarkModeEnabled || ShouldSerializeBackColor() || ShouldSerializeForeColor())
+        if (Application.IsDarkModeEnabled)
         {
             // In dark mode on newer Windows builds, style switching can produce mixed rendering
             // across Blocks/Continuous/Marquee. Disable visual styles and drive colors via PBM_SET*COLOR
             // for consistent appearance.
             PInvoke.SetWindowTheme(HWND, " ", " ");
+        }
+        else
+        {
+            // Restore default theming when dark mode and custom colors are no longer active.
+            PInvoke.SetWindowTheme(HWND, (PCWSTR)null, (PCWSTR)null);
         }
     }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ProgressBar/ProgressBar.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ProgressBar/ProgressBar.cs
@@ -683,13 +683,21 @@ public partial class ProgressBar : Control
     /// </remarks>
     private void UserPreferenceChangedHandler(object o, UserPreferenceChangedEventArgs e)
     {
-        if (IsHandleCreated)
+        if (!IsHandleCreated)
         {
-            ApplyTheming();
-
-            PInvokeCore.SendMessage(this, PInvoke.PBM_SETBARCOLOR, 0, GetEffectiveForeColor().ToWin32());
-            PInvokeCore.SendMessage(this, PInvoke.PBM_SETBKCOLOR, 0, GetEffectiveBackColor().ToWin32());
+            return;
         }
+
+        // Only react to changes that can affect colors or theme changes.
+        if (e.Category is not UserPreferenceCategory.Color and not UserPreferenceCategory.General)
+        {
+            return;
+        }
+
+        ApplyTheming();
+
+        PInvokeCore.SendMessage(this, PInvoke.PBM_SETBARCOLOR, 0, GetEffectiveForeColor().ToWin32());
+        PInvokeCore.SendMessage(this, PInvoke.PBM_SETBKCOLOR, 0, GetEffectiveBackColor().ToWin32());
     }
 
     private Color GetEffectiveBackColor()

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ProgressBar/ProgressBar.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ProgressBar/ProgressBar.cs
@@ -26,6 +26,7 @@ public partial class ProgressBar : Control
     private int _marqueeAnimationSpeed = 100;
 
     private static readonly Color s_defaultForeColor = SystemColors.Highlight;
+    private static readonly Color s_defaultDarkModeBackColor = SystemColors.ControlText;
 
     private ProgressBarStyle _style = ProgressBarStyle.Blocks;
 
@@ -74,26 +75,6 @@ public partial class ProgressBar : Control
     protected override void OnCreateControl()
     {
         base.OnCreateControl();
-
-        // If SystemColorMode is enabled, we need to disable the Visual Styles
-        // so Windows allows setting Fore- and Background color.
-        // There are more ideal ways imaginable, but this does the trick for now.
-
-        if (Application.IsDarkModeEnabled)
-        {
-            if (!ShouldSerializeBackColor())
-            {
-                BackColor = SystemColors.ControlDarkDark;
-            }
-
-            if (!ShouldSerializeForeColor())
-            {
-                ForeColor = SystemColors.Highlight;
-            }
-
-            // Disables Visual Styles for the ProgressBar.
-            PInvoke.SetWindowTheme(HWND, " ", " ");
-        }
     }
 
     [Browsable(false)]
@@ -133,6 +114,8 @@ public partial class ProgressBar : Control
                 if (IsHandleCreated)
                 {
                     RecreateHandle();
+                    // Re-apply theming after handle recreation
+                    ApplyTheming();
                 }
 
                 if (_style == ProgressBarStyle.Marquee)
@@ -349,7 +332,8 @@ public partial class ProgressBar : Control
         base.OnBackColorChanged(e);
         if (IsHandleCreated)
         {
-            PInvokeCore.SendMessage(this, PInvoke.PBM_SETBKCOLOR, 0, BackColor.ToWin32());
+            ApplyTheming();
+            PInvokeCore.SendMessage(this, PInvoke.PBM_SETBKCOLOR, 0, GetEffectiveBackColor().ToWin32());
         }
     }
 
@@ -358,7 +342,8 @@ public partial class ProgressBar : Control
         base.OnForeColorChanged(e);
         if (IsHandleCreated)
         {
-            PInvokeCore.SendMessage(this, PInvoke.PBM_SETBARCOLOR, 0, ForeColor.ToWin32());
+            ApplyTheming();
+            PInvokeCore.SendMessage(this, PInvoke.PBM_SETBARCOLOR, 0, GetEffectiveForeColor().ToWin32());
         }
     }
 
@@ -603,13 +588,17 @@ public partial class ProgressBar : Control
     protected override void OnHandleCreated(EventArgs e)
     {
         base.OnHandleCreated(e);
+
+        ApplyTheming();
+
         if (IsHandleCreated)
         {
             PInvokeCore.SendMessage(this, PInvoke.PBM_SETRANGE32, (WPARAM)_minimum, (LPARAM)_maximum);
             PInvokeCore.SendMessage(this, PInvoke.PBM_SETSTEP, (WPARAM)_step);
             PInvokeCore.SendMessage(this, PInvoke.PBM_SETPOS, (WPARAM)_value);
-            PInvokeCore.SendMessage(this, PInvoke.PBM_SETBKCOLOR, (WPARAM)0, (LPARAM)BackColor);
-            PInvokeCore.SendMessage(this, PInvoke.PBM_SETBARCOLOR, (WPARAM)0, (LPARAM)ForeColor);
+
+            PInvokeCore.SendMessage(this, PInvoke.PBM_SETBKCOLOR, 0, GetEffectiveBackColor().ToWin32());
+            PInvokeCore.SendMessage(this, PInvoke.PBM_SETBARCOLOR, 0, GetEffectiveForeColor().ToWin32());
         }
 
         StartMarquee();
@@ -703,8 +692,46 @@ public partial class ProgressBar : Control
     {
         if (IsHandleCreated)
         {
-            PInvokeCore.SendMessage(this, PInvoke.PBM_SETBARCOLOR, 0, ForeColor.ToWin32());
-            PInvokeCore.SendMessage(this, PInvoke.PBM_SETBKCOLOR, 0, BackColor.ToWin32());
+            ApplyTheming();
+
+            PInvokeCore.SendMessage(this, PInvoke.PBM_SETBARCOLOR, 0, GetEffectiveForeColor().ToWin32());
+            PInvokeCore.SendMessage(this, PInvoke.PBM_SETBKCOLOR, 0, GetEffectiveBackColor().ToWin32());
+        }
+    }
+
+    private Color GetEffectiveBackColor()
+    {
+        if (ShouldSerializeBackColor())
+        {
+            return BackColor;
+        }
+
+        return Application.IsDarkModeEnabled ? s_defaultDarkModeBackColor : SystemColors.Control;
+    }
+
+    private Color GetEffectiveForeColor()
+    {
+        if (ShouldSerializeForeColor())
+        {
+            return ForeColor;
+        }
+
+        return s_defaultForeColor;
+    }
+
+    private void ApplyTheming()
+    {
+        if (!IsHandleCreated)
+        {
+            return;
+        }
+
+        if (Application.IsDarkModeEnabled || ShouldSerializeBackColor() || ShouldSerializeForeColor())
+        {
+            // In dark mode on newer Windows builds, style switching can produce mixed rendering
+            // across Blocks/Continuous/Marquee. Disable visual styles and drive colors via PBM_SET*COLOR
+            // for consistent appearance.
+            PInvoke.SetWindowTheme(HWND, " ", " ");
         }
     }
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ProgressBarTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ProgressBarTests.cs
@@ -2165,6 +2165,69 @@ public class ProgressBarTests
         Assert.True(control.IsHandleCreated);
     }
 
+    [WinFormsFact]
+    public void ProgressBar_RecreateHandle_WithAmbientBackColorInLightMode_SendsAmbientBackColor()
+    {
+        using Form parent = new()
+        {
+            BackColor = Color.OrangeRed
+        };
+        using SubProgressBar progressBar = new();
+        parent.Controls.Add(progressBar);
+
+        parent.CreateControl();
+        Assert.NotEqual(IntPtr.Zero, progressBar.Handle);
+        Assert.Equal(parent.BackColor, progressBar.BackColor);
+
+        progressBar.ResetBkColorTracking();
+        progressBar.RecreateHandle();
+
+        Assert.True(progressBar.SetBkColorMessageCount > 0);
+        Assert.Equal(ColorTranslator.ToWin32(progressBar.BackColor), progressBar.LastSetBkColorMessage);
+    }
+
+    [WinFormsFact]
+    public void ProgressBar_StyleSwitch_WithCustomBackColorInLightMode_SendsCustomBackColor()
+    {
+        using Form parent = new();
+        using SubProgressBar progressBar = new()
+        {
+            BackColor = Color.White,
+            Style = ProgressBarStyle.Blocks
+        };
+        parent.Controls.Add(progressBar);
+
+        parent.CreateControl();
+        Assert.NotEqual(IntPtr.Zero, progressBar.Handle);
+
+        progressBar.ResetColorTracking();
+        progressBar.Style = ProgressBarStyle.Continuous;
+
+        Assert.True(progressBar.SetBkColorMessageCount > 0);
+        Assert.Equal(ColorTranslator.ToWin32(progressBar.BackColor), progressBar.LastSetBkColorMessage);
+    }
+
+    [WinFormsFact]
+    public void ProgressBar_StyleSwitch_WithCustomForeColorInLightMode_SendsCustomForeColor()
+    {
+        using Form parent = new();
+        using SubProgressBar progressBar = new()
+        {
+            ForeColor = Color.LimeGreen,
+            Style = ProgressBarStyle.Blocks
+        };
+        parent.Controls.Add(progressBar);
+
+        parent.CreateControl();
+        Assert.NotEqual(IntPtr.Zero, progressBar.Handle);
+
+        progressBar.ResetColorTracking();
+        progressBar.Style = ProgressBarStyle.Continuous;
+
+        Assert.True(progressBar.SetBarColorMessageCount > 0);
+        Assert.Equal(ColorTranslator.ToWin32(progressBar.ForeColor), progressBar.LastSetBarColorMessage);
+    }
+
     [WinFormsTheory]
     [NewAndDefaultData<EventArgs>]
     public void ProgressBar_OnHandleDestroyed_Invoke_CallsHandleDestroyed(EventArgs eventArgs)
@@ -2641,6 +2704,8 @@ public class ProgressBarTests
 
         public new void CreateHandle() => base.CreateHandle();
 
+        public new void RecreateHandle() => base.RecreateHandle();
+
         public new AutoSizeMode GetAutoSizeMode() => base.GetAutoSizeMode();
 
         public new bool GetStyle(ControlStyles flag) => base.GetStyle(flag);
@@ -2674,5 +2739,42 @@ public class ProgressBarTests
         public new void OnRightToLeftLayoutChanged(EventArgs e) => base.OnRightToLeftLayoutChanged(e);
 
         public new void SetStyle(ControlStyles flag, bool value) => base.SetStyle(flag, value);
+
+        public int? LastSetBkColorMessage { get; private set; }
+
+        public int? LastSetBarColorMessage { get; private set; }
+
+        public int SetBkColorMessageCount { get; private set; }
+
+        public int SetBarColorMessageCount { get; private set; }
+
+        public void ResetColorTracking()
+        {
+            LastSetBkColorMessage = null;
+            LastSetBarColorMessage = null;
+            SetBkColorMessageCount = 0;
+            SetBarColorMessageCount = 0;
+        }
+
+        public void ResetBkColorTracking()
+        {
+            ResetColorTracking();
+        }
+
+        protected override void WndProc(ref Message m)
+        {
+            if (m.Msg == (int)PInvoke.PBM_SETBKCOLOR)
+            {
+                SetBkColorMessageCount++;
+                LastSetBkColorMessage = unchecked((int)m.LParam);
+            }
+            else if (m.Msg == (int)PInvoke.PBM_SETBARCOLOR)
+            {
+                SetBarColorMessageCount++;
+                LastSetBarColorMessage = unchecked((int)m.LParam);
+            }
+
+            base.WndProc(ref m);
+        }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14546

## Root Cause

The native themed ProgressBar rendering on newer Windows builds applies style-dependent visual effects in dark mode. As a result, `Blocks`, `Continuous`, and `Marquee` do not share a single consistent rendering path. When the control depends on native theming, the background and foreground colors can diverge across styles.

## Proposed changes

- Disable native ProgressBar theming in dark mode and drive `ProgressBar` colors through explicit color messages.
- Reapply theming and colors after **handle recreation**, **style changes**, **color changes**, and **user-preference** updates.
- Use `SystemColors.ControlText` as the dark-mode background color to satisfy contrast requirements.
- Preserve system-controlled ProgressBar colors in the classic/native rendering path.
- Apply explicit ProgressBar colors only in the dark-mode workaround path used to ensure consistent rendering across style variants.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Fixes inconsistent ProgressBar appearance in dark mode and improves readability and contrast between the progress fill and background.


## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
`Blocks`, `Continuous`, and `Marquee` render with different visual results.

https://github.com/user-attachments/assets/49566858-53b2-4e08-a7b5-25b8cb027db5

### After
Three ProgressBar styles (`Blocks`, `Continuous`, `Marquee`) render with consistent colors in dark mode and color changes and style switching work correctly

https://github.com/user-attachments/assets/f487ba3f-e213-4e4c-b9ac-6675ca9cc113

## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-preview.5.26268.112


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14551)