### PR TITLE
Adding PDB and Intellisense file for Microsoft.Private.Windows.Core assembly to the NuGet package

### DIFF
--- a/pkg/Microsoft.Private.Windows.Core/Microsoft.Private.Windows.Core.Package.csproj
+++ b/pkg/Microsoft.Private.Windows.Core/Microsoft.Private.Windows.Core.Package.csproj
@@ -83,6 +83,7 @@
   <Target Name="AddPackageSymbols">
     <ItemGroup>
       <TfmSpecificDebugSymbolsFile Include="$(_SourceBinDir)$(_SourceProjectName).pdb"
+                                   Condition="Exists('$(_SourceBinDir)$(_SourceProjectName).pdb')"
                                    TargetPath="$(_SourceProjectName).pdb"
                                    TargetFramework="$(NetFxTFM)" />
     </ItemGroup>

--- a/pkg/Microsoft.Private.Windows.Core/Microsoft.Private.Windows.Core.Package.csproj
+++ b/pkg/Microsoft.Private.Windows.Core/Microsoft.Private.Windows.Core.Package.csproj
@@ -17,10 +17,10 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- Don't include this project in the build output -->
-    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <!-- Enable the pack symbol pipeline, then strip this project's own outputs below. -->
+    <IncludeBuildOutput>true</IncludeBuildOutput>
     <PublishWindowsPdb>false</PublishWindowsPdb>
-    <IncludeSymbols>false</IncludeSymbols>
+    <IncludeSymbols>true</IncludeSymbols>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -53,14 +53,38 @@
     <_SourceBinDir>$(ArtifactsBinDir)$(_SourceProjectName)\$(Configuration)\$(NetFxTFM)\</_SourceBinDir>
 
     <!-- Call custom target when creating the package -->
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);RemovePackProjectBuildOutputs</TargetsForTfmSpecificBuildOutput>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddPackageContent</TargetsForTfmSpecificContentInPackage>
+    <TargetsForTfmSpecificDebugSymbolsInPackage>$(TargetsForTfmSpecificDebugSymbolsInPackage);RemovePackProjectDebugSymbols;AddPackageSymbols</TargetsForTfmSpecificDebugSymbolsInPackage>
   </PropertyGroup>
+
+  <Target Name="RemovePackProjectBuildOutputs">
+    <ItemGroup>
+      <BuiltProjectOutputGroupOutput Remove="@(BuiltProjectOutputGroupOutput)" />
+      <DocumentationProjectOutputGroupOutput Remove="@(DocumentationProjectOutputGroupOutput)" />
+    </ItemGroup>
+  </Target>
 
   <!-- Include implementation and reference assemblies in the package -->
   <Target Name="AddPackageContent">
     <ItemGroup>
       <TfmSpecificPackageFile Include="$(_SourceBinDir)$(_SourceProjectName).dll" PackagePath="lib/$(NetFxTFM)" />
+      <TfmSpecificPackageFile Include="$(_SourceBinDir)$(_SourceProjectName).xml" PackagePath="lib/$(NetFxTFM)" />
       <TfmSpecificPackageFile Include="$(_SourceRefDir)$(_SourceProjectName).dll" PackagePath="ref/$(NetFxTFM)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="RemovePackProjectDebugSymbols">
+    <ItemGroup>
+      <DebugSymbolsProjectOutputGroupOutput Remove="@(DebugSymbolsProjectOutputGroupOutput)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="AddPackageSymbols">
+    <ItemGroup>
+      <TfmSpecificDebugSymbolsFile Include="$(_SourceBinDir)$(_SourceProjectName).pdb"
+                                   TargetPath="$(_SourceProjectName).pdb"
+                                   TargetFramework="$(NetFxTFM)" />
     </ItemGroup>
   </Target>
 

--- a/pkg/Microsoft.Private.Windows.Core/Microsoft.Private.Windows.Core.Package.csproj
+++ b/pkg/Microsoft.Private.Windows.Core/Microsoft.Private.Windows.Core.Package.csproj
@@ -69,8 +69,8 @@
   <Target Name="AddPackageContent">
     <ItemGroup>
       <TfmSpecificPackageFile Include="$(_SourceBinDir)$(_SourceProjectName).dll" PackagePath="lib/$(NetFxTFM)" />
-      <TfmSpecificPackageFile Include="$(_SourceBinDir)$(_SourceProjectName).xml" PackagePath="lib/$(NetFxTFM)" />
       <TfmSpecificPackageFile Include="$(_SourceRefDir)$(_SourceProjectName).dll" PackagePath="ref/$(NetFxTFM)" />
+      <TfmSpecificPackageFile Include="$(_SourceBinDir)$(_SourceProjectName).xml" PackagePath="ref/$(NetFxTFM)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Issue: In addition to the main NuGet package, the VMR official build produces a separate `Microsoft.Private.Windows.Core.<BuildNumber>.symbols.nupkg` which should contain the PDB files for symbol upload. The current package was not adding these files.

Fix: The change adds the missing files to the package. It was also bringing in the output assembly of the package project itself. Since this is not needed, we remove it from the final package.

Testing: Built both the packages locally and ensured that the correct PDB and Intellisense files are present in the packages.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14596)