### PR TITLE
Fix Issue 14005: [DarkMode] the Pane in the Anchor Editor should adapt to the dark mode

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AnchorEditor.AnchorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AnchorEditor.AnchorUI.cs
@@ -197,7 +197,15 @@ public sealed partial class AnchorEditor
         {
             public ControlPlaceholder()
             {
-                BackColor = SystemColors.Control;
+                if (Application.IsDarkModeEnabled)
+                {
+                    BackColor = SystemColors.ControlDark;
+                }
+                else
+                {
+                    BackColor = SystemColors.Control;
+                }
+
                 TabStop = false;
                 SetStyle(ControlStyles.Selectable, false);
             }
@@ -205,7 +213,16 @@ public sealed partial class AnchorEditor
             protected override void OnPaint(PaintEventArgs e)
             {
                 Rectangle rc = ClientRectangle;
-                ControlPaint.DrawButton(e.Graphics, rc, ButtonState.Normal);
+
+                if (Application.IsDarkModeEnabled)
+                {
+                    e.Graphics.FillRectangle(SystemBrushes.ControlDark, rc);
+                    e.Graphics.DrawRectangle(SystemPens.WindowFrame, rc.X, rc.Y, rc.Width - 1, rc.Height - 1);
+                }
+                else
+                {
+                    ControlPaint.DrawButton(e.Graphics, rc, ButtonState.Normal);
+                }
             }
         }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AnchorEditor.AnchorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AnchorEditor.AnchorUI.cs
@@ -213,15 +213,10 @@ public sealed partial class AnchorEditor
             protected override void OnPaint(PaintEventArgs e)
             {
                 Rectangle rc = ClientRectangle;
-
+                ControlPaint.DrawButton(e.Graphics, rc, ButtonState.Normal);
                 if (Application.IsDarkModeEnabled)
                 {
-                    e.Graphics.FillRectangle(SystemBrushes.ControlDark, rc);
-                    e.Graphics.DrawRectangle(SystemPens.WindowFrame, rc.X, rc.Y, rc.Width - 1, rc.Height - 1);
-                }
-                else
-                {
-                    ControlPaint.DrawButton(e.Graphics, rc, ButtonState.Normal);
+                    e.Graphics.FillRectangle(new SolidBrush(BackColor), rc);
                 }
             }
         }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AnchorEditor.AnchorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AnchorEditor.AnchorUI.cs
@@ -216,7 +216,7 @@ public sealed partial class AnchorEditor
                 ControlPaint.DrawButton(e.Graphics, rc, ButtonState.Normal);
                 if (Application.IsDarkModeEnabled)
                 {
-                    e.Graphics.FillRectangle(new SolidBrush(BackColor), rc);
+                    e.Graphics.Clear(BackColor);
                 }
             }
         }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14005 


## Proposed changes

Updated the center placeholder (ControlPlaceholder) visual rendering in AnchorEditor.AnchorUI for dark mode.
- In dark mode:
  - Set center placeholder background to SystemColors.ControlDark.
  - Replaced the previous button-style painting with explicit dark fill + border drawing (FillRectangle + DrawRectangle) to avoid the bright/white center block.
- In non-dark mode:
  - Kept existing rendering behavior (ControlPaint.DrawButton(..., ButtonState.Normal)) unchanged.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Updated the visual rendering of the central placeholder (ControlPlaceholder) in AnchorEditor.AnchorUI to ensure compatibility with dark mode.

## Regression? 

- No

## Risk

- Mini

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<img width="827" height="618" alt="image" src="https://github.com/user-attachments/assets/03dde2f9-db76-4fef-8f45-dcf6141a525f" />

### After

**Dark Mode**
<img width="974" height="166" alt="image" src="https://github.com/user-attachments/assets/41e7ee07-beb0-42da-9fed-19472b153b2b" />

**Normal**
<img width="986" height="175" alt="image" src="https://github.com/user-attachments/assets/b4e61ae3-d9a1-4f07-83c5-f36b1dade904" />

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.0-preview.6.26317


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14715)