### PR TITLE
Handle transient GDI+ ExternalException in SplitContainer.RepaintSplitterRect during display-session transition

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Layout/Containers/SplitContainer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Layout/Containers/SplitContainer.cs
@@ -1550,16 +1550,24 @@ public partial class SplitContainer : ContainerControl, ISupportInitialize
     {
         if (IsHandleCreated)
         {
-            using Graphics g = CreateGraphicsInternal();
-            if (BackgroundImage is not null)
+            try
             {
-                using TextureBrush textureBrush = new(BackgroundImage, WrapMode.Tile);
-                g.FillRectangle(textureBrush, ClientRectangle);
+                using Graphics g = CreateGraphicsInternal();
+                if (BackgroundImage is not null)
+                {
+                    using TextureBrush textureBrush = new(BackgroundImage, WrapMode.Tile);
+                    g.FillRectangle(textureBrush, ClientRectangle);
+                }
+                else
+                {
+                    using var solidBrush = BackColor.GetCachedSolidBrushScope();
+                    g.FillRectangle(solidBrush, _splitterRect);
+                }
             }
-            else
+            catch (ExternalException)
             {
-                using var solidBrush = BackColor.GetCachedSolidBrushScope();
-                g.FillRectangle(solidBrush, _splitterRect);
+                // GDI+ can transiently fail while the display session is transitioning (for example, lock/unlock).
+                // Ignore repaint failures here and let normal painting recover once graphics resources are available.
             }
         }
     }

--- a/src/System.Windows.Forms/System/Windows/Forms/Layout/Containers/SplitContainer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Layout/Containers/SplitContainer.cs
@@ -1564,10 +1564,11 @@ public partial class SplitContainer : ContainerControl, ISupportInitialize
                     g.FillRectangle(solidBrush, _splitterRect);
                 }
             }
-            catch (ExternalException)
+            catch (ExternalException ex)
             {
                 // GDI+ can transiently fail while the display session is transitioning (for example, lock/unlock).
                 // Ignore repaint failures here and let normal painting recover once graphics resources are available.
+                Debug.Fail($"{nameof(RepaintSplitterRect)} failed with hr={ex.ErrorCode}, message={ex}");
             }
         }
     }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14562

## Root Cause
`SplitContainer.RepaintSplitterRect()` performs immediate GDI+ drawing during layout (`CreateGraphicsInternal` + `FillRectangle`).
During display-session transitions (for example, Windows lock/unlock), the graphics context can become transiently invalid and GDI+ may throw `ExternalException` (A generic error occurred in GDI+).
This exception was previously unhandled in this path and could bubble up as an unhandled exception.

## Proposed changes

- Add targeted exception handling in `SplitContainer.RepaintSplitterRect()`:
   - Wrap current repaint logic in `try/catch (ExternalException)`.
   - Keep existing rendering behavior unchanged when drawing succeeds.
   - Ignore only transient GDI+ failures so normal paint/layout cycles can recover automatically.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Users no longer see intermittent crash dialogs (“A generic error occurred in GDI+”) when lock/unlock happens during window creation/layout in forms that use `SplitContainer`

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->
Sample project: [WinFormsApp5.zip](https://github.com/user-attachments/files/28297032/WinFormsApp5.zip)

### Before
When a window containing `SplitContainer` is opened and the machine is locked before layout completes, unlocking can trigger an unhandled error dialog (“A generic error occurred in GDI+”).

<img width="547" height="428" alt="image" src="https://github.com/user-attachments/assets/b8cbf71d-3ccb-4738-ac2a-424bf4e085b4" />

### After
Under the same lock/unlock timing, users no longer see the GDI+ error dialog and the app does not crash from this path.
The window opens and continues rendering normally after unlock, with no new UI changes in normal scenarios.

<img width="983" height="551" alt="image" src="https://github.com/user-attachments/assets/d0ca1238-7f1c-4382-85d0-e86d38ff54df" />


## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-preview.5.26272.112


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14565)