### PR TITLE
Fix cursor editor icon width calculation for proper DPI scaling

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/CursorEditor.CursorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/CursorEditor.CursorUI.cs
@@ -17,7 +17,7 @@ public partial class CursorEditor
         private IWindowsFormsEditorService? _editorService;
         private readonly TypeConverter _cursorConverter;
         private readonly Dictionary<(Cursor cursor, int dpi), int> _cursorWidthCache = new();
-        private readonly int _cursorWidth;
+        private int _cursorWidth;
 
         public CursorUI()
         {
@@ -41,9 +41,7 @@ public partial class CursorEditor
                 }
             }
 
-            using Icon defaultIcon = Icon.FromHandle(Cursors.Default.Handle);
-            using Icon scaledDefaultIcon = ScaleHelper.ScaleSmallIconToDpi(defaultIcon, DeviceDpi);
-            _cursorWidth = scaledDefaultIcon.Size.Width;
+            _cursorWidth = GetCursorWidthForDpi(Cursors.Default, DeviceDpi);
         }
 
         public object? Value { get; private set; }
@@ -72,7 +70,6 @@ public partial class CursorEditor
                 string? text = _cursorConverter.ConvertToString(cursor);
                 Font font = e.Font!;
                 using var brushText = e.ForeColor.GetCachedSolidBrushScope();
-                int cursorWidth = GetCursorWidthForDpi(cursor, DeviceDpi);
 
                 e.DrawBackground();
                 e.Graphics.FillRectangle(SystemBrushes.Control, new Rectangle(e.Bounds.X + 2, e.Bounds.Y + 2, _cursorWidth, e.Bounds.Height - 4));
@@ -128,6 +125,15 @@ public partial class CursorEditor
                     }
                 }
             }
+        }
+
+        protected override void RescaleConstantsForDpi(int deviceDpiOld, int deviceDpiNew)
+        {
+            base.RescaleConstantsForDpi(deviceDpiOld, deviceDpiNew);
+
+            // Recalculate the representative width using the new DPI; all rows continue to share it to avoid the layout issues seen in #14167.
+            _cursorWidth = GetCursorWidthForDpi(Cursors.Default, deviceDpiNew);
+            Invalidate();
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/CursorEditor.CursorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/CursorEditor.CursorUI.cs
@@ -17,6 +17,7 @@ public partial class CursorEditor
         private IWindowsFormsEditorService? _editorService;
         private readonly TypeConverter _cursorConverter;
         private readonly Dictionary<(Cursor cursor, int dpi), int> _cursorWidthCache = new();
+        private readonly int _cursorWidth;
 
         public CursorUI()
         {
@@ -39,6 +40,10 @@ public partial class CursorEditor
                     Items.Add(obj);
                 }
             }
+
+            using Icon defaultIcon = Icon.FromHandle(Cursors.Default.Handle);
+            using Icon scaledDefaultIcon = ScaleHelper.ScaleSmallIconToDpi(defaultIcon, DeviceDpi);
+            _cursorWidth = scaledDefaultIcon.Size.Width;
         }
 
         public object? Value { get; private set; }
@@ -70,11 +75,11 @@ public partial class CursorEditor
                 int cursorWidth = GetCursorWidthForDpi(cursor, DeviceDpi);
 
                 e.DrawBackground();
-                e.Graphics.FillRectangle(SystemBrushes.Control, new Rectangle(e.Bounds.X + 2, e.Bounds.Y + 2, cursorWidth, e.Bounds.Height - 4));
-                e.Graphics.DrawRectangle(SystemPens.WindowText, new Rectangle(e.Bounds.X + 2, e.Bounds.Y + 2, cursorWidth - 1, e.Bounds.Height - 4 - 1));
+                e.Graphics.FillRectangle(SystemBrushes.Control, new Rectangle(e.Bounds.X + 2, e.Bounds.Y + 2, _cursorWidth, e.Bounds.Height - 4));
+                e.Graphics.DrawRectangle(SystemPens.WindowText, new Rectangle(e.Bounds.X + 2, e.Bounds.Y + 2, _cursorWidth - 1, e.Bounds.Height - 4 - 1));
 
-                cursor.DrawStretched(e.Graphics, new Rectangle(e.Bounds.X + 2, e.Bounds.Y + 2, cursorWidth, e.Bounds.Height - 4));
-                e.Graphics.DrawString(text, font, brushText, e.Bounds.X + cursorWidth + 4, e.Bounds.Y + (e.Bounds.Height - font.Height) / 2);
+                cursor.DrawStretched(e.Graphics, new Rectangle(e.Bounds.X + 2, e.Bounds.Y + 2, _cursorWidth, e.Bounds.Height - 4));
+                e.Graphics.DrawString(text, font, brushText, e.Bounds.X + _cursorWidth + 4, e.Bounds.Y + (e.Bounds.Height - font.Height) / 2);
             }
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14167

## Root Cause
Icons similar to HSplit.cur, VSplit.cur are wider than other icons at certain DPI settings (such as 125%, 175%， 225%， 250%), which is causing the webtable to display abnormally. 

## Proposed changes

- Modify the drawing method for list items to use the default icon width as a reference, ensuring that all icons are the same size.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Cursor editor items are displayed correctly in propertyGrid with all DPI settings.

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
<img width="1298" height="676" alt="image" src="https://github.com/user-attachments/assets/ad012b37-9dff-4ece-9479-57a0d1cfe1d8" />

### After

**150DPI**:

https://github.com/user-attachments/assets/d3e733d6-d7d9-4e83-ae12-c4d206a68e72

**175DPI**:

https://github.com/user-attachments/assets/0a493a00-ade4-4e57-ad03-ab685faea762

**200DPI**:

https://github.com/user-attachments/assets/2d21c7b6-899e-47cb-a792-7604b3077143

**225DPI**:

https://github.com/user-attachments/assets/9d71b5e4-8033-4304-9f34-542247ebb06c

## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.0-alpha.1.25619.109


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14163)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14575)