### PR TITLE
Fix ComboBox dropdown height after clearing or removing all items

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.ComboBoxChildNativeWindow.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.ComboBoxChildNativeWindow.cs
@@ -176,10 +176,13 @@ public partial class ComboBox
             WINDOWPOS* pos = (WINDOWPOS*)(nint)m.LParamInternal;
             if (pos is not null && (pos->flags & SET_WINDOW_POS_FLAGS.SWP_NOSIZE) == 0)
             {
-                int height = _owner.GetCalculatedDropDownHeight();
-                if (pos->cy != height)
+                int calculatedHeight = _owner.GetCalculatedDropDownHeight();
+
+                // Only shrink stale native height. Never grow over USER32's proposed height,
+                // because USER32 may have clamped it to fit the monitor work area.
+                if (calculatedHeight > 0 && pos->cy > calculatedHeight)
                 {
-                    pos->cy = height;
+                    pos->cy = calculatedHeight;
                 }
             }
         }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.ComboBoxChildNativeWindow.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.ComboBoxChildNativeWindow.cs
@@ -28,11 +28,6 @@ public partial class ComboBox
                 case PInvokeCore.WM_WINDOWPOSCHANGING:
                     if (_childWindowType == ChildWindowType.DropDownList)
                     {
-                        // The native ComboBox sizes the dropdown list during its own layout
-                        // pass (after CBN_DROPDOWN fires). Intercept here to enforce the
-                        // managed computed height before the OS commits the final size.
-                        // This ensures the UI reflects Items.Count (or explicit DropDownHeight)
-                        // even when the list is empty or items are cleared at runtime.
                         WmWindowPosChanging(ref m);
                         DefWndProc(ref m);
                     }
@@ -173,6 +168,11 @@ public partial class ComboBox
 
         private unsafe void WmWindowPosChanging(ref Message m)
         {
+            // The native ComboBox sizes the dropdown list during its own layout
+            // pass (after CBN_DROPDOWN fires). Intercept here to enforce the
+            // managed computed height before the OS commits the final size.
+            // This ensures the UI reflects Items.Count (or explicit DropDownHeight)
+            // even when the list is empty or items are cleared at runtime.
             WINDOWPOS* pos = (WINDOWPOS*)(nint)m.LParamInternal;
             if (pos is not null && (pos->flags & SET_WINDOW_POS_FLAGS.SWP_NOSIZE) == 0)
             {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.ComboBoxChildNativeWindow.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.ComboBoxChildNativeWindow.cs
@@ -33,15 +33,8 @@ public partial class ComboBox
                         // managed computed height before the OS commits the final size.
                         // This ensures the UI reflects Items.Count (or explicit DropDownHeight)
                         // even when the list is empty or items are cleared at runtime.
-                        WINDOWPOS* wp = (WINDOWPOS*)(nint)m.LParamInternal;
-                        if (wp is not null && (wp->flags & SET_WINDOW_POS_FLAGS.SWP_NOSIZE) == 0)
-                        {
-                            var height = _owner.GetCalculatedDropDownHeight();
-                            if (wp->cy != height)
-                            {
-                                wp->cy = height;
-                            }
-                        }
+                        WmWindowPosChanging(ref m);
+                        DefWndProc(ref m);
                     }
                     else
                     {
@@ -175,6 +168,19 @@ public partial class ComboBox
             catch (Exception e)
             {
                 throw new InvalidOperationException(SR.RichControlLresult, e);
+            }
+        }
+
+        private unsafe void WmWindowPosChanging(ref Message m)
+        {
+            WINDOWPOS* pos = (WINDOWPOS*)(nint)m.LParamInternal;
+            if (pos is not null && (pos->flags & SET_WINDOW_POS_FLAGS.SWP_NOSIZE) == 0)
+            {
+                int height = _owner.GetCalculatedDropDownHeight();
+                if (pos->cy != height)
+                {
+                    pos->cy = height;
+                }
             }
         }
     }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.ComboBoxChildNativeWindow.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.ComboBoxChildNativeWindow.cs
@@ -25,6 +25,26 @@ public partial class ComboBox
                 case PInvokeCore.WM_GETOBJECT:
                     WmGetObject(ref m);
                     return;
