### PR TITLE
Fix issue 14624: [PropertyGrid] FolderNameEditor does not use the modern FolderBrowserDialog

### DIFF
--- a/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
@@ -1278,7 +1278,7 @@ virtual System.Windows.Forms.Design.DesignerOptions.UseSmartTags.set -> void
 virtual System.Windows.Forms.Design.DesignerOptions.UseSnapLines.get -> bool
 virtual System.Windows.Forms.Design.DesignerOptions.UseSnapLines.set -> void
 virtual System.Windows.Forms.Design.FileNameEditor.InitializeDialog(System.Windows.Forms.OpenFileDialog! openFileDialog) -> void
-virtual System.Windows.Forms.Design.FolderNameEditor.InitializeDialog(System.Windows.Forms.Design.FolderNameEditor.FolderBrowser! folderBrowser) -> void
+virtual System.Windows.Forms.Design.FolderNameEditor.InitializeDialog(System.Windows.Forms.FolderBrowserDialog! folderBrowserDialog) -> void
 virtual System.Windows.Forms.Design.MaskDescriptor.Culture.get -> System.Globalization.CultureInfo!
 virtual System.Windows.Forms.Design.ParentControlDesigner.AllowControlLasso.get -> bool
 virtual System.Windows.Forms.Design.ParentControlDesigner.AllowGenericDragBox.get -> bool

--- a/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
@@ -1278,7 +1278,7 @@ virtual System.Windows.Forms.Design.DesignerOptions.UseSmartTags.set -> void
 virtual System.Windows.Forms.Design.DesignerOptions.UseSnapLines.get -> bool
 virtual System.Windows.Forms.Design.DesignerOptions.UseSnapLines.set -> void
 virtual System.Windows.Forms.Design.FileNameEditor.InitializeDialog(System.Windows.Forms.OpenFileDialog! openFileDialog) -> void
-virtual System.Windows.Forms.Design.FolderNameEditor.InitializeDialog(System.Windows.Forms.FolderBrowserDialog! folderBrowserDialog) -> void
+virtual System.Windows.Forms.Design.FolderNameEditor.InitializeDialog(System.Windows.Forms.Design.FolderNameEditor.FolderBrowser! folderBrowser) -> void
 virtual System.Windows.Forms.Design.MaskDescriptor.Culture.get -> System.Globalization.CultureInfo!
 virtual System.Windows.Forms.Design.ParentControlDesigner.AllowControlLasso.get -> bool
 virtual System.Windows.Forms.Design.ParentControlDesigner.AllowGenericDragBox.get -> bool

--- a/src/System.Windows.Forms.Design/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+virtual System.Windows.Forms.Design.FolderNameEditor.InitializeDialog(System.Windows.Forms.FolderBrowserDialog! folderBrowserDialog) -> void

--- a/src/System.Windows.Forms.Design/src/Resources/SR.resx
+++ b/src/System.Windows.Forms.Design/src/Resources/SR.resx
@@ -1179,6 +1179,12 @@ Press Ctrl+Enter to accept Text.</value>
   <data name="InitialDirectoryEditorLabel" xml:space="preserve">
     <value>Select the directory that will initially be opened in the dialog.</value>
   </data>
+  <data name="InitialDirectoryTitle" xml:space="preserve">
+    <value>Initial Directory</value>
+  </data>
+  <data name="SelectedPathTitle" xml:space="preserve">
+    <value>Selected Path</value>
+  </data>
   <data name="Ax_Control" xml:space="preserve">
     <value>ActiveX Control</value>
   </data>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.cs.xlf
@@ -1380,6 +1380,11 @@
         <target state="translated">Vyberte adresář, který se otevře v dialogu jako první.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitialDirectoryTitle">
+        <source>Initial Directory</source>
+        <target state="new">Initial Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidArgument">
         <source>'{1}' is not a valid value for '{0}'.</source>
         <target state="translated">Hodnota {1} není platnou hodnotou pro argument {0}.</target>
