### PR TITLE
Fix MaskedTextBox PropertyGrid text editor DPI scaling at runtime

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxTextEditorDropDown.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxTextEditorDropDown.cs
@@ -48,8 +48,8 @@ internal class MaskedTextBoxTextEditorDropDown : UserControl
         BackColor = Drawing.SystemColors.Control;
         BorderStyle = BorderStyle.FixedSingle;
         Name = "MaskedTextBoxTextEditorDropDown";
-        Padding = new Padding(16);
-        Size = new Drawing.Size(100, 52);
+        Padding = new Padding(LogicalToDeviceUnits(16));
+        Size = LogicalToDeviceUnits(new Drawing.Size(100, 52));
         ((System.ComponentModel.ISupportInitialize)(_errorProvider)).EndInit();
         ResumeLayout(false);
         PerformLayout();

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxTextEditorDropDown.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxTextEditorDropDown.cs
@@ -5,6 +5,11 @@ namespace System.Windows.Forms.Design;
 
 internal class MaskedTextBoxTextEditorDropDown : UserControl
 {
+    // Logical (96 DPI) constants. The actual device-pixel values are recomputed in
+    // RescaleConstantsForDpi so that PerMonitorV2 DPI changes are honoured.
+    private const int LogicalPadding = 16;
+    private static readonly Drawing.Size s_logicalSize = new(100, 52);
+
     private bool _cancel;
     private readonly MaskedTextBox _cloneMtb;
     private readonly ErrorProvider _errorProvider;
@@ -48,8 +53,11 @@ internal class MaskedTextBoxTextEditorDropDown : UserControl
         BackColor = Drawing.SystemColors.Control;
         BorderStyle = BorderStyle.FixedSingle;
         Name = "MaskedTextBoxTextEditorDropDown";
-        Padding = new Padding(LogicalToDeviceUnits(16));
-        Size = LogicalToDeviceUnits(new Drawing.Size(100, 52));
+
+        // Apply the initial DPI-scaled padding/size. Subsequent DPI changes are
+        // picked up automatically through RescaleConstantsForDpi.
+        RescaleConstantsForDpi(DeviceDpi, DeviceDpi);
+
         ((System.ComponentModel.ISupportInitialize)(_errorProvider)).EndInit();
         ResumeLayout(false);
         PerformLayout();
@@ -78,6 +86,16 @@ internal class MaskedTextBoxTextEditorDropDown : UserControl
         }
 
         return base.ProcessDialogKey(keyData);
+    }
+
+    protected override void RescaleConstantsForDpi(int deviceDpiOld, int deviceDpiNew)
+    {
+        base.RescaleConstantsForDpi(deviceDpiOld, deviceDpiNew);
+
+        // DeviceDpi has already been updated to deviceDpiNew by the framework before
+        // this call, so LogicalToDeviceUnits returns values scaled to the new DPI.
+        Padding = new Padding(LogicalToDeviceUnits(LogicalPadding));
+        Size = LogicalToDeviceUnits(s_logicalSize);
     }
 
     private void maskedTextBox_MaskInputRejected(object? sender, MaskInputRejectedEventArgs e)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxTextEditorDropDown.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxTextEditorDropDown.cs
@@ -92,10 +92,8 @@ internal class MaskedTextBoxTextEditorDropDown : UserControl
     {
         base.RescaleConstantsForDpi(deviceDpiOld, deviceDpiNew);
 
-        // DeviceDpi has already been updated to deviceDpiNew by the framework before
-        // this call, so LogicalToDeviceUnits returns values scaled to the new DPI.
-        Padding = new Padding(LogicalToDeviceUnits(LogicalPadding));
-        Size = LogicalToDeviceUnits(s_logicalSize);
+        Padding = new Padding(ScaleHelper.ScaleToDpi(LogicalPadding, deviceDpiNew));
+        Size = ScaleHelper.ScaleToDpi(s_logicalSize, deviceDpiNew);
     }
 
     private void maskedTextBox_MaskInputRejected(object? sender, MaskInputRejectedEventArgs e)

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskedTextBoxTextEditorDropDownTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskedTextBoxTextEditorDropDownTests.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Drawing;
+
 namespace System.Windows.Forms.Design.Tests;
 
 public class MaskedTextBoxTextEditorDropDownTests
@@ -53,5 +55,21 @@ public class MaskedTextBoxTextEditorDropDownTests
         // Incorrectly formatted values will result in the error "Error at position 0: expected number".
         dropDownMaskedTextBox.Text = "invalid";
         errorProvider.GetError(dropDownMaskedTextBox).Should().Contain(SR.MaskedTextBoxHintDigitExpected);
