### PR TITLE
Fix NumericUpDown button rendering regression when visual styles are disabled

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.UpDownButtons.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.UpDownButtons.cs
@@ -270,7 +270,7 @@ public abstract partial class UpDownBase
             int half_height = ClientSize.Height / 2;
 
             // Draw the up and down buttons
-            if (Application.IsDarkModeEnabled || !Application.RenderWithVisualStyles)
+            if (Application.IsDarkModeEnabled)
             {
                 Graphics cachedGraphics = EnsureCachedBitmap(
                     _parent._defaultButtonsWidth,
@@ -300,7 +300,7 @@ public abstract partial class UpDownBase
                     _cachedBitmap,
                     new Point(0, 0));
             }
-            else
+            else if (Application.RenderWithVisualStyles)
             {
                 VisualStyleRenderer vsr = new(_mouseOver == ButtonID.Up
                     ? VisualStyleElement.Spin.Up.Hot
@@ -340,6 +340,20 @@ public abstract partial class UpDownBase
                     hdc,
                     new Rectangle(0, half_height, _parent._defaultButtonsWidth, half_height),
                     HWNDInternal);
+            }
+            else
+            {
+                DrawScrollButton(
+                    e.GraphicsInternal,
+                    new Rectangle(0, 0, _parent._defaultButtonsWidth, half_height),
+                    ScrollButton.Up,
+                    _pushed == ButtonID.Up ? ButtonState.Pushed : (Enabled ? ButtonState.Normal : ButtonState.Inactive));
+
+                DrawScrollButton(
+                    e.GraphicsInternal,
+                    new Rectangle(0, half_height, _parent._defaultButtonsWidth, half_height),
+                    ScrollButton.Down,
+                    _pushed == ButtonID.Down ? ButtonState.Pushed : (Enabled ? ButtonState.Normal : ButtonState.Inactive));
             }
 
             if (half_height != (ClientSize.Height + 1) / 2)


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14641

## Root Cause
The non-visual-style path was unintentionally routed to the modern button renderer by this condition:
`Application.IsDarkModeEnabled || !Application.RenderWithVisualStyles`

That behavior came from PR #13747.

## Proposed changes

In `UpDownBase.UpDownButtons.cs`:
- Use modern renderer only when dark mode is enabled.
- Keep themed renderer path when visual styles are enabled.
- Restore classic `DrawScrollButton` fallback when visual styles are disabled.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

-  After fix, the up/down buttons of the NumericUpDown control are normal gray color.

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
The up/down buttons of the NumericUpDown control are black.
<img width="197" height="99" alt="image" src="https://github.com/user-attachments/assets/0882c401-c34d-47f2-ac84-0dacdae255bb" />


### After
 The up/down buttons of the NumericUpDown control are gray color.
<img width="295" height="129" alt="image" src="https://github.com/user-attachments/assets/fdb0b3ac-d76f-426a-b96e-96f4891d31bc" />



## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-preview.6.26311.113


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14643)