### PR TITLE
Add tests for PropertyGrid.OnComponentRemoved

### DIFF
--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/PropertyGridTests.cs
@@ -4507,15 +4507,26 @@ public partial class PropertyGridTests
 
     #region OnComponentRemoved Tests
 
-    [WinFormsFact]
-    public void PropertyGrid_OnComponentRemoved_ThrowsWhenComponentIsNull()
+    private static PropertyGrid CreatePropertyGridWithActiveDesigner(
+        out Mock<IDesignerHost> mockDesignerHost,
+        out Mock<IComponentChangeService> mockChangeService)
     {
-        using PropertyGrid propertyGrid = new();
-        Mock<IDesignerHost> mockDesignerHost = new();
-        Mock<IComponentChangeService> mockChangeService = new();
+        PropertyGrid propertyGrid = new();
+        mockDesignerHost = new();
+        mockChangeService = new();
 
         mockDesignerHost.Setup(h => h.GetService(typeof(IComponentChangeService))).Returns(mockChangeService.Object);
         propertyGrid.TestAccessor.Dynamic.ActiveDesigner = mockDesignerHost.Object;
+
+        return propertyGrid;
+    }
+
+    [WinFormsFact]
+    public void PropertyGrid_OnComponentRemoved_ThrowsWhenComponentIsNull()
+    {
+        using PropertyGrid propertyGrid = CreatePropertyGridWithActiveDesigner(
+            out Mock<IDesignerHost> mockDesignerHost,
+            out Mock<IComponentChangeService> mockChangeService);
 
         Assert.Throws<InvalidOperationException>(() =>
             mockChangeService.Raise(s => s.ComponentRemoved += null, mockDesignerHost.Object, new ComponentEventArgs(null)));
@@ -4524,18 +4535,15 @@ public partial class PropertyGridTests
     [WinFormsFact]
     public void PropertyGrid_OnComponentRemoved_RemovesComponentFromSelectedObjects()
     {
-        using PropertyGrid propertyGrid = new();
-        Mock<IDesignerHost> mockDesignerHost = new();
-        Mock<IComponentChangeService> mockChangeService = new();
-
-        mockDesignerHost.Setup(h => h.GetService(typeof(IComponentChangeService))).Returns(mockChangeService.Object);
+        using PropertyGrid propertyGrid = CreatePropertyGridWithActiveDesigner(
+            out Mock<IDesignerHost> mockDesignerHost,
+            out Mock<IComponentChangeService> mockChangeService);
 
         using TestComponent component1 = new();
         using TestComponent component2 = new();
         using TestComponent component3 = new();
 
         propertyGrid.SelectedObjects = [component1, component2, component3];
-        propertyGrid.TestAccessor.Dynamic.ActiveDesigner = mockDesignerHost.Object;
 
         mockChangeService.Raise(s => s.ComponentRemoved += null, mockDesignerHost.Object, new ComponentEventArgs(component2));
 
@@ -4548,16 +4556,13 @@ public partial class PropertyGridTests
     [WinFormsFact]
     public void PropertyGrid_OnComponentRemoved_HandlesOnlyComponent()
     {
-        using PropertyGrid propertyGrid = new();
-        Mock<IDesignerHost> mockDesignerHost = new();
-        Mock<IComponentChangeService> mockChangeService = new();
-
-        mockDesignerHost.Setup(h => h.GetService(typeof(IComponentChangeService))).Returns(mockChangeService.Object);
+        using PropertyGrid propertyGrid = CreatePropertyGridWithActiveDesigner(
+            out Mock<IDesignerHost> mockDesignerHost,
+            out Mock<IComponentChangeService> mockChangeService);
 
         using TestComponent component = new();
 
         propertyGrid.SelectedObject = component;
-        propertyGrid.TestAccessor.Dynamic.ActiveDesigner = mockDesignerHost.Object;
 
         mockChangeService.Raise(s => s.ComponentRemoved += null, mockDesignerHost.Object, new ComponentEventArgs(component));
 
@@ -4565,20 +4570,17 @@ public partial class PropertyGridTests
     }
 
     [WinFormsFact]
-    public void PropertyGrid_OnComponentRemoved_BatchMode_UpdatesSelectionWithoutRaisingSelectedObjectsChanged()
+    public void PropertyGrid_OnComponentRemoved_BatchMode_UpdatesSelectedObjectsWithoutRefresh()
     {
-        using PropertyGrid propertyGrid = new();
-        Mock<IDesignerHost> mockDesignerHost = new();
-        Mock<IComponentChangeService> mockChangeService = new();
-
-        mockDesignerHost.Setup(h => h.GetService(typeof(IComponentChangeService))).Returns(mockChangeService.Object);
+        using PropertyGrid propertyGrid = CreatePropertyGridWithActiveDesigner(
+            out Mock<IDesignerHost> mockDesignerHost,
+            out Mock<IComponentChangeService> mockChangeService);
         mockDesignerHost.Setup(h => h.InTransaction).Returns(true);
 
         using TestComponent component1 = new();
         using TestComponent component2 = new();
 
         propertyGrid.SelectedObjects = [component1, component2];
-        propertyGrid.TestAccessor.Dynamic.ActiveDesigner = mockDesignerHost.Object;
 
         int selectedObjectsChangedCallCount = 0;
         propertyGrid.SelectedObjectsChanged += (sender, e) => selectedObjectsChangedCallCount++;
@@ -4602,18 +4604,15 @@ public partial class PropertyGridTests
     [WinFormsFact]
     public void PropertyGrid_OnComponentRemoved_DoesNotRemoveNonExistentComponent()
     {
-        using PropertyGrid propertyGrid = new();
-        Mock<IDesignerHost> mockDesignerHost = new();
-        Mock<IComponentChangeService> mockChangeService = new();
-
-        mockDesignerHost.Setup(h => h.GetService(typeof(IComponentChangeService))).Returns(mockChangeService.Object);
+        using PropertyGrid propertyGrid = CreatePropertyGridWithActiveDesigner(
+            out Mock<IDesignerHost> mockDesignerHost,
+            out Mock<IComponentChangeService> mockChangeService);
 
         using TestComponent component1 = new();
         using TestComponent component2 = new();
         using TestComponent component3 = new();
 
         propertyGrid.SelectedObjects = [component1, component2];
-        propertyGrid.TestAccessor.Dynamic.ActiveDesigner = mockDesignerHost.Object;
 
         // Try to remove a component that is not in the selection
         mockChangeService.Raise(s => s.ComponentRemoved += null, mockDesignerHost.Object, new ComponentEventArgs(component3));
@@ -4626,18 +4625,16 @@ public partial class PropertyGridTests
     [WinFormsFact]
     public void PropertyGrid_OnComponentRemoved_NullSelectedObjects_DoesNotThrow()
     {
-        using PropertyGrid propertyGrid = new();
-        Mock<IDesignerHost> mockDesignerHost = new();
-        Mock<IComponentChangeService> mockChangeService = new();
-
-        mockDesignerHost.Setup(h => h.GetService(typeof(IComponentChangeService))).Returns(mockChangeService.Object);
+        using PropertyGrid propertyGrid = CreatePropertyGridWithActiveDesigner(
+            out Mock<IDesignerHost> mockDesignerHost,
+            out Mock<IComponentChangeService> mockChangeService);
 
         TestComponent component = new();
 
-        propertyGrid.TestAccessor.Dynamic.ActiveDesigner = mockDesignerHost.Object;
-
         // Should not throw when _selectedObjects is null
         mockChangeService.Raise(s => s.ComponentRemoved += null, mockDesignerHost.Object, new ComponentEventArgs(component));
+
+        Assert.Empty(propertyGrid.SelectedObjects);
     }
 
     [PropertyTab(typeof(DocumentScopePropertyTab), PropertyTabScope.Component)]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/PropertyGridTests.cs
@@ -4565,12 +4565,11 @@ public partial class PropertyGridTests
     }
 
     [WinFormsFact]
-    public void PropertyGrid_OnComponentRemoved_BatchMode_UpdatesSelectedObjectsWithoutRefresh()
+    public void PropertyGrid_OnComponentRemoved_BatchMode_UpdatesSelectionWithoutRaisingSelectedObjectsChanged()
     {
         using PropertyGrid propertyGrid = new();
         Mock<IDesignerHost> mockDesignerHost = new();
         Mock<IComponentChangeService> mockChangeService = new();
-        Mock<IDesignerHostTransactionState> mockTransaction = new();
 
         mockDesignerHost.Setup(h => h.GetService(typeof(IComponentChangeService))).Returns(mockChangeService.Object);
         mockDesignerHost.Setup(h => h.InTransaction).Returns(true);
@@ -4581,17 +4580,23 @@ public partial class PropertyGridTests
         propertyGrid.SelectedObjects = [component1, component2];
         propertyGrid.TestAccessor.Dynamic.ActiveDesigner = mockDesignerHost.Object;
 
+        int selectedObjectsChangedCallCount = 0;
+        propertyGrid.SelectedObjectsChanged += (sender, e) => selectedObjectsChangedCallCount++;
+
         // Enter batch mode by starting a transaction
         mockDesignerHost.Raise(h => h.TransactionOpened += null, mockDesignerHost.Object, EventArgs.Empty);
 
         mockChangeService.Raise(s => s.ComponentRemoved += null, mockDesignerHost.Object, new ComponentEventArgs(component1));
 
-        // In batch mode, the component should be removed from internal list
+        // In batch mode, the internal selection updates immediately without invoking the refresh path.
         dynamic testAccessor = propertyGrid.TestAccessor.Dynamic;
         object[] selectedObjects = testAccessor._selectedObjects;
 
         Assert.Single(selectedObjects);
         Assert.Equal(component2, selectedObjects[0]);
+        Assert.Single(propertyGrid.SelectedObjects);
+        Assert.Equal(component2, propertyGrid.SelectedObjects[0]);
+        Assert.Equal(0, selectedObjectsChangedCallCount);
     }
 
     [WinFormsFact]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/PropertyGridTests.cs
@@ -4504,4 +4504,160 @@ public partial class PropertyGridTests
             }
         }
     }
