### PR TITLE
Fix WebBrowser control blocks accelerators of buttons on form

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/WebBrowserBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/WebBrowserBase.cs
@@ -339,7 +339,7 @@ public unsafe partial class WebBrowserBase : Control
 
             PInvoke.GetCursorPos(out Point p);
             msg.pt = p;
-            if (!PInvoke.IsAccelerator(new HandleRef<HACCEL>(this, controlInfo.hAccel), controlInfo.cAccel, &msg, lpwCmd: null))
+            if (PInvoke.IsAccelerator(new HandleRef<HACCEL>(this, controlInfo.hAccel), controlInfo.cAccel, &msg, lpwCmd: null))
             {
                 _axOleControl.OnMnemonic(&msg);
                 Focus();

--- a/src/test/unit/System.Windows.Forms/WebBrowserBaseTests.cs
+++ b/src/test/unit/System.Windows.Forms/WebBrowserBaseTests.cs
@@ -858,6 +858,182 @@ public class WebBrowserBaseTests
         Assert.Throws<NotSupportedException>(() => control.UseWaitCursor = true);
     }
 
+    [WinFormsFact]
+    public void UserControl_ProcessMnemonic_WebBrowserBeforeButton_InvokesButtonMnemonic()
+    {
+        using TestForm form = new();
+        using TestUserControl userControl = new();
+
+        TextBox textBox = new()
+        {
+            Name = "textBox1",
+            TabIndex = 0,
+            Text = "textbox on user control"
+        };
+
+        Panel panel = new()
+        {
+            Name = "panel1",
+            TabIndex = 7
+        };
+
+        WebBrowser webBrowser = new()
+        {
+            Name = "webBrowserControl",
+            TabIndex = 0,
+            Url = new Uri("about:blank"),
+            WebBrowserShortcutsEnabled = false
+        };
+
+        Button button = new()
+        {
+            Name = "button1",
+            TabIndex = 8,
+            Text = "&Button on user control"
+        };
+
+        int clickCount = 0;
+        button.Click += (_, _) => clickCount++;
+
+        panel.Controls.Add(webBrowser);
+        userControl.Controls.Add(textBox);
+        userControl.Controls.Add(panel);
+        userControl.Controls.Add(button);
+        form.Controls.Add(userControl);
+
+        form.Show();
+        textBox.Focus();
+
+        Assert.True(textBox.Focused || textBox.ContainsFocus);
+
+        bool processed = userControl.InvokeProcessMnemonic('B');
+
+        Assert.True(processed);
+        Assert.Equal(1, clickCount);
+    }
+
+    [WinFormsFact]
+    public void Form_ProcessMnemonic_WebBrowserInChildControl_DoesNotBlockFormMnemonic()
+    {
+        using TestForm form = new();
+        using TestUserControl userControl = new();
+
+        TextBox textBox = new()
+        {
+            TabIndex = 0
+        };
+
+        Panel panel = new()
+        {
+            TabIndex = 7
+        };
+
+        WebBrowser webBrowser = new()
+        {
+            TabIndex = 0,
+            Url = new Uri("about:blank"),
+            WebBrowserShortcutsEnabled = false
+        };
+
+        Button childButton = new()
+        {
+            TabIndex = 8,
+            Text = "&Button on user control"
+        };
+
+        Button okButton = new()
+        {
+            Text = "&OK"
+        };
+
+        int okClickCount = 0;
+        okButton.Click += (_, _) => okClickCount++;
+
+        panel.Controls.Add(webBrowser);
+        userControl.Controls.Add(textBox);
+        userControl.Controls.Add(panel);
+        userControl.Controls.Add(childButton);
+
+        form.Controls.Add(userControl);
+        form.Controls.Add(okButton);
+
+        form.Show();
+        textBox.Focus();
+
+        Assert.True(textBox.Focused || textBox.ContainsFocus);
+
+        bool processed = form.InvokeProcessMnemonic('O');
+
+        Assert.True(processed);
+        Assert.Equal(1, okClickCount);
+    }
+
+    [WinFormsFact]
+    public void UserControl_ProcessMnemonic_ButtonBeforeWebBrowser_StillInvokesButtonMnemonic()
+    {
+        using TestForm form = new();
+        using TestUserControl userControl = new();
+
+        TextBox textBox = new()
+        {
+            TabIndex = 0
+        };
+
+        Button button = new()
+        {
+            TabIndex = 7,
+            Text = "&Button on user control"
+        };
+
+        Panel panel = new()
+        {
+            TabIndex = 8
+        };
+
+        WebBrowser webBrowser = new()
+        {
+            TabIndex = 0,
+            Url = new Uri("about:blank"),
+            WebBrowserShortcutsEnabled = false
+        };
+
+        int clickCount = 0;
+        button.Click += (_, _) => clickCount++;
+
+        panel.Controls.Add(webBrowser);
+        userControl.Controls.Add(textBox);
+        userControl.Controls.Add(button);
+        userControl.Controls.Add(panel);
+        form.Controls.Add(userControl);
+
+        form.Show();
+        textBox.Focus();
+
+        bool processed = userControl.InvokeProcessMnemonic('B');
+
+        Assert.True(processed);
+        Assert.Equal(1, clickCount);
+    }
+
+    [WinFormsFact]
+    public void WebBrowser_ProcessMnemonic_UnrelatedMnemonic_ReturnsFalse()
+    {
+        using TestForm form = new();
+        using TestWebBrowser webBrowser = new()
+        {
+            Url = new Uri("about:blank"),
+            WebBrowserShortcutsEnabled = false
+        };
+
+        form.Controls.Add(webBrowser);
+        form.Show();
+        webBrowser.CreateControl();
+
+        bool processed = webBrowser.InvokeProcessMnemonic('B');
+
+        Assert.False(processed);
+    }
+
     private class CustomProcessControl : Control
     {
         public Func<Message, Keys, bool> ProcessCmdKeyAction { get; set; }
@@ -952,5 +1128,20 @@ public class WebBrowserBaseTests
         public new bool ProcessDialogKey(Keys keyData) => base.ProcessDialogKey(keyData);
 
         public new void SetStyle(ControlStyles flag, bool value) => base.SetStyle(flag, value);
+    }
+
+    private sealed class TestUserControl : UserControl
+    {
+        public bool InvokeProcessMnemonic(char charCode) => ProcessMnemonic(charCode);
+    }
+
+    private sealed class TestForm : Form
+    {
+        public bool InvokeProcessMnemonic(char charCode) => ProcessMnemonic(charCode);
+    }
+
+    private sealed class TestWebBrowser : WebBrowser
+    {
+        public bool InvokeProcessMnemonic(char charCode) => ProcessMnemonic(charCode);
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes https://github.com/dotnet/winforms/issues/8862


## Proposed changes

- Fix WebBrowser mnemonic handling in `WebBrowserBase` by correcting the `IsAccelerator(...)` condition.
- Ensure the hosted ActiveX browser processes only its own accelerators instead of claiming unrelated form/user-control mnemonics.
- Restore expected button/form mnemonic behavior when a `WebBrowser` is present in the control hierarchy.


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Fixes a regression where `Alt+<mnemonic>` keys (for example `Alt+B`, `Alt+O`) were blocked when a `WebBrowser` control existed on the form/user control.
- Restores expected keyboard accessibility and usability for buttons and form-level accelerators.


## Regression? 

- Yes

## Risk

- Low to moderate.
- The change is limited to `WebBrowser` mnemonic/accelerator handling and corrects inverted `IsAccelerator(...)` logic.
- Potential impact is limited to cases that previously relied on the incorrect behavior where `WebBrowser` handled keys that were not its own accelerators.


<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->
NA


## Test methodology <!-- How did you ensure quality? -->

- Added regression test coverage for a `UserControl` containing `TextBox`, `Panel`, `WebBrowser`, and a mnemonic `Button`.
- Verified that button mnemonics work when `WebBrowser` appears before the button in tab order.
- Verified that form-level mnemonics (for example `&OK`) are not blocked by `WebBrowser`.


## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- N/A – no UI changes.

 

## Test environment(s)
- Windows 11
- .NET SDK: 11.0.100-preview.3.26170.106

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14717)