### PR TITLE
Fix ListView destroying StateImageList when toggling CheckBoxes

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
@@ -514,7 +514,7 @@ public partial class ListView : Control
 
                     _listViewState[LISTVIEWSTATE_checkBoxes] = value;
 
-                    if ((!value && StateImageList is not null && IsHandleCreated) ||
+                    if ((StateImageList is not null && IsHandleCreated) ||
                         (!value && Alignment == ListViewAlignment.Left && IsHandleCreated) ||
                         (value && View == View.List && IsHandleCreated) ||
                         (value && (View == View.SmallIcon || View == View.LargeIcon) && IsHandleCreated))

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ListViewTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ListViewTests.cs
@@ -927,28 +927,36 @@ public class ListViewTests
                 yield return new object[] { false, View.List, alignment, null, false, 0, 0, 1, 1 };
                 yield return new object[] { false, View.SmallIcon, alignment, null, false, 0, 0, 2, 1 };
 
-                yield return new object[] { false, View.Details, alignment, new ImageList(), true, 1, 0, 2, 1 };
+                yield return new object[] { false, View.Details, alignment, new ImageList(), true, 1, 1, 2, 2 };
                 yield return new object[] { false, View.LargeIcon, alignment, new ImageList(), true, 2, 1, 4, 2 };
                 yield return new object[] { false, View.List, alignment, new ImageList(), true, 1, 1, 2, 2 };
                 yield return new object[] { false, View.SmallIcon, alignment, new ImageList(), true, 2, 1, 4, 2 };
-                yield return new object[] { false, View.Details, alignment, new ImageList(), false, 0, 0, 1, 0 };
+                yield return new object[] { false, View.Details, alignment, new ImageList(), false, 0, 0, 1, 1 };
                 yield return new object[] { false, View.LargeIcon, alignment, new ImageList(), false, 0, 0, 2, 1 };
                 yield return new object[] { false, View.List, alignment, new ImageList(), false, 0, 0, 1, 1 };
                 yield return new object[] { false, View.SmallIcon, alignment, new ImageList(), false, 0, 0, 2, 1 };
             }
         }
 
-        foreach (Func<ImageList> imageListFactory in new Func<ImageList>[] { () => new ImageList(), () => null })
-        {
-            yield return new object[] { false, View.Details, ListViewAlignment.Left, imageListFactory(), true, 1, 0, 2, 1 };
-            yield return new object[] { false, View.LargeIcon, ListViewAlignment.Left, imageListFactory(), true, 2, 1, 4, 2 };
-            yield return new object[] { false, View.List, ListViewAlignment.Left, imageListFactory(), true, 1, 1, 2, 2 };
-            yield return new object[] { false, View.SmallIcon, ListViewAlignment.Left, imageListFactory(), true, 2, 1, 4, 2 };
-            yield return new object[] { false, View.Details, ListViewAlignment.Left, imageListFactory(), false, 0, 0, 1, 0 };
-            yield return new object[] { false, View.LargeIcon, ListViewAlignment.Left, imageListFactory(), false, 0, 0, 2, 1 };
-            yield return new object[] { false, View.List, ListViewAlignment.Left, imageListFactory(), false, 0, 0, 1, 1 };
-            yield return new object[] { false, View.SmallIcon, ListViewAlignment.Left, imageListFactory(), false, 0, 0, 2, 1 };
-        }
+        // With StateImageList: handle recreation occurs both when enabling and disabling CheckBoxes
+        yield return new object[] { false, View.Details, ListViewAlignment.Left, new ImageList(), true, 1, 1, 2, 2 };
+        yield return new object[] { false, View.LargeIcon, ListViewAlignment.Left, new ImageList(), true, 2, 1, 4, 2 };
+        yield return new object[] { false, View.List, ListViewAlignment.Left, new ImageList(), true, 1, 1, 2, 2 };
+        yield return new object[] { false, View.SmallIcon, ListViewAlignment.Left, new ImageList(), true, 2, 1, 4, 2 };
+        yield return new object[] { false, View.Details, ListViewAlignment.Left, new ImageList(), false, 0, 0, 1, 1 };
+        yield return new object[] { false, View.LargeIcon, ListViewAlignment.Left, new ImageList(), false, 0, 0, 2, 1 };
+        yield return new object[] { false, View.List, ListViewAlignment.Left, new ImageList(), false, 0, 0, 1, 1 };
+        yield return new object[] { false, View.SmallIcon, ListViewAlignment.Left, new ImageList(), false, 0, 0, 2, 1 };
+
+        // Without a StateImageList, only the alignment/view-specific conditions drive handle recreation.
+        yield return new object[] { false, View.Details, ListViewAlignment.Left, null, true, 1, 0, 2, 1 };
+        yield return new object[] { false, View.LargeIcon, ListViewAlignment.Left, null, true, 2, 1, 4, 2 };
+        yield return new object[] { false, View.List, ListViewAlignment.Left, null, true, 1, 1, 2, 2 };
+        yield return new object[] { false, View.SmallIcon, ListViewAlignment.Left, null, true, 2, 1, 4, 2 };
+        yield return new object[] { false, View.Details, ListViewAlignment.Left, null, false, 0, 0, 1, 0 };
+        yield return new object[] { false, View.LargeIcon, ListViewAlignment.Left, null, false, 0, 0, 2, 1 };
+        yield return new object[] { false, View.List, ListViewAlignment.Left, null, false, 0, 0, 1, 1 };
+        yield return new object[] { false, View.SmallIcon, ListViewAlignment.Left, null, false, 0, 0, 2, 1 };
     }
 
     [WinFormsTheory]


### PR DESCRIPTION

Fixes [#3531](https://github.com/dotnet/winforms/issues/3531)


## Proposed changes

- Update ListView.CheckBoxes setter to call RecreateHandleInternal() when toggling from true → false as well as false → true.
 
- Ensure LVM_SETIMAGELIST is resent after handle recreation so the user‑supplied StateImageList is preserved.
 
- Prevent native ListView from discarding or corrupting the StateImageList when checkboxes are toggled.

## Customer Impact

- Fixes scenarios where toggling CheckBoxes caused custom state images to disappear or the ImageList to be disposed.
 
- Ensures developers can reliably use StateImageList with checkboxes without losing images.
 
- Improves stability in apps that dynamically toggle CheckBoxes at runtime.

## Regression? 

- No

## Risk

- Low. The change is isolated to the CheckBoxes setter and handle recreation path.


## Screenshots 

### Before


https://github.com/user-attachments/assets/4a32b1a2-8198-452e-8ec7-45cf67cdc08b


https://github.com/user-attachments/assets/3b484817-f97b-4efe-8383-9ce9d767340c



### After


https://github.com/user-attachments/assets/e80d6ab5-03bd-4c25-96df-76d96efa3ca6


https://github.com/user-attachments/assets/3308fe57-3254-41dd-837d-e992f877fe20



## Test methodology 

- Manually toggled CheckBoxes across multiple views (List, SmallIcon, LargeIcon) with custom state images.
 
- Verified items with StateImageIndex retained correct images after toggling.

- Validated under high DPI scaling to confirm images remained intact.

- Repeated toggle operations to confirm stability across multiple transitions.

## Test environment(s) 

- 11.0.100-preview.3.26170.106

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14652)