### PR TITLE
Fix FailFast crash in LabelEditNativeWindow due to garbage collected WinEvent hook delegate

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Accessibility/LabelEditNativeWindow.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Accessibility/LabelEditNativeWindow.cs
@@ -15,6 +15,7 @@ internal class LabelEditNativeWindow : NativeWindow
     private HWINEVENTHOOK _valueChangeHook;
     private HWINEVENTHOOK _textSelectionChangedHook;
     private bool _winEventHooksInstalled;
+    private bool _isReleasing;
 
     private delegate void WINEVENTPROC(
         HWINEVENTHOOK hWinEventHook,
@@ -74,8 +75,24 @@ internal class LabelEditNativeWindow : NativeWindow
     {
         base.OnHandleChange();
 
+        // Prevent reentrant hook installation during ReleaseHandle.
+        // Without this guard, UnhookWinEvent can trigger OnHandleChange (via NativeWindow.Callback),
+        // causing hooks to be reinstalled on a window that is being destroyed.
+        if (_isReleasing)
+        {
+            return;
+        }
+
         if (!IsHandleCreated)
         {
+            // The native window handle was destroyed (e.g., Windows sent WM_NCDESTROY and NativeWindow
+            // cleared the handle without going through our ReleaseHandle override). Unhook the WinEvent
+            // hooks immediately so the WINEVENT_INCONTEXT hook cannot fire after _winEventProcCallback is
+            // garbage collected. Without this, the LabelEditNativeWindow is removed from the NativeWindow
+            // handle table and becomes eligible for GC while the hooks remain registered. The next
+            // CallWindowProc on any window on this thread (e.g. GridViewTextBox.DefWndProc) would then
+            // invoke the GC'd delegate and trigger a FailFast.
+            UnhookWinEventHooks();
             return;
         }
 
@@ -92,31 +109,52 @@ internal class LabelEditNativeWindow : NativeWindow
 
     public override unsafe void ReleaseHandle()
     {
+        _isReleasing = true;
+        try
+        {
+            UnhookWinEventHooks();
+
+            if (IsHandleCreated)
+            {
+                // When a window that previously returned providers has been destroyed,
+                // you should notify UI Automation by calling the UiaReturnRawElementProvider
+                // as follows: UiaReturnRawElementProvider(hwnd, 0, 0, NULL). This call tells
+                // UI Automation that it can safely remove all map entries that refer to the specified window.
+                PInvoke.UiaReturnRawElementProvider(HWND, wParam: 0, lParam: 0, (IRawElementProviderSimple*)null);
+            }
+
+            PInvoke.UiaDisconnectProvider(AccessibilityObject);
+            AccessibilityObject = null;
+            base.ReleaseHandle();
+        }
+        finally
+        {
+            _isReleasing = false;
+        }
+    }
+
+    private void UnhookWinEventHooks()
+    {
         if (_winEventHooksInstalled)
         {
             PInvoke.UnhookWinEvent(_valueChangeHook);
             PInvoke.UnhookWinEvent(_textSelectionChangedHook);
-
             _winEventHooksInstalled = false;
+
+            // Allow the delegate to be garbage collected now that no hook holds a reference
+            // to its underlying unmanaged function pointer.
+            _winEventProcCallback = null;
         }
-
-        if (IsHandleCreated)
-        {
-            // When a window that previously returned providers has been destroyed,
-            // you should notify UI Automation by calling the UiaReturnRawElementProvider
-            // as follows: UiaReturnRawElementProvider(hwnd, 0, 0, NULL). This call tells
-            // UI Automation that it can safely remove all map entries that refer to the specified window.
-            PInvoke.UiaReturnRawElementProvider(HWND, wParam: 0, lParam: 0, (IRawElementProviderSimple*)null);
-        }
-
-        PInvoke.UiaDisconnectProvider(AccessibilityObject);
-
-        AccessibilityObject = null;
-        base.ReleaseHandle();
     }
 
     private void WinEventProcCallback(HWINEVENTHOOK hWinEventHook, uint eventId, HWND hwnd, int idObject, int idChild, uint idEventThread, uint dwmsEventTime)
     {
+        // Late-arriving callbacks should be ignored if we are releasing or hooks are already uninstalled.
+        if (_isReleasing || !_winEventHooksInstalled)
+        {
+            return;
+        }
+
         if (hwnd != Handle || idObject != (int)OBJECT_IDENTIFIER.OBJID_CLIENT || !IsAccessibilityObjectCreated)
         {
             return;
@@ -141,7 +179,9 @@ internal class LabelEditNativeWindow : NativeWindow
 
             // Accessibility object was likely requested by an assistive tech (which sent WM_GETOBJECT message).
             // We may need to install winevent hooks to produce the automation events related to the text pattern.
-            if (!_winEventHooksInstalled)
+            // However, if we are in the process of releasing the handle, skip hook installation to avoid
+            // creating new hooks on a window that is being destroyed.
+            if (!_winEventHooksInstalled && !_isReleasing)
             {
                 InstallWinEventHooks();
             }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/TreeViewLabelEditAccessibleObjectTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/TreeViewLabelEditAccessibleObjectTests.cs
@@ -133,6 +133,56 @@ public class TreeViewLabelEditAccessibleObjectTests
     }
 
     [WinFormsFact]
+    public void LabelEditNativeWindow_OnHandleChange_DuringRelease_DoesNotReinstallHooks()
+    {
+        using TreeView treeView = new() { Size = new Size(300, 200) };
+        treeView.CreateControl();
+
+        TreeViewLabelEditNativeWindow labelEdit = new(treeView);
+
+        labelEdit.TestAccessor.Dynamic._isReleasing = true;
+        labelEdit.TestAccessor.Dynamic.OnHandleChange();
+
+        Assert.False((bool)labelEdit.TestAccessor.Dynamic._winEventHooksInstalled);
+    }
+
+    [WinFormsFact]
+    public void TreeViewLabelEditNativeWindow_ReleaseHandle_UnhooksAndCleansUpState()
+    {
+        using TreeView treeView = new() { Size = new Size(300, 200) };
+        treeView.CreateControl();
+
+        TreeViewLabelEditNativeWindow labelEdit = new(treeView);
+        labelEdit.AssignHandle(treeView.Handle);
+
+        // Simulate hooks installed
+        labelEdit.TestAccessor.Dynamic._winEventHooksInstalled = true;
+
+        labelEdit.ReleaseHandle();
+
+        Assert.False((bool)labelEdit.TestAccessor.Dynamic._winEventHooksInstalled);
+        Assert.Null(labelEdit.TestAccessor.Dynamic._winEventProcCallback);
+    }
+
+    [WinFormsFact]
+    public void TreeViewLabelEditNativeWindow_ReleaseHandle_PreventsReentrantHookInstallation()
+    {
+        using TreeView treeView = new() { Size = new Size(300, 200) };
+        treeView.CreateControl();
+
+        TreeViewLabelEditNativeWindow labelEdit = new(treeView);
+
+        labelEdit.TestAccessor.Dynamic._isReleasing = true;
+        labelEdit.TestAccessor.Dynamic._winEventHooksInstalled = false;
+
+        // Simulates OnHandleChange being triggered mid-release
+        labelEdit.TestAccessor.Dynamic.OnHandleChange();
+
+        // Hooks must NOT be reinstalled while releasing
+        Assert.False((bool)labelEdit.TestAccessor.Dynamic._winEventHooksInstalled);
+    }
+
+    [WinFormsFact]
     public void TreeViewLabelEditUiaTextProvider_Ctor_NullOwningTreeView_ThrowsArgumentNullException()
     {
         using TreeView treeView = CreateTreeViewAndStartEditing();

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/TreeViewLabelEditAccessibleObjectTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/TreeViewLabelEditAccessibleObjectTests.cs
@@ -191,24 +191,6 @@ public class TreeViewLabelEditAccessibleObjectTests
     }
 
     [WinFormsFact]
-    public void TreeViewLabelEditNativeWindow_ReleaseHandle_PreventsReentrantHookInstallation()
-    {
-        using TreeView treeView = new() { Size = new Size(300, 200) };
-        treeView.CreateControl();
-
-        TreeViewLabelEditNativeWindow labelEdit = new(treeView);
-
-        labelEdit.TestAccessor.Dynamic._isReleasing = true;
-        labelEdit.TestAccessor.Dynamic._winEventHooksInstalled = false;
-
-        // Simulates OnHandleChange being triggered mid-release
-        labelEdit.TestAccessor.Dynamic.OnHandleChange();
-
-        // Hooks must NOT be reinstalled while releasing
-        Assert.False((bool)labelEdit.TestAccessor.Dynamic._winEventHooksInstalled);
-    }
-
-    [WinFormsFact]
     public void TreeViewLabelEditUiaTextProvider_Ctor_NullOwningTreeView_ThrowsArgumentNullException()
     {
         using TreeView treeView = CreateTreeViewAndStartEditing();
@@ -224,6 +206,79 @@ public class TreeViewLabelEditAccessibleObjectTests
 
         TreeViewLabelEditNativeWindow labelEdit = treeView.TestAccessor.Dynamic._labelEdit;
         Assert.Throws<ArgumentNullException>(() => new LabelEditUiaTextProvider(treeView, labelEdit, null));
+    }
+
+    [WinFormsFact]
+    public void LabelEditNativeWindow_RepeatedDestroyRecreate_WithGCBetweenCycles_HooksCleanAfterEachRelease()
+    {
+        using TreeView treeView = new() { Size = new Size(300, 200) };
+        treeView.CreateControl();
+        _ = treeView.AccessibilityObject;
+
+        TreeViewLabelEditNativeWindow labelEdit = new(treeView);
+
+        for (int cycle = 0; cycle < 3; cycle++)
+        {
+            labelEdit.AssignHandle(treeView.Handle);
+            Assert.True(labelEdit.IsHandleCreated);
+            Assert.False((bool)labelEdit.TestAccessor.Dynamic._isReleasing);
+
+            // Simulate hooks installed (UiaClientsAreListening() returns false in tests,
+            // so we set the flag manually to replicate the real-world state).
+            labelEdit.TestAccessor.Dynamic._winEventHooksInstalled = true;
+
+            // Force GC to simulate the delegate becoming eligible for collection
+            // while the hooks are still logically registered.
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            labelEdit.ReleaseHandle();
+
+            // After release both cleanup obligations must be fulfilled:
+            // hooks unregistered (_winEventHooksInstalled=false) and delegate reference
+            // dropped (_winEventProcCallback=null) so GC can collect it safely.
+            Assert.False((bool)labelEdit.TestAccessor.Dynamic._winEventHooksInstalled);
+            Assert.Null(labelEdit.TestAccessor.Dynamic._winEventProcCallback);
+            Assert.False((bool)labelEdit.TestAccessor.Dynamic._isReleasing);
+            Assert.False(labelEdit.IsHandleCreated);
+
+            // Force GC again to ensure no outstanding finalizers from this cycle
+            // could corrupt the next cycle.
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+    }
+
+    [WinFormsFact]
+    public void LabelEditNativeWindow_LateWinEventCallback_AfterHandleReleased_IsSafelyIgnored()
+    {
+        using TreeView treeView = new() { Size = new Size(300, 200) };
+        treeView.CreateControl();
+
+        TreeViewLabelEditNativeWindow labelEdit = new(treeView);
+        labelEdit.AssignHandle(treeView.Handle);
+
+        // Simulate hooks installed.
+        labelEdit.TestAccessor.Dynamic._winEventHooksInstalled = true;
+
+        // Release the handle; this must uninstall hooks and null the callback.
+        labelEdit.ReleaseHandle();
+        Assert.False((bool)labelEdit.TestAccessor.Dynamic._winEventHooksInstalled);
+
+        // Invoke the callback directly as if the OS delivered a late event after teardown.
+        // The _winEventHooksInstalled == false guard must make this a no-op without throwing.
+        labelEdit.TestAccessor.Dynamic.WinEventProcCallback(
+            default(HWINEVENTHOOK),
+            (uint)AccessibleEvents.ValueChange,
+            (HWND)treeView.Handle,
+            (int)OBJECT_IDENTIFIER.OBJID_CLIENT,
+            0,
+            0u,
+            0u);
+
+        // State must remain consistent: no hooks, no callback reference.
+        Assert.False((bool)labelEdit.TestAccessor.Dynamic._winEventHooksInstalled);
+        Assert.Null(labelEdit.TestAccessor.Dynamic._winEventProcCallback);
     }
 
     private TreeView CreateTreeViewAndStartEditing()

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/TreeViewLabelEditAccessibleObjectTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/TreeViewLabelEditAccessibleObjectTests.cs
@@ -139,11 +139,37 @@ public class TreeViewLabelEditAccessibleObjectTests
         treeView.CreateControl();
 
         TreeViewLabelEditNativeWindow labelEdit = new(treeView);
+        labelEdit.AssignHandle(treeView.Handle);
+        _ = treeView.AccessibilityObject;
+
+        Assert.True(labelEdit.IsHandleCreated);
 
         labelEdit.TestAccessor.Dynamic._isReleasing = true;
         labelEdit.TestAccessor.Dynamic.OnHandleChange();
 
         Assert.False((bool)labelEdit.TestAccessor.Dynamic._winEventHooksInstalled);
+    }
+
+    [WinFormsFact]
+    public void LabelEditNativeWindow_OnHandleChange_AfterHandleDestroyed_DoesNotReinstallHooks()
+    {
+        using TreeView treeView = new() { Size = new Size(300, 200) };
+        treeView.CreateControl();
+
+        TreeViewLabelEditNativeWindow labelEdit = new(treeView);
+        labelEdit.AssignHandle(treeView.Handle);
+
+        // Simulate installed hooks.
+        labelEdit.TestAccessor.Dynamic._winEventHooksInstalled = true;
+
+        // Simulate handle already destroyed.
+        labelEdit.ReleaseHandle();
+
+        labelEdit.TestAccessor.Dynamic._isReleasing = false;
+        labelEdit.TestAccessor.Dynamic.OnHandleChange();
+
+        Assert.False((bool)labelEdit.TestAccessor.Dynamic._winEventHooksInstalled);
+        Assert.Null(labelEdit.TestAccessor.Dynamic._winEventProcCallback);
     }
 
     [WinFormsFact]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14657

## Root Cause
Window destroyed → hooks not unregistered → object garbage collected → hook callback invokes freed memory → crash (`FailFast`).

The original code skipped cleanup when handle was gone, leaving orphaned hooks running.

## Proposed changes

This prevents callbacks from invoking garbage-collected delegates.
- Added `UnhookWinEventHooks()` method to centralize hook cleanup
- Call unhook when handle is destroyed in `OnHandleChange()`
- Added `_isReleasing` flag to prevent reentry during cleanup
- Set `_winEventProcCallback = null` after unhooking to allow GC

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Applications using screen readers (e.g., Narrator) no longer crash when editing `PropertyGrid` or `TreeView` with accessibility enabled.

## Regression? 

- No

## Risk

- Minimal: only defensive guards added, no behavior changes.

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

```
protected override void OnHandleChange()
{
    base.OnHandleChange();
    
    if (!IsHandleCreated)
    {
        return;  // ← Hooks remain registered even after window destruction
    }
    
    InstallWinEventHooks();
}
```

When native window is destroyed, WinEvent hooks are not unregistered. This orphaned hook persists after the managed object is garbage collected, causing late callbacks to invoke freed delegates → FailFast crash.


### After

```
protected override void OnHandleChange()
{
    base.OnHandleChange();
    
    if (!IsHandleCreated)
    {
        UnhookWinEventHooks();  // ← Properly clean up hooks
        return;
    }
    
    InstallWinEventHooks();
}

private void UnhookWinEventHooks()
{
    if (_winEventHooksInstalled)
    {
        PInvoke.UnhookWinEvent(_valueChangeHook);
        PInvoke.UnhookWinEvent(_textSelectionChangedHook);
        _winEventHooksInstalled = false;
        _winEventProcCallback = null;  // Allow GC
    }
}
```
Hooks are properly unregistered when the native window handle is destroyed, preventing orphaned callbacks and GC-related crashes.

## Test methodology <!-- How did you ensure quality? -->

- Manually
 

## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-preview.6.26310.110


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14663)