### PR TITLE
Fix issue 14025: [DarkMode] the item lost dot line when using the mouse to expand the dropdown panel for SelectionPanelRadioButton

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Drawing/SelectionPanelBase.SelectionPanelRadioButton.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/SelectionPanelBase.SelectionPanelRadioButton.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Windows.Forms;
+using System.Windows.Forms.VisualStyles;
 
 namespace System.Drawing.Design;
 
@@ -20,20 +21,39 @@ internal abstract partial class SelectionPanelBase
         {
             base.WndProc(ref m);
 
-            if (m.MsgInternal != PInvokeCore.WM_PAINT || !Focused || !ShowFocusCues)
-            {
-                return;
-            }
-
-            Rectangle focusBounds = ClientRectangle;
-            focusBounds.Inflate(-LogicalToDeviceUnits(3), -LogicalToDeviceUnits(3));
-            if (focusBounds.Width <= 0 || focusBounds.Height <= 0)
+            if (m.MsgInternal != PInvokeCore.WM_PAINT || !Focused || !Application.IsDarkModeEnabled)
             {
                 return;
             }
 
             using Graphics g = CreateGraphics();
+            Rectangle focusBounds = GetFocusBounds(g);
+            if (focusBounds.Width <= 0 || focusBounds.Height <= 0)
+            {
+                return;
+            }
+
             ControlPaint.DrawFocusRectangle(g, focusBounds, ForeColor, BackColor);
+        }
+
+        private Rectangle GetFocusBounds(Graphics graphics)
+        {
+            if (Application.RenderWithVisualStyles && VisualStyleRenderer.IsSupported)
+            {
+                VisualStyleElement element = Checked
+                    ? VisualStyleElement.Button.PushButton.Pressed
+                    : VisualStyleElement.Button.PushButton.Normal;
+
+                if (VisualStyleRenderer.IsElementDefined(element))
+                {
+                    VisualStyleRenderer renderer = new(element);
+                    return renderer.GetBackgroundContentRectangle(graphics, ClientRectangle);
+                }
+            }
+
+            Rectangle focusBounds = ClientRectangle;
+            focusBounds.Inflate(-SystemInformation.Border3DSize.Width, -SystemInformation.Border3DSize.Height);
+            return focusBounds;
         }
 
         protected override bool IsInputKey(Keys keyData) => keyData switch

--- a/src/System.Windows.Forms.Design/src/System/Drawing/SelectionPanelBase.SelectionPanelRadioButton.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/SelectionPanelBase.SelectionPanelRadioButton.cs
@@ -9,8 +9,6 @@ internal abstract partial class SelectionPanelBase
 {
     protected class SelectionPanelRadioButton : RadioButton
     {
-        private const int WM_PAINT = 0x000F;
-
         public SelectionPanelRadioButton()
         {
             AutoCheck = false;
@@ -22,13 +20,13 @@ internal abstract partial class SelectionPanelBase
         {
             base.WndProc(ref m);
 
-            if (m.Msg != WM_PAINT || !Focused || !ShowFocusCues)
+            if (m.MsgInternal != PInvokeCore.WM_PAINT || !Focused || !ShowFocusCues)
             {
                 return;
             }
 
             Rectangle focusBounds = ClientRectangle;
-            focusBounds.Inflate(-3, -3);
+            focusBounds.Inflate(-LogicalToDeviceUnits(3), -LogicalToDeviceUnits(3));
             if (focusBounds.Width <= 0 || focusBounds.Height <= 0)
             {
                 return;

--- a/src/System.Windows.Forms.Design/src/System/Drawing/SelectionPanelBase.SelectionPanelRadioButton.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/SelectionPanelBase.SelectionPanelRadioButton.cs
@@ -9,12 +9,34 @@ internal abstract partial class SelectionPanelBase
 {
     protected class SelectionPanelRadioButton : RadioButton
     {
+        private const int WM_PAINT = 0x000F;
+
         public SelectionPanelRadioButton()
         {
             AutoCheck = false;
         }
 
         protected override bool ShowFocusCues => true;
+
+        protected override void WndProc(ref Message m)
+        {
+            base.WndProc(ref m);
+
+            if (m.Msg != WM_PAINT || !Focused || !ShowFocusCues)
+            {
+                return;
+            }
+
+            Rectangle focusBounds = ClientRectangle;
+            focusBounds.Inflate(-3, -3);
+            if (focusBounds.Width <= 0 || focusBounds.Height <= 0)
+            {
+                return;
+            }
+
+            using Graphics g = CreateGraphics();
+            ControlPaint.DrawFocusRectangle(g, focusBounds, ForeColor, BackColor);
+        }
 
         protected override bool IsInputKey(Keys keyData) => keyData switch
         {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14025 

## Root Cause
SelectionPanelRadioButton relies on native painting when used with Appearance.Button, if the focus rectangle is not drawn after native painting completes, it can be missing or inconsistent under certain themes/modes.

## Proposed changes

- Override WndProc in SelectionPanelRadioButton and handle WM_PAINT.
- Call base.WndProc(ref m) first to preserve native button visuals.
- Only when Focused && ShowFocusCues, overlay the focus cue by calling ControlPaint.DrawFocusRectangle(...) after WM_PAINT.
- Keep a small inset and bounds validation for the focus rectangle to avoid invalid drawing.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- [Dark Mode] When using the mouse to expand the dropdown panel for the "Selection Panel" radio button, the dashed line displays correctly

## Regression? 

- No

## Risk

- Mini

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<img width="727" height="676" alt="image" src="https://github.com/user-attachments/assets/cf7d92cd-6a90-426c-8fb1-763d759f578f" />


### After

**Dark Mode**

https://github.com/user-attachments/assets/0423466c-a1dc-4aa8-a0d7-c8e41b08abd7

**Normal**

https://github.com/user-attachments/assets/eeda3c59-b641-433a-aec7-49a899dbf52e


## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.0-preview.6.26317


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14710)