### PR TITLE
Fix SendKeys sequential immediate modifier(^a^c, +a+c, %f%t)  parsing regression

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/SendKeys/SendKeys.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/SendKeys/SendKeys.cs
@@ -127,7 +127,7 @@ public partial class SendKeys
         char character,
         int repeat,
         HWND hwnd,
-        (int HaveShift, int HaveCtrl, int HaveAlt) haveKeys,
+        ref (int HaveShift, int HaveCtrl, int HaveAlt) haveKeys,
         bool startNewChar,
         int cGrp)
     {
@@ -509,7 +509,7 @@ public partial class SendKeys
                     }
                     else if (keyName.Length == 1)
                     {
-                        s_startNewChar = AddSimpleKey(keyName[0], repeat, hwnd, haveKeys, s_startNewChar, cGrp);
+                        s_startNewChar = AddSimpleKey(keyName[0], repeat, hwnd, ref haveKeys, s_startNewChar, cGrp);
                     }
                     else
                     {
@@ -605,7 +605,7 @@ public partial class SendKeys
                     break;
 
                 default:
-                    s_startNewChar = AddSimpleKey(keys[i], repeat, hwnd, haveKeys, s_startNewChar, cGrp);
+                    s_startNewChar = AddSimpleKey(keys[i], repeat, hwnd, ref haveKeys, s_startNewChar, cGrp);
                     break;
             }
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/SendKeysTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/SendKeysTests.cs
@@ -3,8 +3,6 @@
 
 #nullable disable
 
-using System.Reflection;
-
 namespace System.Windows.Forms.Tests;
 
 public class SendKeysTests
@@ -15,18 +13,9 @@ public class SendKeysTests
     [InlineData("%f%t")]
     public void SendKeys_ParseKeys_SequentialImmediateModifiers_DoesNotThrow(string keys)
     {
-        MethodInfo parseKeysMethod = typeof(SendKeys).GetMethod("ParseKeys", BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.NotNull(parseKeysMethod);
-
-        ParameterInfo[] parameters = parseKeysMethod.GetParameters();
-        object hwnd = Activator.CreateInstance(parameters[1].ParameterType);
-
-        Exception exception = Record.Exception(() => parseKeysMethod.Invoke(null, [keys, hwnd]));
-        Exception parseException = exception is TargetInvocationException { InnerException: { } innerException }
-            ? innerException
-            : exception;
-
-        Assert.Null(parseException);
+        dynamic accessor = typeof(SendKeys).TestAccessor.Dynamic;
+        Exception exception = Record.Exception(() => accessor.ParseKeys(keys, default(HWND)));
+        Assert.Null(exception);
     }
 
     [WinFormsFact(Skip = "This test depends on focus and should be run manually.")]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/SendKeysTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/SendKeysTests.cs
@@ -3,10 +3,32 @@
 
 #nullable disable
 
+using System.Reflection;
+
 namespace System.Windows.Forms.Tests;
 
 public class SendKeysTests
 {
+    [WinFormsTheory]
+    [InlineData("^a^c")]
+    [InlineData("+a+c")]
+    [InlineData("%f%t")]
+    public void SendKeys_ParseKeys_SequentialImmediateModifiers_DoesNotThrow(string keys)
+    {
+        MethodInfo parseKeysMethod = typeof(SendKeys).GetMethod("ParseKeys", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(parseKeysMethod);
+
+        ParameterInfo[] parameters = parseKeysMethod.GetParameters();
+        object hwnd = Activator.CreateInstance(parameters[1].ParameterType);
+
+        Exception exception = Record.Exception(() => parseKeysMethod.Invoke(null, [keys, hwnd]));
+        Exception parseException = exception is TargetInvocationException { InnerException: { } innerException }
+            ? innerException
+            : exception;
+
+        Assert.Null(parseException);
+    }
+
     [WinFormsFact(Skip = "This test depends on focus and should be run manually.")]
     public void SendKeysGrouping()
     {


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14690

## Root Cause
In PR https://github.com/dotnet/winforms/pull/3621, `int[] haveKeys` (a reference type with implicit by-reference semantics) was refactored to a value `tuple`. Without adding `ref`, the modifier state mutations inside `AddSimpleKey `were silently lost, breaking sequential immediate modifier sequences.

## Proposed changes

- Pass modifier state by reference when calling `AddSimpleKey`, so cancellation updates are preserved in `ParseKeys `state.
- Update `AddSimpleKey `signature to accept modifier tuple by `ref`.
- Add regression unit tests for sequential immediate modifier patterns:`^a^c`, `+a+c`, `%f%t`


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

-  Apps migrated from .NET Framework that use sequential immediate modifier sequences in `SendKeys `(e.g. `^a^c`) will no longer throw an unexpected

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

Sample project [WinFormsApp8.zip](https://github.com/user-attachments/files/29544702/WinFormsApp8.zip)

### Before
System.ArgumentException: SendKeys string "^a^c" is not valid.

<img width="1254" height="620" alt="image" src="https://github.com/user-attachments/assets/6d7277cf-cd67-49a4-b03c-5306fb06418f" />

### After
`^a^c` was parsed as Ctrl+A followed by Ctrl+C, consistent with .NET Framework behavior.

<img width="872" height="428" alt="image" src="https://github.com/user-attachments/assets/4228b2a1-214f-42fd-8cc4-35ee384ec241" />


## Test methodology <!-- How did you ensure quality? -->

- Manually and unit test

## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-preview.7.26330.112


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14691)