### PR TITLE
Correct IsSynchronized values across ListBox collections

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListBoxes/ListBox.IntegerCollection.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListBoxes/ListBox.IntegerCollection.cs
@@ -43,7 +43,7 @@ public partial class ListBox
         {
             get
             {
-                return true;
+                return false;
             }
         }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListBoxes/ListBox.SelectedIndexCollection.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListBoxes/ListBox.SelectedIndexCollection.cs
@@ -41,7 +41,7 @@ public partial class ListBox
         {
             get
             {
-                return true;
+                return false;
             }
         }
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ListBox.IntegerCollectionTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ListBox.IntegerCollectionTests.cs
@@ -30,7 +30,7 @@ public class ListBoxIntegerCollectionTests
         using ListBox owner = new();
         ICollection collection = new ListBox.IntegerCollection(owner);
         Assert.Empty(collection);
-        Assert.True(collection.IsSynchronized);
+        Assert.False(collection.IsSynchronized);
         Assert.Same(collection, collection.SyncRoot);
     }
 
@@ -42,7 +42,7 @@ public class ListBoxIntegerCollectionTests
         Assert.Empty(collection);
         Assert.False(collection.IsFixedSize);
         Assert.False(collection.IsReadOnly);
-        Assert.True(collection.IsSynchronized);
+        Assert.False(collection.IsSynchronized);
         Assert.Same(collection, collection.SyncRoot);
     }
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ListBox.SelectedIndexCollectionTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ListBox.SelectedIndexCollectionTests.cs
@@ -29,7 +29,7 @@ public class ListBoxSelectedIndexCollectionTests
         using ListBox owner = new();
         ICollection collection = new ListBox.SelectedIndexCollection(owner);
         Assert.Empty(collection);
-        Assert.True(collection.IsSynchronized);
+        Assert.False(collection.IsSynchronized);
         Assert.Same(collection, collection.SyncRoot);
     }
 
@@ -41,7 +41,7 @@ public class ListBoxSelectedIndexCollectionTests
         Assert.Empty(collection);
         Assert.True(collection.IsFixedSize);
         Assert.True(collection.IsReadOnly);
-        Assert.True(collection.IsSynchronized);
+        Assert.False(collection.IsSynchronized);
         Assert.Same(collection, collection.SyncRoot);
     }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/winforms/issues/3088


## Proposed changes

- Override IsSynchronized in ListBox.SelectedIndexCollection and ListBox.IntegerCollection to return false.
- Ensure consistency across all ListBox collections (SelectedObjectCollection, ObjectCollection, SelectedIndexCollection, IntegerCollection).
- Add unit tests verifying that all four collections return IsSynchronized == false.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Developers will no longer be misled into thinking SelectedIndexCollection and IntegerCollection are thread‑safe.
- Clearer, consistent API behavior across all ListBox collections.
- Prevents incorrect assumptions about synchronization and reduces risk of threading bugs.

## Regression? 

- No.

## Risk

- Low. The change only affects the IsSynchronized property return value.
- No runtime behavior or collection logic is altered.
- Unit tests ensure correctness and prevent regressions.

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

- Added unit tests for all four ListBox collections.
- Verified consistent IsSynchronized == false return values.
- Ran full test suite to confirm no regressions.


## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.100-preview.3.26170.106

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14679)