@@ -1715,6 +1720,11 @@ Stisknutím kombinace kláves Ctrl+Enter text přijměte.</target>
       <trans-unit id="SelectedPathEditorLabel">
         <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
         <target state="translated">Vyberte cestu ke složce, která bude standardně vybrána v dialogovém okně FolderBrowserDialog.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectedPathTitle">
+        <source>Selected Path</source>
+        <target state="new">Selected Path</target>
         <note />
       </trans-unit>
       <trans-unit id="SerializationManagerAlreadyInSession">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.de.xlf
@@ -1380,6 +1380,11 @@
         <target state="translated">Wählen Sie das Verzeichnis aus, das anfänglich im Dialogfeld geöffnet wird.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitialDirectoryTitle">
+        <source>Initial Directory</source>
+        <target state="new">Initial Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidArgument">
         <source>'{1}' is not a valid value for '{0}'.</source>
         <target state="translated">{1} ist kein gültiger Wert für {0}.</target>
@@ -1715,6 +1720,11 @@ Drücken Sie STRG+EINGABETASTE, um Text zu übernehmen.</target>
       <trans-unit id="SelectedPathEditorLabel">
         <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
         <target state="translated">Wählen Sie den Pfad für den Ordner, der zu Beginn in FolderBrowserDialog ausgewählt wird.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectedPathTitle">
+        <source>Selected Path</source>
+        <target state="new">Selected Path</target>
         <note />
       </trans-unit>
       <trans-unit id="SerializationManagerAlreadyInSession">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.es.xlf
@@ -1380,6 +1380,11 @@
         <target state="translated">Seleccione el directorio que se abrirá inicialmente en el diálogo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitialDirectoryTitle">
+        <source>Initial Directory</source>
+        <target state="new">Initial Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidArgument">
         <source>'{1}' is not a valid value for '{0}'.</source>
         <target state="translated">'{1}' no es un valor válido para '{0}'.</target>
@@ -1715,6 +1720,11 @@ Presione Ctrl+Entrar para aceptar el texto.</target>
       <trans-unit id="SelectedPathEditorLabel">
         <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
         <target state="translated">Seleccione la ruta de acceso a la carpeta que se seleccionará inicialmente en FolderBrowserDialog.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectedPathTitle">
+        <source>Selected Path</source>
+        <target state="new">Selected Path</target>
         <note />
       </trans-unit>
       <trans-unit id="SerializationManagerAlreadyInSession">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.fr.xlf
@@ -1380,6 +1380,11 @@
         <target state="translated">Sélectionnez le répertoire à ouvrir initialement dans la boîte de dialogue.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitialDirectoryTitle">
+        <source>Initial Directory</source>
+        <target state="new">Initial Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidArgument">
         <source>'{1}' is not a valid value for '{0}'.</source>
         <target state="translated">'{1}' n'est pas une valeur valide pour '{0}'.</target>
@@ -1715,6 +1720,11 @@ Appuyez sur Ctrl+Entrée pour valider le texte.</target>
       <trans-unit id="SelectedPathEditorLabel">
         <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
         <target state="translated">Sélectionnez le chemin du dossier qui sera sélectionné initialement dans FolderBrowserDialog.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectedPathTitle">
+        <source>Selected Path</source>
+        <target state="new">Selected Path</target>
         <note />
       </trans-unit>
       <trans-unit id="SerializationManagerAlreadyInSession">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.it.xlf
@@ -1380,6 +1380,11 @@
         <target state="translated">Consente di selezionare la directory che verrà aperta inizialmente nella finestra di dialogo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitialDirectoryTitle">
+        <source>Initial Directory</source>
+        <target state="new">Initial Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidArgument">
         <source>'{1}' is not a valid value for '{0}'.</source>
         <target state="translated">'{1}' non è un valore valido per '{0}'.</target>
@@ -1715,6 +1720,11 @@ Per accettare testo premere CTRL+INVIO.</target>
       <trans-unit id="SelectedPathEditorLabel">
         <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
         <target state="translated">Selezionare il percorso della cartella che dovrà essere selezionata subito in FolderBrowserDialog.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectedPathTitle">
