### PR TITLE
Fix GroupBox doesn't apply ForeColor in ambient condition

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/GroupBox/GroupBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/GroupBox/GroupBox.cs
@@ -421,9 +421,6 @@ public partial class GroupBox : Control
                 textFlags |= (TextFormatFlags.Right | TextFormatFlags.RightToLeft);
             }
 
-            var form = FindForm();
-            Color foreColor = form is not null ? form.ForeColor : SystemColors.ControlText;
-
             // We only pass in the text color if it is explicitly set, else we let the renderer use the color
             // specified by the theme. This is a temporary workaround till we find a good solution for the
             // "default theme color" issue.
@@ -441,26 +438,29 @@ public partial class GroupBox : Control
                     textFlags,
                     gbState);
             }
-            else if (!ShouldSerializeForeColor() && foreColor != SystemColors.ControlText)
-            {
-                GroupBoxRenderer.DrawGroupBox(
-                    e,
-                    new Rectangle(0, 0, Width, Height),
-                    Text,
-                    Font,
-                    foreColor,
-                    textFlags,
-                    gbState);
-            }
             else
             {
-                GroupBoxRenderer.DrawGroupBox(
+                if (FindForm() is Form form && form.ForeColor != SystemColors.ControlText)
+                {
+                    GroupBoxRenderer.DrawGroupBox(
+                        e,
+                        new Rectangle(0, 0, Width, Height),
+                        Text,
+                        Font,
+                        form.ForeColor,
+                        textFlags,
+                        gbState);
+                }
+                else
+                {
+                    GroupBoxRenderer.DrawGroupBox(
                     e,
                     new Rectangle(0, 0, Width, Height),
                     Text,
                     Font,
                     textFlags,
                     gbState);
+                }
             }
         }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/GroupBox/GroupBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/GroupBox/GroupBox.cs
@@ -425,7 +425,7 @@ public partial class GroupBox : Control
             // specified by the theme. This is a temporary workaround till we find a good solution for the
             // "default theme color" issue.
 
-            if (ShouldSerializeForeColor() || Application.IsDarkModeEnabled || !Enabled)
+            if (ShouldSerializeForeColor() || Application.IsDarkModeEnabled || !Enabled || ForeColor != DefaultForeColor)
             {
                 Color textColor = Enabled ? ForeColor : TextRenderer.DisabledTextColor(BackColor);
 
@@ -440,27 +440,13 @@ public partial class GroupBox : Control
             }
             else
             {
-                if (FindForm() is Form form && form.ForeColor != SystemColors.ControlText)
-                {
-                    GroupBoxRenderer.DrawGroupBox(
-                        e,
-                        new Rectangle(0, 0, Width, Height),
-                        Text,
-                        Font,
-                        form.ForeColor,
-                        textFlags,
-                        gbState);
-                }
-                else
-                {
-                    GroupBoxRenderer.DrawGroupBox(
+                GroupBoxRenderer.DrawGroupBox(
                     e,
                     new Rectangle(0, 0, Width, Height),
                     Text,
                     Font,
                     textFlags,
                     gbState);
-                }
             }
         }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/GroupBox/GroupBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/GroupBox/GroupBox.cs
@@ -421,6 +421,9 @@ public partial class GroupBox : Control
                 textFlags |= (TextFormatFlags.Right | TextFormatFlags.RightToLeft);
             }
 
+            var form = FindForm();
+            Color foreColor = form is not null ? form.ForeColor : SystemColors.ControlText;
+
             // We only pass in the text color if it is explicitly set, else we let the renderer use the color
             // specified by the theme. This is a temporary workaround till we find a good solution for the
             // "default theme color" issue.
@@ -435,6 +438,17 @@ public partial class GroupBox : Control
                     Text,
                     Font,
                     textColor,
+                    textFlags,
+                    gbState);
+            }
+            else if (!ShouldSerializeForeColor() && foreColor != SystemColors.ControlText)
+            {
+                GroupBoxRenderer.DrawGroupBox(
+                    e,
+                    new Rectangle(0, 0, Width, Height),
+                    Text,
+                    Font,
+                    foreColor,
                     textFlags,
                     gbState);
             }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/GroupBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/GroupBoxTests.cs
@@ -1958,6 +1958,97 @@ public class GroupBoxTests
         Assert.Throws<NullReferenceException>(() => control.OnPaint(null));
     }
 