+    }
+
+    [Fact]
+    public void DropDown_SizeAndPadding_ScalesWithDPI()
+    {
+        using MaskedTextBox maskedTextBox = new();
+        using MaskedTextBoxTextEditorDropDown dropDown = new(maskedTextBox);
+
+        // The size and padding should be scaled based on DPI
+        // At 96 DPI (100%), Size should be (100, 52) and Padding should be (16, 16, 16, 16)
+        // At higher DPI, these values should scale proportionally
+        Size expectedSize = dropDown.LogicalToDeviceUnits(new Size(100, 52));
+        Padding expectedPadding = new(dropDown.LogicalToDeviceUnits(16));
+
+        dropDown.Size.Should().Be(expectedSize);
+        dropDown.Padding.Should().Be(expectedPadding);
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskedTextBoxTextEditorDropDownTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskedTextBoxTextEditorDropDownTests.cs
@@ -63,13 +63,10 @@ public class MaskedTextBoxTextEditorDropDownTests
         using MaskedTextBox maskedTextBox = new();
         using MaskedTextBoxTextEditorDropDown dropDown = new(maskedTextBox);
 
-        // The size and padding should be scaled based on DPI
-        // At 96 DPI (100%), Size should be (100, 52) and Padding should be (16, 16, 16, 16)
-        // At higher DPI, these values should scale proportionally
-        Size expectedSize = dropDown.LogicalToDeviceUnits(new Size(100, 52));
-        Padding expectedPadding = new(dropDown.LogicalToDeviceUnits(16));
+        // Simulate a DPI change and verify that the dropdown recomputes its logical constants.
+        dropDown.TestAccessor.Dynamic.RescaleConstantsForDpi(96, 192);
 
-        dropDown.Size.Should().Be(expectedSize);
-        dropDown.Padding.Should().Be(expectedPadding);
+        dropDown.Size.Should().Be(new Size(100, 52));
+        dropDown.Padding.Should().Be(new Padding(16));
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskedTextBoxTextEditorDropDownTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskedTextBoxTextEditorDropDownTests.cs
@@ -61,12 +61,21 @@ public class MaskedTextBoxTextEditorDropDownTests
     public void DropDown_SizeAndPadding_ScalesWithDPI()
     {
         using MaskedTextBox maskedTextBox = new();
-        using MaskedTextBoxTextEditorDropDown dropDown = new(maskedTextBox);
+        using SubMaskedTextBoxTextEditorDropDown dropDown = new(maskedTextBox);
 
-        // Simulate a DPI change and verify that the dropdown recomputes its logical constants.
-        dropDown.TestAccessor.Dynamic.RescaleConstantsForDpi(96, 192);
+        dropDown.RescaleConstantsForDpi(96, 192);
+        dropDown.Size.Should().Be(new Size(200, 104));
+        dropDown.Padding.Should().Be(new Padding(32));
+        dropDown.IsHandleCreated.Should().BeFalse();
+    }
 
-        dropDown.Size.Should().Be(new Size(100, 52));
-        dropDown.Padding.Should().Be(new Padding(16));
+    private sealed class SubMaskedTextBoxTextEditorDropDown : MaskedTextBoxTextEditorDropDown
+    {
+        public SubMaskedTextBoxTextEditorDropDown(MaskedTextBox maskedTextBox) : base(maskedTextBox)
+        {
+        }
+
+        public new void RescaleConstantsForDpi(int deviceDpiOld, int deviceDpiNew)
+            => base.RescaleConstantsForDpi(deviceDpiOld, deviceDpiNew);
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14165

## Root Cause
The MaskedTextBox text editor dropdown in PropertyGrid uses hardcoded pixel values that don't scale with DPI, causing clipped/undersized rendering at high DPI (e.g., 300%).

## Proposed changes

- **MaskedTextBoxTextEditorDropDown.cs**: Apply `LogicalToDeviceUnits()` to size and padding values in constructor
  ```csharp
  // Before: hardcoded values
  Padding = new Padding(16);
  Size = new Drawing.Size(100, 52);
  
  // After: DPI-aware scaling
  Padding = new Padding(LogicalToDeviceUnits(16));
  Size = LogicalToDeviceUnits(new Drawing.Size(100, 52));
  ```

- **MaskedTextBoxTextEditorDropDownTests.cs**: Add test verifying DPI scaling behavior

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The MaskedTextBox text editor dropdown list in PropertyGrid uses hard-coded pixel values ​​and displays correctly at different DPI settings.

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
<img width="560" height="371" alt="image" src="https://github.com/user-attachments/assets/37c6deb1-7e7a-47e5-b590-60dcf350ba6f" />

### After

<img width="1773" height="1065" alt="After" src="https://github.com/user-attachments/assets/915d737d-9b54-4a4d-b3a8-349b4148cb64" />

## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.100


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14163)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14576)