+        <source>Selected Path</source>
+        <target state="new">Selected Path</target>
         <note />
       </trans-unit>
       <trans-unit id="SerializationManagerAlreadyInSession">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ja.xlf
@@ -1380,6 +1380,11 @@
         <target state="translated">ダイアログで最初に開くディレクトリを選択してください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitialDirectoryTitle">
+        <source>Initial Directory</source>
+        <target state="new">Initial Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidArgument">
         <source>'{1}' is not a valid value for '{0}'.</source>
         <target state="translated">'{1}' は '{0}' に有効な値ではありません。</target>
@@ -1715,6 +1720,11 @@ Press Ctrl+Enter to accept Text.</source>
       <trans-unit id="SelectedPathEditorLabel">
         <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
         <target state="translated">FolderBrowserDialog で最初に選択されるフォルダーへのパスを選択してください。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectedPathTitle">
+        <source>Selected Path</source>
+        <target state="new">Selected Path</target>
         <note />
       </trans-unit>
       <trans-unit id="SerializationManagerAlreadyInSession">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ko.xlf
@@ -1380,6 +1380,11 @@
         <target state="translated">대화 상자에서 처음에 열 디렉터리를 선택합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitialDirectoryTitle">
+        <source>Initial Directory</source>
+        <target state="new">Initial Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidArgument">
         <source>'{1}' is not a valid value for '{0}'.</source>
         <target state="translated">'{1}'은(는) '{0}'에 사용할 수 없는 값입니다.</target>
@@ -1715,6 +1720,11 @@ Press Ctrl+Enter to accept Text.</source>
       <trans-unit id="SelectedPathEditorLabel">
         <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
         <target state="translated">FolderBrowserDialog에서 처음 선택되어 표시될 폴더의 경로를 선택합니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectedPathTitle">
+        <source>Selected Path</source>
+        <target state="new">Selected Path</target>
         <note />
       </trans-unit>
       <trans-unit id="SerializationManagerAlreadyInSession">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pl.xlf
@@ -1380,6 +1380,11 @@
         <target state="translated">Wybierz katalog, który będzie wstępnie otwierany w oknie dialogowym.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitialDirectoryTitle">
+        <source>Initial Directory</source>
+        <target state="new">Initial Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidArgument">
         <source>'{1}' is not a valid value for '{0}'.</source>
         <target state="translated">„{1}” nie jest prawidłową wartością elementu „{0}”.</target>
@@ -1715,6 +1720,11 @@ Naciśnij klawisze Ctrl+Enter, aby zaakceptować tekst.</target>
       <trans-unit id="SelectedPathEditorLabel">
         <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
         <target state="translated">Wybierz ścieżkę do folderu, która będzie początkowo wybrana w oknie dialogowym FolderBrowserDialog.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectedPathTitle">
+        <source>Selected Path</source>
+        <target state="new">Selected Path</target>
         <note />
       </trans-unit>
       <trans-unit id="SerializationManagerAlreadyInSession">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pt-BR.xlf
@@ -1380,6 +1380,11 @@
         <target state="translated">Selecione o diretório que será aberto inicialmente na caixa de diálogo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitialDirectoryTitle">
+        <source>Initial Directory</source>
+        <target state="new">Initial Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidArgument">
         <source>'{1}' is not a valid value for '{0}'.</source>
         <target state="translated">'{1}' não é um valor válido para '{0}'.</target>
@@ -1715,6 +1720,11 @@ Pressione Ctrl+Enter para aceitar Texto.</target>
       <trans-unit id="SelectedPathEditorLabel">
         <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
         <target state="translated">Selecione o caminho para a pasta que será selecionada inicialmente no FolderBrowserDialog.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectedPathTitle">
+        <source>Selected Path</source>
+        <target state="new">Selected Path</target>
         <note />
       </trans-unit>
       <trans-unit id="SerializationManagerAlreadyInSession">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ru.xlf
