### PR TITLE
Fix PictureBox StretchImage repaint perf regression by caching scaled bitmap

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PictureBox/PictureBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PictureBox/PictureBox.cs
@@ -4,6 +4,7 @@
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Drawing;
+using System.Drawing.Imaging;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Windows.Forms.Layout;
@@ -59,6 +60,9 @@ public partial class PictureBox : Control, ISupportInitialize
     private MemoryStream? _tempDownloadStream;
     private const int ReadBlockSize = 4096;
     private byte[]? _readBuffer;
+    private Bitmap? _stretchedImageCache;
+    private Image? _stretchedImageCacheSource;
+    private Size _stretchedImageCacheSize;
     private ImageInstallationType _imageInstallationType;
     private SendOrPostCallback? _loadCompletedDelegate;
     private SendOrPostCallback? _loadProgressDelegate;
@@ -417,6 +421,7 @@ public partial class PictureBox : Control, ISupportInitialize
     private void InstallNewImage(Image? value, ImageInstallationType installationType)
     {
         StopAnimate();
+        DisposeStretchedImageCache();
         _image = value;
 
         LayoutTransaction.DoLayoutIf(AutoSize, this, this, PropertyNames.Image);
@@ -841,6 +846,7 @@ public partial class PictureBox : Control, ISupportInitialize
                 }
 
                 _sizeMode = value;
+                DisposeStretchedImageCache();
                 AdjustSize();
                 Invalidate();
                 OnSizeModeChanged(EventArgs.Empty);
@@ -1001,6 +1007,7 @@ public partial class PictureBox : Control, ISupportInitialize
         if (disposing)
         {
             StopAnimate();
+            DisposeStretchedImageCache();
         }
 
         DisposeImageStream();
@@ -1128,11 +1135,59 @@ public partial class PictureBox : Control, ISupportInitialize
                 ? ImageRectangleFromSizeMode(PictureBoxSizeMode.CenterImage)
                 : ImageRectangle;
 
-            pe.Graphics.DrawImage(_image, drawingRect);
+            if (TryGetStretchImageCache(drawingRect, out Bitmap? stretchedImage) && stretchedImage is not null)
+            {
+                pe.Graphics.DrawImageUnscaled(stretchedImage, drawingRect.Location);
+            }
+            else
+            {
+                pe.Graphics.DrawImage(_image, drawingRect);
+            }
         }
 
         // Windows draws the border for us (see CreateParams)
         base.OnPaint(pe!);
+    }
+
+    private bool TryGetStretchImageCache(Rectangle drawingRect, out Bitmap? stretchedImage)
+    {
+        stretchedImage = null;
+
+        if (_sizeMode != PictureBoxSizeMode.StretchImage
+            || _image is null
+            || _imageInstallationType == ImageInstallationType.ErrorOrInitial
+            || drawingRect.Width <= 0
+            || drawingRect.Height <= 0
+            || ImageAnimator.CanAnimate(_image))
+        {
+            return false;
+        }
+
+        Size drawingSize = drawingRect.Size;
+        if (_stretchedImageCache is null
+            || _stretchedImageCacheSource != _image
+            || _stretchedImageCacheSize != drawingSize)
+        {
+            DisposeStretchedImageCache();
+
+            _stretchedImageCache = new Bitmap(drawingSize.Width, drawingSize.Height, PixelFormat.Format32bppPArgb);
+            using Graphics cacheGraphics = Graphics.FromImage(_stretchedImageCache);
+            cacheGraphics.DrawImage(_image, new Rectangle(Point.Empty, drawingSize));
+
+            _stretchedImageCacheSource = _image;
+            _stretchedImageCacheSize = drawingSize;
+        }
+
+        stretchedImage = _stretchedImageCache;
+        return true;
+    }
+
+    private void DisposeStretchedImageCache()
+    {
+        _stretchedImageCache?.Dispose();
+        _stretchedImageCache = null;
+        _stretchedImageCacheSource = null;
+        _stretchedImageCacheSize = Size.Empty;
     }
 
     protected override void OnVisibleChanged(EventArgs e)