+    [WinFormsFact]
+    public void GroupBox_OnPaint_VisualStyles_on_AmbientForeColor_FromForm_UsedWhenNotExplicitlySet()
+    {
+        if (!Application.RenderWithVisualStyles)
+        {
+            return;
+        }
+
+        using Bitmap image = new(100, 100);
+        using Graphics graphics = Graphics.FromImage(image);
+        using PaintEventArgs eventArgs = new(graphics, Rectangle.Empty);
+
+        using Form form = new()
+        {
+            ForeColor = Color.Red
+        };
+        using SubGroupBox control = new()
+        {
+            Size = new Size(100, 100),
+            Text = "Test",
+            Parent = form
+        };
+
+        control.OnPaint(eventArgs);
+
+        Assert.False(control.ShouldSerializeForeColor());
+        Assert.Equal(Color.Red, control.ForeColor);
+    }
+
+    [WinFormsFact]
+    public void GroupBox_OnPaint_VisualStyles_on_AmbientForeColor_FromIntermediatePanel_UsedWhenNotExplicitlySet()
+    {
+        if (!Application.RenderWithVisualStyles)
+        {
+            return;
+        }
+
+        using Bitmap image = new(100, 100);
+        using Graphics graphics = Graphics.FromImage(image);
+        using PaintEventArgs eventArgs = new(graphics, Rectangle.Empty);
+
+        using Form form = new()
+        {
+            ForeColor = SystemColors.ControlText
+        };
+        using Panel panel = new()
+        {
+            ForeColor = Color.Lime,
+            Parent = form
+        };
+        using SubGroupBox control = new()
+        {
+            Size = new Size(100, 100),
+            Text = "Test",
+            Parent = panel
+        };
+
+        control.OnPaint(eventArgs);
+        Assert.False(control.ShouldSerializeForeColor());
+        Assert.Equal(Color.Lime, control.ForeColor);
+    }
+
+    [WinFormsFact]
+    public void GroupBox_OnPaint_VisualStyles_on_ExplicitForeColor_TakesPrecedenceOverAmbient()
+    {
+        if (!Application.RenderWithVisualStyles)
+        {
+            return;
+        }
+
+        using Bitmap image = new(100, 100);
+        using Graphics graphics = Graphics.FromImage(image);
+        using PaintEventArgs eventArgs = new(graphics, Rectangle.Empty);
+
+        using Form form = new()
+        {
+            ForeColor = Color.Red
+        };
+        using SubGroupBox control = new()
+        {
+            Size = new Size(100, 100),
+            Text = "Test",
+            ForeColor = Color.Blue,
+            Parent = form
+        };
+
+        control.OnPaint(eventArgs);
+        Assert.True(control.ShouldSerializeForeColor());
+        Assert.Equal(Color.Blue, control.ForeColor);
+    }
+
     public static IEnumerable<object[]> ProcessMnemonic_TestData()
     {
         yield return new object[] { null, 'a', false };


### PR DESCRIPTION
Fixes [#9958](https://github.com/dotnet/winforms/issues/9958)

## Proposed changes
 - Fixed GroupBox not respecting ambient ForeColor when its own ForeColor is not explicitly set.
 - Updated rendering logic to fall back to the parent Form.ForeColor instead of defaulting to Visual Styles text color.
 - Ensured consistency with other controls like Button and Label, which already respect ambient ForeColor.

## Customer Impact
 - Applications that rely on setting ForeColor at the Form level will now see consistent text color in GroupBox.
 - Improves UI consistency and expected behavior across controls without requiring additional manual overrides.

## Regression? 
- No

## Risk

- Low 
  - Change is limited to GroupBox rendering logic.
  - Only affects scenarios where ForeColor is not explicitly set on GroupBox.
  - Explicit ForeColor settings on GroupBox continue to take precedence.

## Screenshots

### Before

<img width="872" height="421" alt="image" src="https://github.com/user-attachments/assets/01f7d5af-c75f-4a58-9f31-05d0068fa2c5" />

### After

<img width="871" height="421" alt="image" src="https://github.com/user-attachments/assets/878ca884-2f28-4ed7-a0fa-a7bf592a1769" />

## Test methodology
 - Verified behavior with default GroupBox.ForeColor and custom Form.ForeColor.
 - Tested explicit override: 
   - When GroupBox.ForeColor is set, it takes precedence.
 - Dynamically changed GroupBox.ForeColor at runtime and verified correct updates.
 - Compared behavior with Button and Label to ensure consistency.
 - Manually validated rendering with Visual Styles enabled.

## Accessibility testing

NA

## Test environment(s)
 - OS: Windows
 - SDK: 11.0.100-preview.3.26170.106
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14638)