@@ -1380,6 +1380,11 @@
         <target state="translated">Выберите каталог, который будет изначально открываться в диалоговом окне.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitialDirectoryTitle">
+        <source>Initial Directory</source>
+        <target state="new">Initial Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidArgument">
         <source>'{1}' is not a valid value for '{0}'.</source>
         <target state="translated">'{1}' не является допустимым значением для '{0}'.</target>
@@ -1715,6 +1720,11 @@ Press Ctrl+Enter to accept Text.</source>
       <trans-unit id="SelectedPathEditorLabel">
         <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
         <target state="translated">Выберите путь к папке, которая изначально будет выбираться в FolderBrowserDialog.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectedPathTitle">
+        <source>Selected Path</source>
+        <target state="new">Selected Path</target>
         <note />
       </trans-unit>
       <trans-unit id="SerializationManagerAlreadyInSession">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.tr.xlf
@@ -1380,6 +1380,11 @@
         <target state="translated">Başlangıçta iletişim kutusunda açılacak olan dizini seçin.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitialDirectoryTitle">
+        <source>Initial Directory</source>
+        <target state="new">Initial Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidArgument">
         <source>'{1}' is not a valid value for '{0}'.</source>
         <target state="translated">'{1}' değeri '{0}' öğesi için geçerli değil.</target>
@@ -1715,6 +1720,11 @@ Metni kabul etmek için Ctrl+Enter tuşlarına basın.</target>
       <trans-unit id="SelectedPathEditorLabel">
         <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
         <target state="translated">FolderBrowserDialog iletişim kutusunda başlangıçta seçili olacak klasörün yolunu seçin.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectedPathTitle">
+        <source>Selected Path</source>
+        <target state="new">Selected Path</target>
         <note />
       </trans-unit>
       <trans-unit id="SerializationManagerAlreadyInSession">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hans.xlf
@@ -1380,6 +1380,11 @@
         <target state="translated">选择要最先将在对话框中打开的目录。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitialDirectoryTitle">
+        <source>Initial Directory</source>
+        <target state="new">Initial Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidArgument">
         <source>'{1}' is not a valid value for '{0}'.</source>
         <target state="translated">“{1}”不是“{0}”的有效值。</target>
@@ -1715,6 +1720,11 @@ Press Ctrl+Enter to accept Text.</source>
       <trans-unit id="SelectedPathEditorLabel">
         <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
         <target state="translated">选择最初会在 FolderBrowserDialog 中被选中的文件夹的路径。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectedPathTitle">
+        <source>Selected Path</source>
+        <target state="new">Selected Path</target>
         <note />
       </trans-unit>
       <trans-unit id="SerializationManagerAlreadyInSession">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hant.xlf
@@ -1380,6 +1380,11 @@
         <target state="translated">選取一開始要在對話方塊中開啟的目錄。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InitialDirectoryTitle">
+        <source>Initial Directory</source>
+        <target state="new">Initial Directory</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidArgument">
         <source>'{1}' is not a valid value for '{0}'.</source>
         <target state="translated">'{1}' 不是 '{0}' 的有效值。</target>
@@ -1715,6 +1720,11 @@ Press Ctrl+Enter to accept Text.</source>
       <trans-unit id="SelectedPathEditorLabel">
         <source>Select the path to the folder that will initially be selected in the FolderBrowserDialog.</source>
         <target state="translated">請選取在 FolderBrowserDialog 中一開始就被選取的資料夾的路徑。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SelectedPathTitle">
