### PR TITLE
Fix endless loop when adding TabPage directly to Form.Controls

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Control.ControlCollection.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Control.ControlCollection.cs
@@ -72,7 +72,7 @@ public partial class Control
             // Add the control
             InnerList.Add(value);
 
-            int _savedTabIndex = value._tabIndex;
+            int savedTabIndex = value._tabIndex;
 
             if (value._tabIndex == -1)
             {
@@ -119,7 +119,7 @@ public partial class Control
                         value._parent = oldParent;
                     }
 
-                    value._tabIndex = _savedTabIndex;
+                    value._tabIndex = savedTabIndex;
                     throw;
                 }
                 finally

--- a/src/System.Windows.Forms/System/Windows/Forms/Control.ControlCollection.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Control.ControlCollection.cs
@@ -72,6 +72,8 @@ public partial class Control
             // Add the control
             InnerList.Add(value);
 
+            int _savedTabIndex = value._tabIndex;
+
             if (value._tabIndex == -1)
             {
                 // Find the next highest tab index
@@ -100,6 +102,25 @@ public partial class Control
                     // would make us short-circuit the rest of the reparenting logic.
                     // you could end up with a control half reparented.
                     value.AssignParent(Owner);
+                }
+                catch
+                {
+                    // AssignParent may throw for invalid parents, leaving the control partially added.
+                    // Roll back the failed add to keep the collection and parent state consistent.
+                    if (InnerList.Contains(value))
+                    {
+                        InnerList.Remove(value);
+                    }
+
+                    // AssignParent may have already changed the parent before throwing.
+                    // Restore the previous parent to keep Parent and Controls collection in sync.
+                    if (value._parent == Owner)
+                    {
+                        value._parent = oldParent;
+                    }
+
+                    value._tabIndex = _savedTabIndex;
+                    throw;
                 }
                 finally
                 {

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/Form.ControlCollectionTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/Form.ControlCollectionTests.cs
@@ -32,7 +32,7 @@ public class Form_ControlCollection
 
         int oldCount = form.Controls.Count;
 
-        Assert.ThrowsAny<Exception>(() => form.Controls.Add(tabPage));
+        Assert.ThrowsAny<ArgumentException>(() => form.Controls.Add(tabPage));
 
         Assert.Equal(oldCount, form.Controls.Count);
         Assert.False(form.Controls.Contains(tabPage));
@@ -42,19 +42,48 @@ public class Form_ControlCollection
     [WinFormsFact]
     public void ControlCollection_Clear_AfterFailedTabPageAdd_DoesNotHang()
     {
-        using Form form = new();
-        using Button button = new() { Name = "button1" };
-        using TabPage tabPage = new();
+        Exception threadException = null;
+        using ManualResetEventSlim completed = new(false);
 
-        form.Controls.Add(button);
+        Thread thread = new(() =>
+        {
+            try
+            {
+                using Form form = new();
+                using Button button = new() { Name = "button1" };
+                using TabPage tabPage = new();
 
-        Assert.ThrowsAny<Exception>(() => form.Controls.Add(tabPage));
+                form.Controls.Add(button);
 
-        // If the failed add left the TabPage half-added,
-        // Clear() could hang. After the fix, it should complete normally.
-        form.Controls.Clear();
+                Assert.ThrowsAny<ArgumentException>(() => form.Controls.Add(tabPage));
 
-        Assert.Empty(form.Controls);
-        Assert.Null(tabPage.Parent);
+                // This is the operation that previously could hang.
+                form.Controls.Clear();
+
+                Assert.Empty(form.Controls);
+                Assert.Null(tabPage.Parent);
+            }
+            catch (Exception ex)
+            {
+                threadException = ex;
+            }
+            finally
+            {
+                completed.Set();
+            }
+        });
+
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.IsBackground = true;
+        thread.Start();
+
+        Assert.True(
+            completed.Wait(TimeSpan.FromSeconds(5)),
+            "ControlCollection.Clear() appears to hang after a failed TabPage add.");
+
+        if (threadException is not null)
+        {
+            ExceptionDispatchInfo.Capture(threadException).Throw();
+        }
     }
 }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/Form.ControlCollectionTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/Form.ControlCollectionTests.cs
@@ -23,4 +23,38 @@ public class Form_ControlCollection
     {
         Assert.Throws<ArgumentNullException>("owner", () => new Form.ControlCollection(null));
     }
+
+    [WinFormsFact]
+    public void ControlCollection_Add_InvalidTabPageParent_DoesNotLeaveHalfAddedControl()
+    {
+        using Form form = new();
+        using TabPage tabPage = new();
+
+        int oldCount = form.Controls.Count;
+
+        Assert.ThrowsAny<Exception>(() => form.Controls.Add(tabPage));
+
+        Assert.Equal(oldCount, form.Controls.Count);
+        Assert.False(form.Controls.Contains(tabPage));
+        Assert.Null(tabPage.Parent);
+    }
+
+    [WinFormsFact]
+    public void ControlCollection_Clear_AfterFailedTabPageAdd_DoesNotHang()
+    {
+        using Form form = new();
+        using Button button = new() { Name = "button1" };
+        using TabPage tabPage = new();
+
+        form.Controls.Add(button);
+
+        Assert.ThrowsAny<Exception>(() => form.Controls.Add(tabPage));
+
+        // If the failed add left the TabPage half-added,
+        // Clear() could hang. After the fix, it should complete normally.
+        form.Controls.Clear();
+
+        Assert.Empty(form.Controls);
+        Assert.Null(tabPage.Parent);
+    }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes https://github.com/dotnet/winforms/issues/5661


## Proposed changes

- Added rollback logic in `Control.ControlCollection.Add` exception handling when `AssignParent` throws.
- Remove the control from `InnerList` if the add operation fails, so the control is not left partially added.
- Restore the previous parent and saved tab index to keep control state consistent after a failed add.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Prevents controls such as `TabPage` from being left in an inconsistent “half-added” state when added to an invalid parent.
- Avoids hangs/endless loops in later operations such as `Controls.Clear()` / `Controls.Remove()` after a failed `Add`.

## Regression? 

- No

## Risk

- Low for the reported `TabPage` scenario.
- Medium-low for broader reparenting scenarios, since this change affects the exception rollback path in `ControlCollection.Add`.
- Covered by targeted tests for failed add, clear/remove behavior, and parent state restoration.

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->
NA

## Test methodology <!-- How did you ensure quality? -->

- Verified the original repro: `Form.Controls.Add(new TabPage())` throws and no longer leaves the control in the collection.
- Verified `Controls.Clear()` after the failed add completes without hang.
- Verified parent and tab index state are restored correctly after exception.
- Verified normal add/remove behavior for standard controls remains unchanged.
- Added/validated targeted unit tests under `Control.ControlCollectionTests`. 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Not applicable. This change does not modify UI behavior, rendering, or accessible properties directly.

## Test environment(s) <!-- Remove any that don't apply -->
-  Windows 11
-  .NET SDK: 11.0.100-preview.3.26170.106
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14678)