### PR TITLE
Fix KeyboardToolTipStateMachine KeyNotFoundException when focus changes during tooltip popup event

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/ToolTip/KeyboardToolTipStateMachine.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/ToolTip/KeyboardToolTipStateMachine.cs
@@ -248,7 +248,7 @@ internal sealed partial class KeyboardToolTipStateMachine
         return wrapper;
     }
 
-    private void Transit(SmEvent @event, IKeyboardToolTip source)
+    private void Transit(SmEvent @event, IKeyboardToolTip? source)
     {
         bool fullFsmResetRequired = false;
         try

--- a/src/System.Windows.Forms/System/Windows/Forms/ToolTip/KeyboardToolTipStateMachine.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/ToolTip/KeyboardToolTipStateMachine.cs
@@ -73,8 +73,9 @@ internal sealed partial class KeyboardToolTipStateMachine
             (SmState.ReadyForReshow, SmEvent.LeftTool) => StartWaitingForRefocus(tool),
             (SmState.ReadyForReshow, SmEvent.ReshowDelayTimerExpired) => ShowToolTip(tool, tooltip),
 
-            // This is what we would have thrown historically
-            (_, _) => throw new KeyNotFoundException()
+            // Reentrant focus changes can yield event/state combinations outside the normal transition table.
+            // Resetting avoids surfacing framework exceptions to application code.
+            (_, _) => FullFsmReset()
         };
 
     public void ResetStateMachine(ToolTip toolTip)
@@ -252,6 +253,12 @@ internal sealed partial class KeyboardToolTipStateMachine
         bool fullFsmResetRequired = false;
         try
         {
+            if (source is null)
+            {
+                fullFsmResetRequired = true;
+                return;
+            }
+
             ToolTip? toolTip = _toolToTip[source];
             if ((_currentTool is null || _currentTool.CanShowToolTipsNow()) && toolTip is not null)
             {

--- a/src/test/unit/System.Windows.Forms/KeyboardTooltipStateMachineTests.cs
+++ b/src/test/unit/System.Windows.Forms/KeyboardTooltipStateMachineTests.cs
@@ -109,6 +109,36 @@ public class KeyboardTooltipStateMachineTests
         Assert.Equal(isPersistent && OsVersion.IsWindows11_OrGreater() ? "Hidden" : "Shown", currentState);
     }
 
+    [WinFormsFact]
+    public void KeyboardTooltipStateMachine_UnexpectedTransition_DoesNotThrow_AndResets()
+    {
+        using TestControl control = new();
+        using ToolTip toolTip = new();
+
+        control.CreateControl();
+        _ = toolTip.Handle;
+
+        toolTip.SetToolTip(control, "test");
+
+        KeyboardToolTipStateMachine instance = KeyboardToolTipStateMachine.Instance;
+        instance.Hook(control, toolTip);
+
+        instance.TestAccessor.Dynamic._currentTool = control;
+        instance.TestAccessor.Dynamic._currentState = KeyboardToolTipStateMachine.SmState.Shown;
+
+        // SmEvent.InitialDelayTimerExpired = 2, which is invalid for Shown state
+        // This simulates a re-entrant focus change triggering an unexpected transition.
+        Exception exception = Record.Exception(() =>
+            instance.TestAccessor.Dynamic.Transit((byte)2, control));
+
+        IKeyboardToolTip currentTool = instance.TestAccessor.Dynamic._currentTool;
+        string currentState = instance.TestAccessor.Dynamic._currentState.ToString();
+
+        Assert.Null(exception);
+        Assert.Null(currentTool);
+        Assert.Equal("Hidden", currentState);
+    }
+
     private class TestControl : Control
     {
         public void SimulateKeyUp(Keys keys) => base.OnKeyUp(new KeyEventArgs(keys));


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14729

## Root Cause
Calling` Focus()` in ToolTip.Popup event causes re-entrant focus change that creates invalid state-event combinations, triggering `KeyNotFoundException`. Timer callbacks on unhooked tools cause `ArgumentNullException`.

## Proposed changes

- Replace throw new `KeyNotFoundException()` with `FullFsmReset()`
- Add null check in `Transit()` method before accessing weak reference table

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Applications no longer crash during focus re-entrance in Popup events

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Switching focus to the second text box using the Tab key triggers an /ArgumentNullException pop-up.

in .NET framework 4.8.1:

<img width="2456" height="1232" alt="Image" src="https://github.com/user-attachments/assets/ca0e076a-5956-46d0-83ac-f9b0b56dc49b" />

in .net10 application:

<img width="939" height="413" alt="image" src="https://github.com/user-attachments/assets/58951962-9b09-40f6-9a14-ef47415b7b1d" />


### After
App continues running

https://github.com/user-attachments/assets/5e4bb4ac-a51a-4c81-bf6c-7b38de50a7ab

## Test methodology <!-- How did you ensure quality? -->

- Manually
 

## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-preview.7.26355.102


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14731)