+        <source>Selected Path</source>
+        <target state="new">Selected Path</target>
         <note />
       </trans-unit>
       <trans-unit id="SerializationManagerAlreadyInSession">

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FolderNameEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FolderNameEditor.cs
@@ -12,21 +12,19 @@ namespace System.Windows.Forms.Design;
 [CLSCompliant(false)]
 public partial class FolderNameEditor : UITypeEditor
 {
-    private FolderBrowserDialog? _folderBrowserDialog;
-
     public override object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
     {
-        if (_folderBrowserDialog is null)
-        {
-            _folderBrowserDialog = new FolderBrowserDialog();
-            InitializeDialog(_folderBrowserDialog);
-        }
+        // The dialog is created locally and disposed at the end of the call so its
+        // native resources (Component/CommonDialog state) are released, and no stale
+        // configuration leaks between successive invocations of EditValue.
+        using FolderBrowserDialog folderBrowserDialog = new();
+        InitializeDialog(folderBrowserDialog);
 
-        _folderBrowserDialog.SelectedPath = value as string ?? string.Empty;
+        folderBrowserDialog.SelectedPath = value as string ?? string.Empty;
 
-        if (_folderBrowserDialog.ShowDialog() == DialogResult.OK)
+        if (folderBrowserDialog.ShowDialog() == DialogResult.OK)
         {
-            return _folderBrowserDialog.SelectedPath;
+            return folderBrowserDialog.SelectedPath;
         }
 
         return value;
@@ -34,6 +32,16 @@ public partial class FolderNameEditor : UITypeEditor
 
     /// <inheritdoc />
     public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext? context) => UITypeEditorEditStyle.Modal;
+
+    /// <summary>
+    ///  Initializes the folder browser dialog when it is created. This gives you an opportunity
+    ///  to configure the dialog as you please. The default implementation provides a generic folder browser.
+    /// </summary>
+    [Obsolete]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    protected virtual void InitializeDialog(FolderBrowser folderBrowser)
+    {
+    }
 
     /// <summary>
     ///  Initializes the folder browser dialog when it is created. This gives you an opportunity

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FolderNameEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FolderNameEditor.cs
@@ -12,19 +12,21 @@ namespace System.Windows.Forms.Design;
 [CLSCompliant(false)]
 public partial class FolderNameEditor : UITypeEditor
 {
-    private FolderBrowser? _folderBrowser;
+    private FolderBrowserDialog? _folderBrowserDialog;
 
     public override object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
     {
-        if (_folderBrowser is null)
+        if (_folderBrowserDialog is null)
         {
-            _folderBrowser = new FolderBrowser();
-            InitializeDialog(_folderBrowser);
+            _folderBrowserDialog = new FolderBrowserDialog();
+            InitializeDialog(_folderBrowserDialog);
         }
 
-        if (_folderBrowser.ShowDialog() == DialogResult.OK)
+        _folderBrowserDialog.SelectedPath = value as string ?? string.Empty;
+
+        if (_folderBrowserDialog.ShowDialog() == DialogResult.OK)
         {
-            return _folderBrowser.DirectoryPath;
+            return _folderBrowserDialog.SelectedPath;
         }
 
         return value;
@@ -37,7 +39,7 @@ public partial class FolderNameEditor : UITypeEditor
     ///  Initializes the folder browser dialog when it is created. This gives you an opportunity
     ///  to configure the dialog as you please. The default implementation provides a generic folder browser.
     /// </summary>
-    protected virtual void InitializeDialog(FolderBrowser folderBrowser)
+    protected virtual void InitializeDialog(FolderBrowserDialog folderBrowserDialog)
     {
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/InitialDirectoryEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/InitialDirectoryEditor.cs
@@ -8,8 +8,8 @@ namespace System.Windows.Forms.Design;
 /// </summary>
 internal class InitialDirectoryEditor : FolderNameEditor
 {
-    protected override void InitializeDialog(FolderBrowser folderBrowser)
+    protected override void InitializeDialog(FolderBrowserDialog folderBrowserDialog)
     {
-        folderBrowser.Description = SR.InitialDirectoryEditorLabel;
+        folderBrowserDialog.Description = SR.InitialDirectoryEditorLabel;
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/InitialDirectoryEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/InitialDirectoryEditor.cs
@@ -10,6 +10,7 @@ internal class InitialDirectoryEditor : FolderNameEditor
 {
     protected override void InitializeDialog(FolderBrowserDialog folderBrowserDialog)
     {
-        folderBrowserDialog.Description = SR.InitialDirectoryEditorLabel;
+        folderBrowserDialog.UseDescriptionForTitle = true;
+        folderBrowserDialog.Description = SR.InitialDirectoryTitle;
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectedPathEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectedPathEditor.cs
@@ -8,8 +8,8 @@ namespace System.Windows.Forms.Design;
 /// </summary>
 internal class SelectedPathEditor : FolderNameEditor
 {
-    protected override void InitializeDialog(FolderBrowser folderBrowser)
+    protected override void InitializeDialog(FolderBrowserDialog folderBrowserDialog)
     {
-        folderBrowser.Description = SR.SelectedPathEditorLabel;
+        folderBrowserDialog.Description = SR.SelectedPathEditorLabel;
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectedPathEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectedPathEditor.cs
@@ -10,6 +10,7 @@ internal class SelectedPathEditor : FolderNameEditor
 {
     protected override void InitializeDialog(FolderBrowserDialog folderBrowserDialog)
     {
-        folderBrowserDialog.Description = SR.SelectedPathEditorLabel;
+        folderBrowserDialog.UseDescriptionForTitle = true;
+        folderBrowserDialog.Description = SR.SelectedPathTitle;
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/FolderNameEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/FolderNameEditorTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -38,71 +38,24 @@ public class FolderNameEditorTests
     public void FolderNameEditor_InitializeDialog_Invoke_Nop()
     {
         SubFolderNameEditor editor = new();
-        editor.InitializeDialog();
-    }
+        using FolderBrowserDialog dialog = new();
 
-    public class FolderBrowserTests : FolderNameEditor
-    {
-        [Fact]
-        public void FolderBrowser_Ctor_Default()
-        {
-            FolderBrowser browser = new();
-            Assert.Empty(browser.DirectoryPath);
-            Assert.Empty(browser.Description);
-            Assert.Equal(FolderBrowserStyles.RestrictToFilesystem, browser.Style);
-            Assert.Equal(FolderBrowserFolder.Desktop, browser.StartLocation);
-        }
+        // The base implementation is intentionally a no-op; invoking it should not
+        // throw and should leave the dialog's defaults untouched.
+        string originalSelectedPath = dialog.SelectedPath;
+        string originalDescription = dialog.Description;
+        Environment.SpecialFolder originalRootFolder = dialog.RootFolder;
 
-        [Theory]
-        [NormalizedStringData]
-        public void FolderBrowser_Description_Set_GetReturnsExpected(string value, string expected)
-        {
-            FolderBrowser browser = new()
-            {
-                Description = value
-            };
-            Assert.Equal(expected, browser.Description);
+        editor.InitializeDialog(dialog);
 
-            // Set same.
-            browser.Description = value;
-            Assert.Equal(expected, browser.Description);
-        }
-
-        [Theory]
-        [EnumData<FolderBrowserFolder>]
-        [InvalidEnumData<FolderBrowserFolder>]
-        protected void FolderBrowser_StartLocation_Set_GetReturnsExpected(FolderBrowserFolder value)
-        {
-            FolderBrowser browser = new()
-            {
-                StartLocation = value
-            };
-            Assert.Equal(value, browser.StartLocation);
-
-            // Set same.
-            browser.StartLocation = value;
-            Assert.Equal(value, browser.StartLocation);
-        }
-
-        [Theory]
-        [EnumData<FolderBrowserStyles>]
-        [InvalidEnumData<FolderBrowserStyles>]
-        protected void FolderBrowser_Style_Set_GetReturnsExpected(FolderBrowserStyles value)
-        {
-            FolderBrowser browser = new()
-            {
-                Style = value
-            };
-            Assert.Equal(value, browser.Style);
-
-            // Set same.
-            browser.Style = value;
-            Assert.Equal(value, browser.Style);
-        }
+        Assert.Equal(originalSelectedPath, dialog.SelectedPath);
+        Assert.Equal(originalDescription, dialog.Description);
+        Assert.Equal(originalRootFolder, dialog.RootFolder);
     }
 
     private class SubFolderNameEditor : FolderNameEditor
     {
-        public void InitializeDialog() => base.InitializeDialog(null);
+        public new void InitializeDialog(FolderBrowserDialog folderBrowserDialog) =>
+            base.InitializeDialog(folderBrowserDialog);
     }
 }

--- a/src/test/integration/UIIntegrationTests/FolderNameEditorTests.cs
+++ b/src/test/integration/UIIntegrationTests/FolderNameEditorTests.cs
@@ -30,21 +30,21 @@ public class FolderNameEditorTests : ControlTestBase
 
     private class TestFolderNameEditor : FolderNameEditor
     {
-        private FolderBrowserDialog? _folderBrowser;
+        private FolderBrowserDialog? _folderBrowserDialog;
 
         public override object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
         {
             using DialogHostForm dialogOwnerForm = new();
 
-            if (_folderBrowser is null)
+            if (_folderBrowserDialog is null)
             {
-                _folderBrowser = new FolderBrowserDialog();
-                InitializeDialog(_folderBrowser);
+                _folderBrowserDialog = new FolderBrowserDialog();
+                InitializeDialog(_folderBrowserDialog);
             }
 
-            if (_folderBrowser.ShowDialog(dialogOwnerForm) == DialogResult.OK)
+            if (_folderBrowserDialog.ShowDialog(dialogOwnerForm) == DialogResult.OK)
             {
-                return _folderBrowser.SelectedPath;
+                return _folderBrowserDialog.SelectedPath = value as string ?? string.Empty;
             }
 
             return value;

--- a/src/test/integration/UIIntegrationTests/FolderNameEditorTests.cs
+++ b/src/test/integration/UIIntegrationTests/FolderNameEditorTests.cs
@@ -30,7 +30,7 @@ public class FolderNameEditorTests : ControlTestBase
 
     private class TestFolderNameEditor : FolderNameEditor
     {
-        private FolderBrowser? _folderBrowser;
+        private FolderBrowserDialog? _folderBrowser;
 
         public override object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
         {
@@ -38,13 +38,13 @@ public class FolderNameEditorTests : ControlTestBase
 
             if (_folderBrowser is null)
             {
-                _folderBrowser = new FolderBrowser();
+                _folderBrowser = new FolderBrowserDialog();
                 InitializeDialog(_folderBrowser);
             }
 
             if (_folderBrowser.ShowDialog(dialogOwnerForm) == DialogResult.OK)
             {
-                return _folderBrowser.DirectoryPath;
+                return _folderBrowser.SelectedPath;
             }
 
             return value;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14624 


## Proposed changes

- Before the FolderNameEditor used for folder paths in a PropertyGrid is the old folder browser, which is a system component control and called by [FolderBrowserHelper](https://github.com/dotnet/winforms/blob/cd04c1d2c3be624bf2c779cd202a80c390012226/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Shell/FolderBrowserHelper.cs#L16)
- Now use the modern [FolderBrowserDialog](https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms/System/Windows/Forms/Dialogs/CommonDialogs/FolderBrowserDialog.cs) to instead the old one, which is also a system component control and called by  [PInvokeCore.CoCreateInstance](https://github.com/dotnet/winforms/blob/cd04c1d2c3be624bf2c779cd202a80c390012226/src/System.Windows.Forms/System/Windows/Forms/Dialogs/CommonDialogs/FolderBrowserDialog.cs#L290);
- Refactoring Unit Tests - FolderNameEditorTests.cs

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

-  [PropertyGrid] FolderNameEditor use the modern FolderBrowserDialog

## Regression? 

-  No

## Risk

- Mini

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

https://github.com/user-attachments/assets/781ec382-3c97-4e8b-a309-33d2412b9885

### After

https://github.com/user-attachments/assets/64cf51d3-e9f4-4f0f-a842-7f4ee3c33e9c




## Test methodology <!-- How did you ensure quality? -->

- Manual testing
 

## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.100-preview.5.26227.104


<!-- Mention language, UI scaling, or anything else that might be relevant -->