+                case PInvokeCore.WM_WINDOWPOSCHANGING:
+                    if (_childWindowType == ChildWindowType.DropDownList)
+                    {
+                        // The native ComboBox sizes the dropdown list during its own layout
+                        // pass (after CBN_DROPDOWN fires). Intercept here to enforce the
+                        // managed computed height before the OS commits the final size.
+                        // This ensures the UI reflects Items.Count (or explicit DropDownHeight)
+                        // even when the list is empty or items are cleared at runtime.
+                        WINDOWPOS* pos = (WINDOWPOS*)(nint)m.LParamInternal;
+                        if (pos is not null && (pos->flags & SET_WINDOW_POS_FLAGS.SWP_NOSIZE) == 0)
+                        {
+                            var height = _owner.GetCalculatedDropDownHeight();
+                            if (pos->cy != height)
+                            {
+                                pos->cy = height;
+                            }
+                        }
+                    }
+
+                    return;
                 case PInvokeCore.WM_MOUSEMOVE:
                     if (_childWindowType == ChildWindowType.DropDownList)
                     {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.ComboBoxChildNativeWindow.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.ComboBoxChildNativeWindow.cs
@@ -33,18 +33,22 @@ public partial class ComboBox
                         // managed computed height before the OS commits the final size.
                         // This ensures the UI reflects Items.Count (or explicit DropDownHeight)
                         // even when the list is empty or items are cleared at runtime.
-                        WINDOWPOS* pos = (WINDOWPOS*)(nint)m.LParamInternal;
-                        if (pos is not null && (pos->flags & SET_WINDOW_POS_FLAGS.SWP_NOSIZE) == 0)
+                        WINDOWPOS* wp = (WINDOWPOS*)(nint)m.LParamInternal;
+                        if (wp is not null && (wp->flags & SET_WINDOW_POS_FLAGS.SWP_NOSIZE) == 0)
                         {
                             var height = _owner.GetCalculatedDropDownHeight();
-                            if (pos->cy != height)
+                            if (wp->cy != height)
                             {
-                                pos->cy = height;
+                                wp->cy = height;
                             }
                         }
                     }
+                    else
+                    {
+                        _owner.ChildWndProc(ref m);
+                    }
 
-                    return;
+                    break;
                 case PInvokeCore.WM_MOUSEMOVE:
                     if (_childWindowType == ChildWindowType.DropDownList)
                     {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
@@ -3327,6 +3327,19 @@ public partial class ComboBox : ListControl
         return $"{s}, Items.Count: {_itemsCollection?.Count ?? 0}";
     }
 
+    private int GetCalculatedDropDownHeight()
+    {
+        int height = DropDownHeight;
+        if (height == DefaultDropDownHeight)
+        {
+            int itemCount = (_itemsCollection is null) ? 0 : _itemsCollection.Count;
+            int count = Math.Min(Math.Max(itemCount, 1), _maxDropDownItems);
+            height = ItemHeight * count + 2;
+        }
+
+        return height;
+    }
+
     private void UpdateDropDownHeight()
     {
         if (_dropDownHandle.IsNull)
@@ -3335,13 +3348,7 @@ public partial class ComboBox : ListControl
         }
 
         // Now use the DropDownHeight property instead of calculating the Height...
-        int height = DropDownHeight;
-        if (height == DefaultDropDownHeight)
-        {
-            int itemCount = (_itemsCollection is null) ? 0 : _itemsCollection.Count;
-            int count = Math.Min(Math.Max(itemCount, 1), _maxDropDownItems);
-            height = ItemHeight * count + 2;
-        }
+        int height = GetCalculatedDropDownHeight();
 
         PInvoke.SetWindowPos(
             _dropDownHandle,

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ComboBox.ComboBoxChildNativeWindowTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ComboBox.ComboBoxChildNativeWindowTests.cs
@@ -22,4 +22,72 @@ public class ComboBox_ComboBoxChildNativeWindowTests
             Assert.True(childNativeWindow.TestAccessor.Dynamic.GetChildAccessibleObject() is ComboBox.ChildAccessibleObject);
         }
     }
