### PR TITLE
Fix RichTextBox flooding AT channel with entire document on focus

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
@@ -2388,20 +2388,7 @@ public partial class RichTextBox : TextBoxBase
         ((ContentsResizedEventHandler?)Events[s_requestSizeEvent])?.Invoke(this, e);
     }
 
-    protected override void OnGotFocus(EventArgs e)
-    {
-        base.OnGotFocus(e);
-
-        // Use parent's accessible object because RichTextBox doesn't support UIA Providers, and its
-        // AccessibilityObject doesn't get created even when assistive tech (e.g. Narrator) is used
-        if (Parent?.IsAccessibilityObjectCreated == true)
-        {
-            Parent.AccessibilityObject.InternalRaiseAutomationNotification(
-                Automation.AutomationNotificationKind.Other,
-                Automation.AutomationNotificationProcessing.MostRecent,
-                Text);
-        }
-    }
+    protected override void OnGotFocus(EventArgs e) => base.OnGotFocus(e);
 
     protected override void OnHandleCreated(EventArgs e)
     {

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/RichTextBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/RichTextBoxTests.cs
@@ -10597,7 +10597,7 @@ public partial class RichTextBoxTests
     public void RichTextBox_OnGotFocus_DoesNotRaiseAutomationNotification(EventArgs eventArgs)
     {
         // NVDA and JAWS already announce the focused line via native MSAA on focus; an additional
-        // UIA automation notification caused the line to be read twice. The correct behaviour is
+        // UIA automation notification caused the line to be read twice. The correct behavior is
         // to let the native accessibility infrastructure handle the announcement.
         Mock<Control> mockParent = new() { CallBase = true };
         Mock<Control.ControlAccessibleObject> mockAccessibleObject = new(MockBehavior.Strict, mockParent.Object);

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/RichTextBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/RichTextBoxTests.cs
@@ -10594,26 +10594,21 @@ public partial class RichTextBoxTests
 
     [WinFormsTheory]
     [NewAndDefaultData<EventArgs>]
-    public void RichTextBox_OnGotFocus_RaisesAutomationNotification_WithText(EventArgs eventArgs)
+    public void RichTextBox_OnGotFocus_DoesNotRaiseAutomationNotification(EventArgs eventArgs)
     {
+        // NVDA and JAWS already announce the focused line via native MSAA on focus; an additional
+        // UIA automation notification caused the line to be read twice. The correct behaviour is
+        // to let the native accessibility infrastructure handle the announcement.
         Mock<Control> mockParent = new() { CallBase = true };
         Mock<Control.ControlAccessibleObject> mockAccessibleObject = new(MockBehavior.Strict, mockParent.Object);
-        mockAccessibleObject
-            .Setup(a => a.InternalRaiseAutomationNotification(
-                It.IsAny<AutomationNotificationKind>(),
-                It.IsAny<AutomationNotificationProcessing>(),
-                It.IsAny<string>()))
-            .Returns(true)
-            .Verifiable();
         mockParent.Protected().Setup<AccessibleObject>("CreateAccessibilityInstance")
             .Returns(mockAccessibleObject.Object);
 
         using Control parent = mockParent.Object;
-        string richTextBoxContent = "RichTextBox";
         using SubRichTextBox control = new()
         {
             Parent = parent,
-            Text = richTextBoxContent,
+            Text = "RichTextBox",
         };
 
         // Enforce accessible object creation
@@ -10622,10 +10617,10 @@ public partial class RichTextBoxTests
         control.OnGotFocus(eventArgs);
 
         mockAccessibleObject.Verify(a => a.InternalRaiseAutomationNotification(
-            AutomationNotificationKind.Other,
-            AutomationNotificationProcessing.MostRecent,
-            richTextBoxContent),
-            Times.Once);
+            It.IsAny<AutomationNotificationKind>(),
+            It.IsAny<AutomationNotificationProcessing>(),
+            It.IsAny<string>()),
+            Times.Never);
     }
 
     [WinFormsTheory]


### PR DESCRIPTION
Fixes #14671

## Proposed changes

Removes the explicit UIA automation notification from OnGotFocus that was sending the full Text of the control to assistive technology on every focus event. For large documents this caused NVDA and JAWS to freeze, and produced a double-announcement (the native MSAA focus event already reads the current line correctly). The pass-through override is kept to satisfy the shipped public API surface.


## Customer Impact

Any rich text box with a lot of content in it risks freezing user's assistive technologies.

## Regression? 

- No

## Risk

- None

## Test methodology <!-- How did you ensure quality? -->

Created a basic winforms app, created a RichTextBox inside it, gave it 6 lines, tested without my custom assembly and with, my custom version fixes the bug.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

Tested with NVDA on Windows 11 24H2.

## Test environment(s) <!-- Remove any that don't apply -->

.NET SDK:
 Version:           10.0.202
 Commit:            1e7d5a8ae3
 Workload version:  10.0.200-manifests.f96d7f23
 MSBuild version:   18.3.3+1e7d5a8ae

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.26100
 OS Platform: Windows
 RID:         win-x64
 Base Path:   C:\Program Files\dotnet\sdk\10.0.202\

.NET workloads installed:
There are no installed workloads to display.
Configured to use workload sets when installing new manifests.
No workload sets are installed. Run "dotnet workload restore" to install a workload set.

Host:
  Version:      10.0.6
  Architecture: x64
  Commit:       47fb725acf

.NET SDKs installed:
  10.0.202 [C:\Program Files\dotnet\sdk]

.NET runtimes installed:
  Microsoft.AspNetCore.App 10.0.6 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 10.0.6 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.WindowsDesktop.App 10.0.6 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]

Other architectures found:
  None

Environment variables:
  Not set

global.json file:
  Not found

Learn more:
  https://aka.ms/dotnet/info

Download .NET:
  https://aka.ms/dotnet/download

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14675)