@@ -1153,6 +1208,12 @@ public partial class PictureBox : Control, ISupportInitialize
     protected override void OnResize(EventArgs e)
     {
         base.OnResize(e);
+
+        if (_sizeMode == PictureBoxSizeMode.StretchImage)
+        {
+            DisposeStretchedImageCache();
+        }
+
         if (_sizeMode == PictureBoxSizeMode.Zoom
             || _sizeMode == PictureBoxSizeMode.StretchImage
             || _sizeMode == PictureBoxSizeMode.CenterImage

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PictureBox/PictureBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PictureBox/PictureBox.cs
@@ -4,6 +4,7 @@
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Drawing;
+using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.Net;
 using System.Runtime.InteropServices;
@@ -59,10 +60,11 @@ public partial class PictureBox : Control, ISupportInitialize
     private int _totalBytesRead;
     private MemoryStream? _tempDownloadStream;
     private const int ReadBlockSize = 4096;
+    private const int MaxCachedStretchImageBytes = 16 * 1024 * 1024;
     private byte[]? _readBuffer;
     private Bitmap? _stretchedImageCache;
-    private Image? _stretchedImageCacheSource;
     private Size _stretchedImageCacheSize;
+    private InterpolationMode _stretchedImageCacheInterpolationMode;
     private ImageInstallationType _imageInstallationType;
     private SendOrPostCallback? _loadCompletedDelegate;
     private SendOrPostCallback? _loadProgressDelegate;
@@ -1135,7 +1137,7 @@ public partial class PictureBox : Control, ISupportInitialize
                 ? ImageRectangleFromSizeMode(PictureBoxSizeMode.CenterImage)
                 : ImageRectangle;
 
-            if (TryGetStretchImageCache(drawingRect, out Bitmap? stretchedImage) && stretchedImage is not null)
+            if (TryGetStretchImageCache(drawingRect, pe.Graphics.InterpolationMode, out Bitmap? stretchedImage))
             {
                 pe.Graphics.DrawImageUnscaled(stretchedImage, drawingRect.Location);
             }
@@ -1149,45 +1151,56 @@ public partial class PictureBox : Control, ISupportInitialize
         base.OnPaint(pe!);
     }
 
-    private bool TryGetStretchImageCache(Rectangle drawingRect, out Bitmap? stretchedImage)
+    private bool TryGetStretchImageCache(
+        Rectangle drawingRect,
+        InterpolationMode interpolationMode,
+        [NotNullWhen(true)] out Bitmap? stretchedImage)
     {
         stretchedImage = null;
+
+        // This cache tracks control state (size/mode/image assignment), but not in-place pixel edits on
+        // the same Image instance. Callers that mutate pixels should reassign Image or invalidate explicitly.
 
         if (_sizeMode != PictureBoxSizeMode.StretchImage
             || _image is null
             || _imageInstallationType == ImageInstallationType.ErrorOrInitial
             || drawingRect.Width <= 0
             || drawingRect.Height <= 0
-            || ImageAnimator.CanAnimate(_image))
+            || ImageAnimator.CanAnimate(_image)
+            || !CanCacheStretchImage(drawingRect.Size))
         {
             return false;
         }
 
         Size drawingSize = drawingRect.Size;
         if (_stretchedImageCache is null
-            || _stretchedImageCacheSource != _image
-            || _stretchedImageCacheSize != drawingSize)
+            || _stretchedImageCacheSize != drawingSize
+            || _stretchedImageCacheInterpolationMode != interpolationMode)
         {
             DisposeStretchedImageCache();
 
             _stretchedImageCache = new Bitmap(drawingSize.Width, drawingSize.Height, PixelFormat.Format32bppPArgb);
             using Graphics cacheGraphics = Graphics.FromImage(_stretchedImageCache);
+            cacheGraphics.InterpolationMode = interpolationMode;
             cacheGraphics.DrawImage(_image, new Rectangle(Point.Empty, drawingSize));
 
-            _stretchedImageCacheSource = _image;
             _stretchedImageCacheSize = drawingSize;
+            _stretchedImageCacheInterpolationMode = interpolationMode;
         }
 
         stretchedImage = _stretchedImageCache;
         return true;
     }
 