+
+    [WinFormsFact]
+    public void ComboBox_DropDownHeight_UpdatesAfterItemsClear()
+    {
+        using ComboBox comboBox = new() { DropDownStyle = ComboBoxStyle.DropDown, ItemHeight = 20 };
+        comboBox.Items.Add("Item 1");
+        comboBox.Items.Add("Item 2");
+        comboBox.Items.Add("Item 3");
+        comboBox.CreateControl();
+        comboBox.DroppedDown = true;
+
+        var childNativeWindow = comboBox.GetListNativeWindow();
+        Assert.NotNull(childNativeWindow);
+        PInvokeCore.GetWindowRect(childNativeWindow.HWND, out RECT rect);
+        int heightBeforeClear = rect.Height;
+        comboBox.DroppedDown = false;
+
+        comboBox.Items.Clear();
+        comboBox.DroppedDown = true;
+        PInvokeCore.GetWindowRect(childNativeWindow.HWND, out RECT rect1);
+        int heightAfterClear = rect1.Height;
+        comboBox.DroppedDown = false;
+
+        bool heightReduced = heightBeforeClear > heightAfterClear;
+        Assert.True(heightReduced);
+        Assert.NotEqual(heightBeforeClear, heightAfterClear);
+
+        comboBox.Items.Add("Item 1");
+        comboBox.Items.Add("Item 2");
+        comboBox.DroppedDown = true;
+        PInvokeCore.GetWindowRect(childNativeWindow.HWND, out RECT rect2);
+        int heightAfterAdd = rect2.Height;
+
+        bool heightIncreased = heightAfterAdd > heightAfterClear;
+        Assert.True(heightIncreased);
+        Assert.NotEqual(heightAfterAdd, heightAfterClear);
+    }
+
+    [WinFormsFact]
+    public void ComboBox_DropDownHeight_UpdatesAfterRemovingAllItems()
+    {
+        using ComboBox comboBox = new() { DropDownStyle = ComboBoxStyle.DropDown, ItemHeight = 20 };
+        comboBox.Items.Add("Item 1");
+        comboBox.Items.Add("Item 2");
+        comboBox.Items.Add("Item 3");
+        comboBox.CreateControl();
+        comboBox.DroppedDown = true;
+
+        var childNativeWindow = comboBox.GetListNativeWindow();
+        Assert.NotNull(childNativeWindow);
+        PInvokeCore.GetWindowRect(childNativeWindow.HWND, out RECT rect);
+        int heightBeforeClear = rect.Height;
+        comboBox.DroppedDown = false;
+
+        for (int i = 0; i < 3; i++)
+        {
+            comboBox.Items.RemoveAt(0);
+        }
+
+        comboBox.DroppedDown = true;
+        PInvokeCore.GetWindowRect(childNativeWindow.HWND, out RECT rect1);
+        int heightAfterClear = rect1.Height;
+        comboBox.DroppedDown = false;
+
+        bool heightReduced = heightBeforeClear > heightAfterClear;
+        Assert.True(heightReduced);
+        Assert.NotEqual(heightBeforeClear, heightAfterClear);
+    }
 }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ComboBoxTests.cs
@@ -2742,6 +2742,60 @@ public class ComboBoxTests
         handleCreatedInvoked.Should().Be(2);
     }
 
