### PR TITLE
Fix Issue 14721: TreeView.CustomDraw leaks one HFONT per visible item per paint when NodeFont is set, leading to GDI handle exhaustion and crash

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -2782,12 +2782,16 @@ public partial class TreeView : Control
                 if (renderinfo is not null && renderinfo.Font is not null)
                 {
                     // Mess with the DC directly...
-                    PInvokeCore.SelectObject(nmtvcd->nmcd.hdc, renderinfo.FontHandle);
+                    Debug.Assert(node._propBag is not null);
+                    if (node._propBag is not null && node._propBag.Font is not null)
+                    {
+                        PInvokeCore.SelectObject(nmtvcd->nmcd.hdc, node._propBag.FontHandle);
 
-                    // There is a problem in winctl that clips node fonts if the fontSize
-                    // is larger than the treeView font size. The behavior is much better in comctl 5 and above.
-                    m.ResultInternal = (LRESULT)(nint)PInvoke.CDRF_NEWFONT;
-                    return;
+                        // There is a problem in winctl that clips node fonts if the fontSize
+                        // is larger than the treeView font size. The behavior is much better in comctl 5 and above.
+                        m.ResultInternal = (LRESULT)(nint)PInvoke.CDRF_NEWFONT;
+                        return;
+                    }
                 }
 
                 // fall through and do the default drawing work

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -2782,12 +2782,16 @@ public partial class TreeView : Control
                 if (renderinfo is not null && renderinfo.Font is not null)
                 {
                     // Mess with the DC directly...
-                    PInvokeCore.SelectObject(nmtvcd->nmcd.hdc, renderinfo.FontHandle);
+                    Debug.Assert(node._propBag is not null);
+                    if (node._propBag is not null && node._propBag.Font is not null)
+                    {
+                        PInvokeCore.SelectObject(nmtvcd->nmcd.hdc, node._propBag.FontHandle);
 
-                    // There is a problem in winctl that clips node fonts if the fontSize
-                    // is larger than the treeView font size. The behavior is much better in comctl 5 and above.
-                    m.ResultInternal = (LRESULT)(nint)PInvoke.CDRF_NEWFONT;
-                    return;
+                        // There is a problem in winctl that clips node fonts if the fontSize
+                        // is larger than the treeView font size. The behavior is much better in comctl 5 and above.
+                        m.ResultInternal = (LRESULT)(nint)PInvoke.CDRF_NEWFONT;
+                        return;
+                    }
                 }
 
                 // fall through and do the default drawing work