+    private static bool CanCacheStretchImage(Size drawingSize)
+        => (long)drawingSize.Width * drawingSize.Height * sizeof(uint) <= MaxCachedStretchImageBytes;
+
     private void DisposeStretchedImageCache()
     {
         _stretchedImageCache?.Dispose();
         _stretchedImageCache = null;
-        _stretchedImageCacheSource = null;
         _stretchedImageCacheSize = Size.Empty;
+        _stretchedImageCacheInterpolationMode = InterpolationMode.Invalid;
     }
 
     protected override void OnVisibleChanged(EventArgs e)
@@ -1208,11 +1221,6 @@ public partial class PictureBox : Control, ISupportInitialize
     protected override void OnResize(EventArgs e)
     {
         base.OnResize(e);
-
-        if (_sizeMode == PictureBoxSizeMode.StretchImage)
-        {
-            DisposeStretchedImageCache();
-        }
 
         if (_sizeMode == PictureBoxSizeMode.Zoom
             || _sizeMode == PictureBoxSizeMode.StretchImage

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PictureBox/PictureBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PictureBox/PictureBox.cs
@@ -1139,7 +1139,11 @@ public partial class PictureBox : Control, ISupportInitialize
 
             if (TryGetStretchImageCache(drawingRect, pe.Graphics.InterpolationMode, out Bitmap? stretchedImage))
             {
-                pe.Graphics.DrawImageUnscaled(stretchedImage, drawingRect.Location);
+                pe.Graphics.DrawImage(
+                    stretchedImage,
+                    drawingRect,
+                    new Rectangle(Point.Empty, drawingRect.Size),
+                    GraphicsUnit.Pixel);
             }
             else
             {

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/PictureBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/PictureBoxTests.cs
@@ -2608,6 +2608,55 @@ public class PictureBoxTests
         Assert.Equal(1, callCount);
     }
 
+    [WinFormsFact]
+    public void PictureBox_OnPaint_StretchImage_CachesScaledImage()
+    {
+        using Bitmap sourceImage = new(16, 16);
+        using SubPictureBox pictureBox = new()
+        {
+            SizeMode = PictureBoxSizeMode.StretchImage,
+            Image = sourceImage,
+            Size = new Size(100, 50)
+        };
+        using Bitmap canvas = new(100, 50);
+        using Graphics graphics = Graphics.FromImage(canvas);
+        using PaintEventArgs eventArgs = new(graphics, new Rectangle(Point.Empty, canvas.Size));
+
+        pictureBox.OnPaint(eventArgs);
+        Bitmap firstCache = GetStretchedImageCache(pictureBox);
+        Assert.NotNull(firstCache);
+
+        pictureBox.OnPaint(eventArgs);
+        Bitmap secondCache = GetStretchedImageCache(pictureBox);
+        Assert.Same(firstCache, secondCache);
+    }
+
+    [WinFormsFact]
+    public void PictureBox_OnPaint_StretchImage_WithNewImage_RecreatesScaledImageCache()
+    {
+        using Bitmap firstImage = new(16, 16);
+        using Bitmap secondImage = new(16, 16);
+        using SubPictureBox pictureBox = new()
+        {
+            SizeMode = PictureBoxSizeMode.StretchImage,
+            Image = firstImage,
+            Size = new Size(100, 50)
+        };
+        using Bitmap canvas = new(100, 50);
+        using Graphics graphics = Graphics.FromImage(canvas);
+        using PaintEventArgs eventArgs = new(graphics, new Rectangle(Point.Empty, canvas.Size));
+
+        pictureBox.OnPaint(eventArgs);
+        Bitmap firstCache = GetStretchedImageCache(pictureBox);
+        Assert.NotNull(firstCache);
+
+        pictureBox.Image = secondImage;
+        pictureBox.OnPaint(eventArgs);
+        Bitmap secondCache = GetStretchedImageCache(pictureBox);
+        Assert.NotNull(secondCache);
+        Assert.NotSame(firstCache, secondCache);
+    }
+
     [WinFormsTheory]
     [NewAndDefaultData<EventArgs>]
     public void PictureBox_OnParentChanged_Invoke_CallsParentChanged(EventArgs eventArgs)
@@ -2928,5 +2977,10 @@ public class PictureBoxTests
         public new void OnVisibleChanged(EventArgs e) => base.OnVisibleChanged(e);
 
         public new void SetStyle(ControlStyles flag, bool value) => base.SetStyle(flag, value);
+    }
+
+    private static Bitmap GetStretchedImageCache(PictureBox pictureBox)
+    {
+        return Assert.IsType<Bitmap>(pictureBox.TestAccessor.Dynamic._stretchedImageCache);
     }
 }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/PictureBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/PictureBoxTests.cs