+    [WinFormsFact]
+    public void ComboBox_GetCalculatedDropDownHeight_Reflects_Items_Clear()
+    {
+        using ComboBox combo = new();
+        combo.DropDownStyle = ComboBoxStyle.DropDown;
+
+        // Add items to influence calculated height and create handle.
+        for (int i = 0; i < 20; i++)
+        {
+            combo.Items.Add($"item{i}");
+        }
+
+        Assert.NotEqual(IntPtr.Zero, combo.Handle);
+
+        MethodInfo mi = typeof(ComboBox).GetMethod("GetCalculatedDropDownHeight", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(mi);
+
+        int heightWithItems = (int)mi.Invoke(combo, null);
+
+        combo.Items.Clear();
+
+        mi = typeof(ComboBox).GetMethod("GetCalculatedDropDownHeight", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(mi);
+        int heightAfterClear = (int)mi.Invoke(combo, null);
+
+        // After clearing items the calculated height should change and not remain the previous items height.
+        Assert.NotEqual(heightWithItems, heightAfterClear);
+    }
+
+    [WinFormsFact]
+    public void ComboBox_GetCalculatedDropDownHeight_Uses_DropDownHeight_When_NoItems()
+    {
+        using ComboBox combo = new();
+        combo.DropDownStyle = ComboBoxStyle.DropDown;
+
+        // Add items to influence calculated height and create handle.
+        for (int i = 0; i < 2; i++)
+        {
+            combo.Items.Add($"item{i}");
+        }
+
+        // Ensure handle exists and items are empty.
+        Assert.NotEqual(IntPtr.Zero, combo.Handle);
+        combo.Items.Clear();
+
+        MethodInfo mi = typeof(ComboBox).GetMethod("GetCalculatedDropDownHeight", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(mi);
+
+        int calculated = (int)mi.Invoke(combo, null);
+
+        // Calculated height should not exceed the explicit DropDownHeight when there are no items.
+        Assert.InRange(calculated, 0, combo.DropDownHeight);
+    }
+
     private void InitializeItems(ComboBox comboBox, int numItems)
     {
         for (int i = 0; i < numItems; i++)

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ComboBoxTests.cs
@@ -2742,60 +2742,6 @@ public class ComboBoxTests
         handleCreatedInvoked.Should().Be(2);
     }
 
-    [WinFormsFact]
-    public void ComboBox_GetCalculatedDropDownHeight_Reflects_Items_Clear()
-    {
-        using ComboBox combo = new();
-        combo.DropDownStyle = ComboBoxStyle.DropDown;
-
-        // Add items to influence calculated height and create handle.
-        for (int i = 0; i < 20; i++)
-        {
-            combo.Items.Add($"item{i}");
-        }
-
-        Assert.NotEqual(IntPtr.Zero, combo.Handle);
-
-        MethodInfo mi = typeof(ComboBox).GetMethod("GetCalculatedDropDownHeight", BindingFlags.Instance | BindingFlags.NonPublic);
-        Assert.NotNull(mi);
-
-        int heightWithItems = (int)mi.Invoke(combo, null);
-
-        combo.Items.Clear();
-
-        mi = typeof(ComboBox).GetMethod("GetCalculatedDropDownHeight", BindingFlags.Instance | BindingFlags.NonPublic);
-        Assert.NotNull(mi);
-        int heightAfterClear = (int)mi.Invoke(combo, null);
-
-        // After clearing items the calculated height should change and not remain the previous items height.
-        Assert.NotEqual(heightWithItems, heightAfterClear);
-    }
-
-    [WinFormsFact]
-    public void ComboBox_GetCalculatedDropDownHeight_Uses_DropDownHeight_When_NoItems()
-    {
-        using ComboBox combo = new();
-        combo.DropDownStyle = ComboBoxStyle.DropDown;
-
-        // Add items to influence calculated height and create handle.
-        for (int i = 0; i < 2; i++)
-        {
-            combo.Items.Add($"item{i}");
-        }
-
-        // Ensure handle exists and items are empty.
-        Assert.NotEqual(IntPtr.Zero, combo.Handle);
-        combo.Items.Clear();
-
-        MethodInfo mi = typeof(ComboBox).GetMethod("GetCalculatedDropDownHeight", BindingFlags.Instance | BindingFlags.NonPublic);
-        Assert.NotNull(mi);
-
-        int calculated = (int)mi.Invoke(combo, null);
-
-        // Calculated height should not exceed the explicit DropDownHeight when there are no items.
-        Assert.InRange(calculated, 0, combo.DropDownHeight);
-    }
-
     private void InitializeItems(ComboBox comboBox, int numItems)
     {
         for (int i = 0; i < numItems; i++)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes https://github.com/dotnet/winforms/issues/339


## Proposed changes

- Update `ComboBoxChildNativeWindow` handling for the dropdown list window.
- Intercept `WM_WINDOWPOSCHANGING` for the native dropdown LISTBOX and update `WINDOWPOS.cy` with the managed calculated dropdown height.
- Ensure dropdown height reflects current `Items.Count` / `DropDownHeight` even after `Items.Clear()` or removing the last item.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Fixes incorrect ComboBox dropdown height after items are cleared or removed at runtime.
- Prevents the dropdown from using a stale native cached height when the item count becomes zero.


## Regression? 

- No

## Risk


- Low.
- The change is limited to the ComboBox dropdown LISTBOX window during `WM_WINDOWPOSCHANGING`.
- The fix only updates height when the native window position change includes sizing and does not affect other child window types.
- Existing `IntegralHeight` behavior is preserved while ensuring the final committed dropdown height matches WinForms calculated height.

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
<img width="74" height="73" alt="image" src="https://github.com/user-attachments/assets/683f879e-aa51-4fa7-b26f-d8bcc2dc7f80" />

### After
<img width="225" height="120" alt="image" src="https://github.com/user-attachments/assets/cbac40bf-4d17-4e51-873d-e5b1735c5941" />

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->
- Added/updated unit test coverage to verify `WM_WINDOWPOSCHANGING` updates `WINDOWPOS.cy` to the managed calculated dropdown height.
- Verified the dropdown height is corrected after `Items.Clear()`.
- Verified the fix does not update height when `SWP_NOSIZE` is set.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- No accessibility behavior change expected.
- The change only corrects the native dropdown LISTBOX height calculation.
- No changes were made to accessible names, roles, states, keyboard navigation, or UI Automation patterns.

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


## Test environment(s) <!-- Remove any that don't apply -->
- Windows 11
- .NET SDK: 11.0.100-preview.3.26170.106

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14632)