### PR TITLE
Fixes PropertyGrid.ResetHelpForeColor resets the back color instead of the fore color

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
@@ -3628,7 +3628,7 @@ public partial class PropertyGrid : ContainerControl, IComPropertyBrowser, IProp
 
     private void ResetHelpBackColor() => _helpPane.ResetBackColor();
 
-    private void ResetHelpForeColor() => _helpPane.ResetBackColor();
+    private void ResetHelpForeColor() => _helpPane.ResetForeColor();
 
     /// <summary>
     ///  This method is intended for use in replacing a specific selected root object with another object of the

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/PropertyGridTests.cs
@@ -1972,6 +1972,36 @@ public partial class PropertyGridTests
         Assert.False(property.ShouldSerializeValue(control));
     }
 
+    [WinFormsFact]
+    public void PropertyGrid_ResetHelpForeColor_Invoke_ResetsForeColorOnly()
+    {
+        using PropertyGrid control = new()
+        {
+            HelpForeColor = Color.Red,
+            HelpBackColor = Color.Yellow
+        };
+
+        control.TestAccessor.Dynamic.ResetHelpForeColor();
+
+        Assert.Equal(SystemColors.ControlText, control.HelpForeColor);
+        Assert.Equal(Color.Yellow, control.HelpBackColor);
+    }
+
+    [WinFormsFact]
+    public void PropertyGrid_ResetHelpBackColor_Invoke_ResetsBackColorOnly()
+    {
+        using PropertyGrid control = new()
+        {
+            HelpForeColor = Color.Red,
+            HelpBackColor = Color.Yellow
+        };
+
+        control.TestAccessor.Dynamic.ResetHelpBackColor();
+
+        Assert.Equal(SystemColors.Control, control.HelpBackColor);
+        Assert.Equal(Color.Red, control.HelpForeColor);
+    }
+
     [WinFormsTheory]
     [InlineData(true, true, 0, 0, 1)]
     [InlineData(true, false, 1, 1, 2)]


### PR DESCRIPTION
Fixes #14571
Related #12055

## Root Cause

`PropertyGrid.ResetHelpForeColor` (PropertyGrid.cs:3631) delegated to `_helpPane.ResetBackColor()` instead of `_helpPane.ResetForeColor()`; copy-paste typo from `ResetHelpBackColor`, present since the initial WinForms source import in 2018. The method is private with zero call sites, so the defect was never observable through any public API and went undetected.

## Proposed changes

- PropertyGrid.cs:3631: `_helpPane.ResetBackColor()` > `_helpPane.ResetForeColor()`.
- PropertyGridTests.cs: add `PropertyGrid_ResetHelpForeColor_Invoke_ResetsForeColorOnly` and `PropertyGrid_ResetHelpBackColor_Invoke_ResetsBackColorOnly`, invoking the private methods directly via `TestAccessor.Dynamic` so coverage and regression protection are independent of the `PropertyDescriptor.ResetValue` path. Contributes to #12055.

## Customer Impact

None. The buggy method has no call sites; no shipped behavior changes.

## Regression?

No.

## Risk

Minimal

## Test methodology

Unit tests

## Test environment(s)

11.0.100-preview.5.26227.104

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14572)