### PR TITLE
Fix the focus issue of SmartTag/DropDown by preserving the modal menu tracking of ToolStripDropDown.

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
@@ -3934,7 +3934,7 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
     /// <param name="items">contains ToolStrip or ToolStripDropDown items to disconnect</param>
     internal virtual void ReleaseToolStripItemsProviders(ToolStripItemCollection items)
     {
-        ToolStripItem[] itemsArray = [..items.Cast<ToolStripItem>()];
+        ToolStripItem[] itemsArray = [.. items.Cast<ToolStripItem>()];
         foreach (ToolStripItem toolStripItem in itemsArray)
         {
             if (toolStripItem is ToolStripDropDownItem dropDownItem && dropDownItem.DropDownItems.Count > 0)
@@ -4579,14 +4579,24 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
         {
             SnapFocus((HWND)(nint)m.WParamInternal);
 
+            if (IsDropDown)
+            {
+                // Designer SmartTag panels are hosted in ToolStripDropDown. Keep these
+                // participating in modal menu tracking regardless of previous focus.
+                ToolStripManager.ModalMenuFilter.SetActiveToolStrip(this);
+            }
+
             // Only activate ModalMenuFilter when focus transfers
             // between ToolStrips (to fix #12916).
             // Do NOT activate on generic Tab focus (#14489).
-            HWND previousFocus = (HWND)(nint)m.WParamInternal;
-            Control? previousControl = FromChildHandle(previousFocus);
-            if (previousControl is ToolStrip || previousControl?.Parent is ToolStrip)
+            else
             {
-                ToolStripManager.ModalMenuFilter.SetActiveToolStrip(this);
+                HWND previousFocus = (HWND)(nint)m.WParamInternal;
+                Control? previousControl = FromChildHandle(previousFocus);
+                if (previousControl is ToolStrip || previousControl?.Parent is ToolStrip)
+                {
+                    ToolStripManager.ModalMenuFilter.SetActiveToolStrip(this);
+                }
             }
         }
 
@@ -4594,16 +4604,21 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
         {
             // Clear modal menu tracking when focus leaves ToolStrip context so
             // keyboard input is not incorrectly routed after tabbing away.
-            HWND nextFocus = (HWND)(nint)m.WParamInternal;
-            Control? nextControl = FromChildHandle(nextFocus);
-            if (ToolStripManager.ModalMenuFilter.GetActiveToolStrip() == this
-                && nextControl is not ToolStrip
-                && nextControl?.Parent is not ToolStrip)
+            // Keep ToolStripDropDowns in menu tracking while they remain visible (for
+            // example, designer SmartTag panels that may temporarily transfer focus).
+            if (!IsDropDown)
             {
-                ToolStripManager.ModalMenuFilter.RemoveActiveToolStrip(this);
-                if (ToolStripManager.ModalMenuFilter.GetActiveToolStrip() is null)
+                HWND nextFocus = (HWND)(nint)m.WParamInternal;
+                Control? nextControl = FromChildHandle(nextFocus);
+                if (ToolStripManager.ModalMenuFilter.GetActiveToolStrip() == this
+                    && nextControl is not ToolStrip
+                    && nextControl?.Parent is not ToolStrip)
                 {
-                    ToolStripManager.ModalMenuFilter.ExitMenuMode();
+                    ToolStripManager.ModalMenuFilter.RemoveActiveToolStrip(this);
+                    if (ToolStripManager.ModalMenuFilter.GetActiveToolStrip() is null)
+                    {
+                        ToolStripManager.ModalMenuFilter.ExitMenuMode();
+                    }
                 }
             }
         }


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14600

## Root Cause
PR #14491 tightened ToolStrip focus handling to avoid accidental menu activation for normal tab navigation.
The new logic worked for regular ToolStrip, but it also affected ToolStripDropDown scenarios (including SmartTag-hosted UI):

1. On focus transitions, modal menu tracking was gated too aggressively.
2. On kill-focus, active ToolStrip/menu mode could be cleared too early for drop-down hosts.
3. Once menu mode exited prematurely, the expected auto-dismiss behavior on subsequent UI navigation (such as tab switching) could break.

## Proposed changes

- Keep the #14489 fix for regular ToolStrip focus behavior.
- Restore ToolStripDropDown focus/menu tracking behavior to avoid premature menu-mode exit.
- Update ToolStrip focus handling in `WM_SETFOCUS/WM_KILLFOCUS` to treat DropDown and non-DropDown separately.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The SmartTag dialog can be exited normally when switch the TabPage items

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
The SmartTag dialog doesn't disappear when switch the Tabpage items

https://github.com/user-attachments/assets/feda07d8-f1ca-49a5-93c7-4cb17eb73323


### After
The SmartTag can be closed normally when switching the TabPage items

https://github.com/user-attachments/assets/c5b08742-720a-44fc-b8b4-0391e99ab97d


## Test methodology <!-- How did you ensure quality? -->

- Manualy


## Test environment(s) <!-- Remove any that don't apply -->

-  .net 11.0.0-preview.5.26258.110


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14606)