### PR TITLE
Adds tests to ExpandAllGridItems and CollapseAllGridItems

### DIFF
--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/PropertyGridTests.cs
@@ -4050,10 +4050,12 @@ public partial class PropertyGridTests
     public void PropertyGrid_ExpandAllGridItems_ExpandsNestedGridItems()
     {
         using PropertyGrid propertyGrid = new();
+        propertyGrid.PropertySort = PropertySort.Alphabetical;
         propertyGrid.SelectedObject = new MyClass();
 
         GridItem nested = FindExpandableProperty(propertyGrid.SelectedGridItem);
         nested.Should().NotBeNull();
+        nested.Expanded.Should().BeFalse();
 
         propertyGrid.ExpandAllGridItems();
 
@@ -4064,6 +4066,7 @@ public partial class PropertyGridTests
     public void PropertyGrid_CollapseAllGridItems_CollapsesNestedGridItems()
     {
         using PropertyGrid propertyGrid = new();
+        propertyGrid.PropertySort = PropertySort.Alphabetical;
         propertyGrid.SelectedObject = new MyClass();
 
         GridItem nested = FindExpandableProperty(propertyGrid.SelectedGridItem);
@@ -4084,7 +4087,8 @@ public partial class PropertyGridTests
             root = root.Parent;
         }
 
-        return Find(root.GridItems);
+        return Find(root.GridItems)
+            ?? throw new InvalidOperationException("No expandable property found on the selected object.");
 
         static GridItem Find(GridItemCollection items)
         {

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/PropertyGridTests.cs
@@ -4047,6 +4047,66 @@ public partial class PropertyGridTests
     }
 
     [WinFormsFact]
+    public void PropertyGrid_ExpandAllGridItems_ExpandsNestedGridItems()
+    {
+        using PropertyGrid propertyGrid = new();
+        propertyGrid.SelectedObject = new MyClass();
+
+        GridItem nested = FindExpandableProperty(propertyGrid.SelectedGridItem);
+        nested.Should().NotBeNull();
+
+        propertyGrid.ExpandAllGridItems();
+
+        nested.Expanded.Should().BeTrue();
+    }
+
+    [WinFormsFact]
+    public void PropertyGrid_CollapseAllGridItems_CollapsesNestedGridItems()
+    {
+        using PropertyGrid propertyGrid = new();
+        propertyGrid.SelectedObject = new MyClass();
+
+        GridItem nested = FindExpandableProperty(propertyGrid.SelectedGridItem);
+        nested.Should().NotBeNull();
+
+        propertyGrid.ExpandAllGridItems();
+        nested.Expanded.Should().BeTrue();
+
+        propertyGrid.CollapseAllGridItems();
+        nested.Expanded.Should().BeFalse();
+    }
+
+    private static GridItem FindExpandableProperty(GridItem item)
+    {
+        GridItem root = item;
+        while (root.Parent is not null)
+        {
+            root = root.Parent;
+        }
+
+        return Find(root.GridItems);
+
+        static GridItem Find(GridItemCollection items)
+        {
+            foreach (GridItem item in items)
+            {
+                if (item.GridItemType == GridItemType.Property && item.GridItems.Count > 0)
+                {
+                    return item;
+                }
+
+                GridItem found = Find(item.GridItems);
+                if (found is not null)
+                {
+                    return found;
+                }
+            }
+
+            return null;
+        }
+    }
+
+    [WinFormsFact]
     public void PropertyGrid_PropertyValueChanged_Invoke_CallsPropertyValueChanged()
     {
         using PropertyGrid propertyGrid = new();


### PR DESCRIPTION
Related to #12055

## Root Cause

- Not a bug. `PropertyGrid.ExpandAllGridItems` and `PropertyGrid.CollapseAllGridItems` had no unit test coverage, contributing to the PropertyGrid's overall coverage gap (~49.91%).

## Proposed changes

- Add two unit tests to `PropertyGridTests.cs`:
  - `PropertyGrid_ExpandAllGridItems_ExpandsNestedGridItems`
  - `PropertyGrid_CollapseAllGridItems_CollapsesNestedGridItems`
- Both reuse the existing `MyClass` fixture (it already exposes an `[ExpandableObjectConverter]` nested property), set it as `SelectedObject`, then assert the nested entry's `Expanded` state flips as expected.
- Add a small `FindExpandableProperty` test helper that walks to the root grid item and returns the first expandable property entry.

## Customer Impact

- None

## Regression?

- No

## Risk

- Minimal


## Test methodology

- Unit tests

## Test environment(s)

- 11.0.100-preview.5.26227.104

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14601)