+
+    #region OnComponentRemoved Tests
+
+    [WinFormsFact]
+    public void PropertyGrid_OnComponentRemoved_ThrowsWhenComponentIsNull()
+    {
+        using PropertyGrid propertyGrid = new();
+        Mock<IDesignerHost> mockDesignerHost = new();
+        Mock<IComponentChangeService> mockChangeService = new();
+
+        mockDesignerHost.Setup(h => h.GetService(typeof(IComponentChangeService))).Returns(mockChangeService.Object);
+        propertyGrid.TestAccessor.Dynamic.ActiveDesigner = mockDesignerHost.Object;
+
+        Assert.Throws<InvalidOperationException>(() =>
+            mockChangeService.Raise(s => s.ComponentRemoved += null, mockDesignerHost.Object, new ComponentEventArgs(null)));
+    }
+
+    [WinFormsFact]
+    public void PropertyGrid_OnComponentRemoved_RemovesComponentFromSelectedObjects()
+    {
+        using PropertyGrid propertyGrid = new();
+        Mock<IDesignerHost> mockDesignerHost = new();
+        Mock<IComponentChangeService> mockChangeService = new();
+
+        mockDesignerHost.Setup(h => h.GetService(typeof(IComponentChangeService))).Returns(mockChangeService.Object);
+
+        using TestComponent component1 = new();
+        using TestComponent component2 = new();
+        using TestComponent component3 = new();
+
+        propertyGrid.SelectedObjects = [component1, component2, component3];
+        propertyGrid.TestAccessor.Dynamic.ActiveDesigner = mockDesignerHost.Object;
+
+        mockChangeService.Raise(s => s.ComponentRemoved += null, mockDesignerHost.Object, new ComponentEventArgs(component2));
+
+        Assert.Equal(2, propertyGrid.SelectedObjects.Length);
+        Assert.Contains(component1, propertyGrid.SelectedObjects);
+        Assert.Contains(component3, propertyGrid.SelectedObjects);
+        Assert.DoesNotContain(component2, propertyGrid.SelectedObjects);
+    }
+
+    [WinFormsFact]
+    public void PropertyGrid_OnComponentRemoved_HandlesOnlyComponent()
+    {
+        using PropertyGrid propertyGrid = new();
+        Mock<IDesignerHost> mockDesignerHost = new();
+        Mock<IComponentChangeService> mockChangeService = new();
+
+        mockDesignerHost.Setup(h => h.GetService(typeof(IComponentChangeService))).Returns(mockChangeService.Object);
+
+        using TestComponent component = new();
+
+        propertyGrid.SelectedObject = component;
+        propertyGrid.TestAccessor.Dynamic.ActiveDesigner = mockDesignerHost.Object;
+
+        mockChangeService.Raise(s => s.ComponentRemoved += null, mockDesignerHost.Object, new ComponentEventArgs(component));
+
+        Assert.Empty(propertyGrid.SelectedObjects);
+    }
+
+    [WinFormsFact]
+    public void PropertyGrid_OnComponentRemoved_BatchMode_UpdatesSelectedObjectsWithoutRefresh()
+    {
+        using PropertyGrid propertyGrid = new();
+        Mock<IDesignerHost> mockDesignerHost = new();
+        Mock<IComponentChangeService> mockChangeService = new();
+        Mock<IDesignerHostTransactionState> mockTransaction = new();
+
+        mockDesignerHost.Setup(h => h.GetService(typeof(IComponentChangeService))).Returns(mockChangeService.Object);
+        mockDesignerHost.Setup(h => h.InTransaction).Returns(true);
+
+        using TestComponent component1 = new();
+        using TestComponent component2 = new();
+
+        propertyGrid.SelectedObjects = [component1, component2];
+        propertyGrid.TestAccessor.Dynamic.ActiveDesigner = mockDesignerHost.Object;
+
+        // Enter batch mode by starting a transaction
+        mockDesignerHost.Raise(h => h.TransactionOpened += null, mockDesignerHost.Object, EventArgs.Empty);
+
+        mockChangeService.Raise(s => s.ComponentRemoved += null, mockDesignerHost.Object, new ComponentEventArgs(component1));
+
+        // In batch mode, the component should be removed from internal list
+        dynamic testAccessor = propertyGrid.TestAccessor.Dynamic;
+        object[] selectedObjects = testAccessor._selectedObjects;
+
+        Assert.Single(selectedObjects);
+        Assert.Equal(component2, selectedObjects[0]);
+    }
+
+    [WinFormsFact]
+    public void PropertyGrid_OnComponentRemoved_DoesNotRemoveNonExistentComponent()
+    {
+        using PropertyGrid propertyGrid = new();
+        Mock<IDesignerHost> mockDesignerHost = new();
+        Mock<IComponentChangeService> mockChangeService = new();
+
+        mockDesignerHost.Setup(h => h.GetService(typeof(IComponentChangeService))).Returns(mockChangeService.Object);
+
+        using TestComponent component1 = new();
+        using TestComponent component2 = new();
+        using TestComponent component3 = new();
+
+        propertyGrid.SelectedObjects = [component1, component2];
+        propertyGrid.TestAccessor.Dynamic.ActiveDesigner = mockDesignerHost.Object;
+
+        // Try to remove a component that is not in the selection
+        mockChangeService.Raise(s => s.ComponentRemoved += null, mockDesignerHost.Object, new ComponentEventArgs(component3));
+
+        Assert.Equal(2, propertyGrid.SelectedObjects.Length);
+        Assert.Contains(component1, propertyGrid.SelectedObjects);
+        Assert.Contains(component2, propertyGrid.SelectedObjects);
+    }
+
+    [WinFormsFact]
+    public void PropertyGrid_OnComponentRemoved_NullSelectedObjects_DoesNotThrow()
+    {
+        using PropertyGrid propertyGrid = new();
+        Mock<IDesignerHost> mockDesignerHost = new();
+        Mock<IComponentChangeService> mockChangeService = new();
+
+        mockDesignerHost.Setup(h => h.GetService(typeof(IComponentChangeService))).Returns(mockChangeService.Object);
+
+        TestComponent component = new();
+
+        propertyGrid.TestAccessor.Dynamic.ActiveDesigner = mockDesignerHost.Object;
+
+        // Should not throw when _selectedObjects is null
+        mockChangeService.Raise(s => s.ComponentRemoved += null, mockDesignerHost.Object, new ComponentEventArgs(component));
+    }
+
+    [PropertyTab(typeof(DocumentScopePropertyTab), PropertyTabScope.Component)]
+    private class TestComponent : Component, IDisposable
+    {
+        public string TestProperty { get; set; } = "Test";
+    }
+
+    private class DocumentScopePropertyTab : PropertyTab
+    {
+        private Bitmap _bitmap;
+        public override string TabName => "Document Tab";
+        public override Bitmap Bitmap => _bitmap ??= new(1, 1);
+        public override PropertyDescriptorCollection GetProperties(object component, Attribute[] attributes)
+            => TypeDescriptor.GetProperties(component, attributes);
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _bitmap?.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+    #endregion
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related #12055


## Proposed changes

-  Add tests for `PropertyGrid.OnComponentRemoved
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14561)