@@ -2863,12 +2867,12 @@ public partial class TreeView : Control
     /// </summary>
     protected OwnerDrawPropertyBag GetItemRenderStyles(TreeNode? node, int state)
     {
+        OwnerDrawPropertyBag retval = new();
         if (node is null || node._propBag is null)
         {
-            return new();
+            return retval;
         }
 
-        OwnerDrawPropertyBag retval = node._propBag;
         // we only change colors if we're displaying things normally
         if ((state &
             (int)(NMCUSTOMDRAW_DRAW_STATE_FLAGS.CDIS_SELECTED |

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -2782,16 +2782,12 @@ public partial class TreeView : Control
                 if (renderinfo is not null && renderinfo.Font is not null)
                 {
                     // Mess with the DC directly...
-                    Debug.Assert(node._propBag is not null);
-                    if (node._propBag is not null && node._propBag.Font is not null)
-                    {
-                        PInvokeCore.SelectObject(nmtvcd->nmcd.hdc, node._propBag.FontHandle);
+                    PInvokeCore.SelectObject(nmtvcd->nmcd.hdc, renderinfo.FontHandle);
 
-                        // There is a problem in winctl that clips node fonts if the fontSize
-                        // is larger than the treeView font size. The behavior is much better in comctl 5 and above.
-                        m.ResultInternal = (LRESULT)(nint)PInvoke.CDRF_NEWFONT;
-                        return;
-                    }
+                    // There is a problem in winctl that clips node fonts if the fontSize
+                    // is larger than the treeView font size. The behavior is much better in comctl 5 and above.
+                    m.ResultInternal = (LRESULT)(nint)PInvoke.CDRF_NEWFONT;
+                    return;
                 }
 
                 // fall through and do the default drawing work
@@ -2867,12 +2863,12 @@ public partial class TreeView : Control
     /// </summary>
     protected OwnerDrawPropertyBag GetItemRenderStyles(TreeNode? node, int state)
     {
-        OwnerDrawPropertyBag retval = new();
         if (node is null || node._propBag is null)
         {
-            return retval;
+            return new();
         }
 
+        OwnerDrawPropertyBag retval = node._propBag;
         // we only change colors if we're displaying things normally
         if ((state &
             (int)(NMCUSTOMDRAW_DRAW_STATE_FLAGS.CDIS_SELECTED |

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -2783,7 +2783,7 @@ public partial class TreeView : Control
                 {
                     // Mess with the DC directly...
                     Debug.Assert(node._propBag is not null);
-                    if (node._propBag is not null && node._propBag.Font is not null)
+                    if (node._propBag is not null)
                     {
                         PInvokeCore.SelectObject(nmtvcd->nmcd.hdc, node._propBag.FontHandle);
 

--- a/src/System.Windows.Forms/System/Windows/Forms/OwnerDrawPropertyBag.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/OwnerDrawPropertyBag.cs
@@ -12,6 +12,7 @@ namespace System.Windows.Forms;
 [Serializable] // This class is participating in resx serialization scenarios for listview/treeview items.
 public class OwnerDrawPropertyBag : MarshalByRefObject, ISerializable
 {
+    private Font? _font;
     private Control.FontHandleWrapper? _fontWrapper;
     private static readonly Lock s_internalSyncObject = new();
 
@@ -38,7 +39,19 @@ public class OwnerDrawPropertyBag : MarshalByRefObject, ISerializable
     {
     }
 
-    public Font? Font { get; set; }
+    public Font? Font
+    {
+        get => _font;
+        set
+        {
+            if (!ReferenceEquals(_font, value))
+            {
+                _font = value;
+                _fontWrapper?.Dispose();
+                _fontWrapper = null;
+            }
+        }
+    }
 
     public Color ForeColor { get; set; }
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/OwnerDrawPropertyBagTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/OwnerDrawPropertyBagTests.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System.Drawing;
+using System.Reflection;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Windows.Forms.TestUtilities;
 
@@ -54,6 +55,24 @@ public class OwnerDrawPropertyBagTests
         bag.Font = value;
         Assert.Same(value, bag.Font);
         Assert.Equal(value is null, bag.IsEmpty());
+    }
+
+    [WinFormsFact]
+    public void OwnerDrawPropertyBag_Font_SetDifferentValue_ResetsCachedFontWrapper()
+    {
+        using SubTreeView treeView = new();
+        OwnerDrawPropertyBag bag = treeView.GetItemRenderStyles(null, 0);
+        using Font firstFont = new(SystemFonts.MenuFont, FontStyle.Regular);
+        using Font secondFont = new(SystemFonts.MenuFont, FontStyle.Bold);
+
+        bag.Font = firstFont;
+        _ = bag.GetType().GetProperty("FontHandle", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(bag);
+
+        FieldInfo fontWrapperField = bag.GetType().GetField("_fontWrapper", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        Assert.NotNull(fontWrapperField.GetValue(bag));
+
+        bag.Font = secondFont;
+        Assert.Null(fontWrapperField.GetValue(bag));
     }
 
     [WinFormsTheory]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/OwnerDrawPropertyBagTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/OwnerDrawPropertyBagTests.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System.Drawing;
-using System.Reflection;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Windows.Forms.TestUtilities;
 
@@ -66,13 +65,13 @@ public class OwnerDrawPropertyBagTests
         using Font secondFont = new(SystemFonts.MenuFont, FontStyle.Bold);
 
         bag.Font = firstFont;
-        _ = bag.GetType().GetProperty("FontHandle", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(bag);
+        _ = bag.FontHandle;
 
-        FieldInfo fontWrapperField = bag.GetType().GetField("_fontWrapper", BindingFlags.Instance | BindingFlags.NonPublic)!;
-        Assert.NotNull(fontWrapperField.GetValue(bag));
+        dynamic accessor = bag.TestAccessor.Dynamic;
+        Assert.NotNull(accessor._fontWrapper);
 
         bag.Font = secondFont;
-        Assert.Null(fontWrapperField.GetValue(bag));
+        Assert.Null(accessor._fontWrapper);
     }
 
     [WinFormsTheory]


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14721 

## Root Cause

`TreeView.CustomDraw` calls `GetItemRenderStyles` during every `ITEMPREPAINT` event, and this method creates a new `OwnerDrawPropertyBag`. The original code utilized [renderinfo.FontHandle](https://github.com/dotnet/winforms/blob/f9076b6495ab193eedc54e6c5d22c87ad99a7341/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs#L2785), which triggered `Font.ToHfont()`—allocating a new `HFONT`—whenever the property was first accessed in a new bag. Because these short-lived objects could not be released immediately, GDI font handles accumulated rapidly during high-frequency repainting, eventually leading to handle exhaustion and a crash.

## Proposed changes

- The source for selecting the font into the Device Context has been changed from `renderinfo.FontHandle` to `node._propBag.FontHandle`, utilizing the reusable, long-lived cache available on the `TreeNode`. Null checks (for `node._propBag` and `node._propBag.Font`) are retained to ensure safety. This change preserves standard rendering semantics (using the same font source) while avoiding the repeated creation of an `HFONT` during every paint operation.
- In `OwnerDrawPropertyBag`, change `Font` from an auto-property to one with a custom setter: when the font changes, explicitly dispose of the old `_fontWrapper` and set it to `null`, ensuring that the correct `HFONT` is recreated the next time `FontHandle` is accessed.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Avoid exceptions (such as `Win32Exception: The operation completed successfully.`) and subsequent application crashes (0xC000041D) caused by reaching the 10,000 GDI handle limit.
- Reduce or eliminate the rapid proliferation of GDI font handles during frequent TreeView repainting.
- After switching `TreeNode.NodeFont` at runtime, the new font is correctly reflected, and the old `HFONT` is not used.

## Regression? 

- No

## Risk

- Mini

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

https://github.com/user-attachments/assets/aa975718-fb2b-45d1-88f8-a4ce8e0f637f

### After


https://github.com/user-attachments/assets/c0939035-0c92-4d46-9b47-2f79cfb6f2c6


**Change the font of a TreeNode**:

https://github.com/user-attachments/assets/af62d5b9-5e3f-4c09-88aa-a54ce2ba2c1c



## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.100-preview.5.26302.115


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14730)