### PR TITLE
Fix issue 14667: [HDPI] The icon of Property Page button changed after switched the LargeButtons property value from False to True

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
@@ -2066,12 +2066,12 @@ public partial class PropertyGrid : ContainerControl, IComPropertyBrowser, IProp
             AddLargeImage(_alphaBitmap);
             AddLargeImage(_categoryBitmap);
 
+            AddLargeImage(_propertyPageBitmap);
+
             foreach (var tab in _tabs)
             {
                 AddLargeImage(tab.Tab.Bitmap);
             }
-
-            AddLargeImage(_propertyPageBitmap);
         }
         else
         {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
@@ -2066,12 +2066,15 @@ public partial class PropertyGrid : ContainerControl, IComPropertyBrowser, IProp
             AddLargeImage(_alphaBitmap);
             AddLargeImage(_categoryBitmap);
 
-            AddLargeImage(_propertyPageBitmap);
-
-            foreach (var tab in _tabs)
+            if (_tabs.Count > 1)
             {
-                AddLargeImage(tab.Tab.Bitmap);
+                foreach (var tab in _tabs)
+                {
+                    AddLargeImage(tab.Tab.Bitmap);
+                }
             }
+
+            AddLargeImage(_propertyPageBitmap);
         }
         else
         {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14667 

When creating _largeButtonImages in EnsureLargeButtons(), the order in which _propertyPageBitmap and _tabs icons are added is inconsistent, causing the image index to be misaligned, resulting in the display of the wrong icon after switching to the larger icon.

## Proposed changes

- Adjust the order in which large icons are added within EnsureLargeButtons(): Add _propertyPageBitmap first, then add the bitmaps for each tab, ensuring consistency with the toolbar button creation/indexing logic.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Fixes incorrect Property Page icon rendering in HDPI when toggling PropertyGrid.LargeButtons from False to True, preventing UI confusion and restoring correct toolbar icon mapping.

## Regression? 

- Yes

## Risk

- Mini

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<img width="1073" height="303" alt="image" src="https://github.com/user-attachments/assets/cf445541-b9ba-46da-8224-c1223efb3866" />

### After

https://github.com/user-attachments/assets/48a6942d-35e2-4b34-8355-5f9277bccbc9


## Test methodology <!-- How did you ensure quality? -->

- Manual

 

## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.100-preview.5.26227.104


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14672)