@@ -5,6 +5,7 @@
 
 using System.ComponentModel;
 using System.Drawing;
+using System.Drawing.Drawing2D;
 using System.Windows.Forms.TestUtilities;
 using Moq;
 using Point = System.Drawing.Point;
@@ -2654,6 +2655,56 @@ public class PictureBoxTests
         pictureBox.OnPaint(eventArgs);
         Bitmap secondCache = GetStretchedImageCache(pictureBox);
         Assert.NotNull(secondCache);
+        Assert.NotSame(firstCache, secondCache);
+    }
+
+    [WinFormsFact]
+    public void PictureBox_OnPaint_StretchImage_WithOversizedTarget_DoesNotCreateScaledImageCache()
+    {
+        using Bitmap sourceImage = new(16, 16);
+        using SubPictureBox pictureBox = new()
+        {
+            SizeMode = PictureBoxSizeMode.StretchImage,
+            Image = sourceImage,
+            Size = new Size(3000, 2000)
+        };
+
+        using Bitmap canvas = new(1, 1);
+        using Graphics graphics = Graphics.FromImage(canvas);
+        using PaintEventArgs eventArgs = new(graphics, new Rectangle(Point.Empty, canvas.Size));
+
+        pictureBox.OnPaint(eventArgs);
+
+        Assert.Null(pictureBox.TestAccessor.Dynamic._stretchedImageCache);
+    }
+
+    [WinFormsFact]
+    public void PictureBox_OnPaint_StretchImage_WithInterpolationModeChanged_RecreatesScaledImageCache()
+    {
+        using Bitmap sourceImage = new(16, 16);
+        using SubPictureBox pictureBox = new()
+        {
+            SizeMode = PictureBoxSizeMode.StretchImage,
+            Image = sourceImage,
+            Size = new Size(100, 50)
+        };
+
+        using Bitmap firstCanvas = new(100, 50);
+        using Graphics firstGraphics = Graphics.FromImage(firstCanvas);
+        firstGraphics.InterpolationMode = InterpolationMode.Bilinear;
+        using PaintEventArgs firstEventArgs = new(firstGraphics, new Rectangle(Point.Empty, firstCanvas.Size));
+
+        pictureBox.OnPaint(firstEventArgs);
+        Bitmap firstCache = GetStretchedImageCache(pictureBox);
+
+        using Bitmap secondCanvas = new(100, 50);
+        using Graphics secondGraphics = Graphics.FromImage(secondCanvas);
+        secondGraphics.InterpolationMode = InterpolationMode.NearestNeighbor;
+        using PaintEventArgs secondEventArgs = new(secondGraphics, new Rectangle(Point.Empty, secondCanvas.Size));
+
+        pictureBox.OnPaint(secondEventArgs);
+        Bitmap secondCache = GetStretchedImageCache(pictureBox);
+
         Assert.NotSame(firstCache, secondCache);
     }
 


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14009


## Proposed changes

-  Added a scaled bitmap cache for `StretchImage` (key: source image + destination size).
- In `OnPaint`, when cache is hit, render via non-scaling path (`DrawImageUnscaled`).
- Invalidate/rebuild cache on image change, `SizeMode` change, `Resize`, and `Dispose`.
- Bypass cache for animated images (`ImageAnimator.CanAnimate`) to preserve frame update semantics.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

-  Lower CPU usage during frequent repaints with `StretchImage`

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
On a page containing a PictureBox that uses StretchImage, pressing A to run 1000 refreshes takes about 11348ms.

<img width="1447" height="817" alt="image" src="https://github.com/user-attachments/assets/243fa4ba-ba1e-4367-aebe-798dffb361a0" />

### After
The same 1000 refreshes complete much faster.

<img width="1452" height="820" alt="image" src="https://github.com/user-attachments/assets/f425f336-996c-43be-92c6-dcc80e49d98b" />


## Test methodology <!-- How did you ensure quality? -->

- Manually and unit tests


## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-preview.5.26272.112


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14559)