### PR TITLE
Fix ItemHeight of ListBox is not scaled on high DPI in OwnerDrawFixed mode

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListBoxes/ListBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListBoxes/ListBox.cs
@@ -2073,9 +2073,11 @@ public partial class ListBox : ListControl
 
         // In OwnerDrawFixed the native list box doesn't rescale the fixed item height when the control
         // autoscales, so scale it here (clamped to [1, 255]; height-axis guard avoids a double-apply). #6382
+        // Round away from zero: banker's rounding would round .5 midpoints down (15 * 1.5 -> 22), which
+        // re-introduces the cramped rows this fixes.
         if (_drawMode == DrawMode.OwnerDrawFixed && factor.Height != 1F && (specified & BoundsSpecified.Height) != 0)
         {
-            ItemHeight = Math.Clamp((int)Math.Round(_itemHeight * factor.Height), 1, 255);
+            ItemHeight = Math.Clamp((int)Math.Round(_itemHeight * factor.Height, MidpointRounding.AwayFromZero), 1, 255);
         }
 
         base.ScaleControl(factor, specified);

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListBoxes/ListBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListBoxes/ListBox.cs
@@ -2071,6 +2071,13 @@ public partial class ListBox : ListControl
             UpdateFontCache();
         }
 
+        // In OwnerDrawFixed the native list box doesn't rescale the fixed item height when the control
+        // autoscales, so scale it here (clamped to [1, 255]; height-axis guard avoids a double-apply). #6382
+        if (_drawMode == DrawMode.OwnerDrawFixed && factor.Height != 1F && (specified & BoundsSpecified.Height) != 0)
+        {
+            ItemHeight = Math.Clamp((int)Math.Round(_itemHeight * factor.Height), 1, 255);
+        }
+
         base.ScaleControl(factor, specified);
     }
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ListBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ListBoxTests.cs
@@ -1849,11 +1849,11 @@ public class ListBoxTests
     public void ListBox_ScaleControl_OwnerDrawFixed_ScalesItemHeight()
     {
         // #6382: an OwnerDrawFixed item height must scale with the control during autoscaling.
-        using SubListBox control = new() { DrawMode = DrawMode.OwnerDrawFixed, ItemHeight = 25 };
+        using SubListBox control = new() { DrawMode = DrawMode.OwnerDrawFixed, ItemHeight = 20 };
 
         control.ScaleControl(new SizeF(1.5f, 1.5f), BoundsSpecified.All);
 
-        Assert.Equal(38, control.ItemHeight); // 25 * 1.5 = 37.5 -> 38
+        Assert.Equal(30, control.ItemHeight);
     }
 
     [WinFormsFact]
@@ -1867,6 +1867,30 @@ public class ListBoxTests
 
         Assert.Equal(40, control.ItemHeight);
         Assert.Equal(40, (int)PInvokeCore.SendMessage(control, PInvoke.LB_GETITEMHEIGHT));
+    }
+
+    [WinFormsTheory]
+    [InlineData(25, 38)] // 37.5 rounds up
+    [InlineData(15, 23)] // 22.5 rounds up, not down to 22 as banker's rounding would
+    public void ListBox_ScaleControl_OwnerDrawFixed_RoundsMidpointsAwayFromZero(int itemHeight, int expected)
+    {
+        using SubListBox control = new() { DrawMode = DrawMode.OwnerDrawFixed, ItemHeight = itemHeight };
+
+        control.ScaleControl(new SizeF(1.5f, 1.5f), BoundsSpecified.All);
+
+        Assert.Equal(expected, control.ItemHeight);
+    }
+
+    [WinFormsFact]
+    public void ListBox_ScaleControl_OwnerDrawFixed_HeightExcluded_DoesNotScaleItemHeight()
+    {
+        // A scaling pass that excludes the height axis must leave the item height alone, otherwise the
+        // included/excluded pass pair in ContainerControl.PerformAutoScale would apply the factor twice.
+        using SubListBox control = new() { DrawMode = DrawMode.OwnerDrawFixed, ItemHeight = 25 };
+
+        control.ScaleControl(new SizeF(1.5f, 1.5f), BoundsSpecified.Width);
+
+        Assert.Equal(25, control.ItemHeight);
     }
 
     [WinFormsFact]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ListBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ListBoxTests.cs
@@ -1845,6 +1845,52 @@ public class ListBoxTests
         Assert.False(property.ShouldSerializeValue(control));
     }
 
+    [WinFormsFact]
+    public void ListBox_ScaleControl_OwnerDrawFixed_ScalesItemHeight()
+    {
+        // #6382: an OwnerDrawFixed item height must scale with the control during autoscaling.
+        using SubListBox control = new() { DrawMode = DrawMode.OwnerDrawFixed, ItemHeight = 25 };
+
+        control.ScaleControl(new SizeF(1.5f, 1.5f), BoundsSpecified.All);
+
+        Assert.Equal(38, control.ItemHeight); // 25 * 1.5 = 37.5 -> 38
+    }
+
+    [WinFormsFact]
+    public void ListBox_ScaleControl_OwnerDrawFixed_WithHandle_UpdatesNativeItemHeight()
+    {
+        using SubListBox control = new() { DrawMode = DrawMode.OwnerDrawFixed, ItemHeight = 20 };
+        Assert.NotEqual(IntPtr.Zero, control.Handle);
+        Assert.Equal(20, (int)PInvokeCore.SendMessage(control, PInvoke.LB_GETITEMHEIGHT));
+
+        control.ScaleControl(new SizeF(2f, 2f), BoundsSpecified.All);
+
+        Assert.Equal(40, control.ItemHeight);
+        Assert.Equal(40, (int)PInvokeCore.SendMessage(control, PInvoke.LB_GETITEMHEIGHT));
+    }
+
+    [WinFormsFact]
+    public void ListBox_ScaleControl_OwnerDrawFixed_ClampsItemHeightToMax()
+    {
+        // Scaling must not throw when the result exceeds the 255 maximum; it clamps instead.
+        using SubListBox control = new() { DrawMode = DrawMode.OwnerDrawFixed, ItemHeight = 200 };
+
+        control.ScaleControl(new SizeF(2f, 2f), BoundsSpecified.All);
+
+        Assert.Equal(255, control.ItemHeight);
+    }
+
+    [WinFormsFact]
+    public void ListBox_ScaleControl_Normal_DoesNotChangeItemHeight()
+    {
+        using SubListBox control = new() { DrawMode = DrawMode.Normal };
+        int before = control.ItemHeight;
+
+        control.ScaleControl(new SizeF(1.5f, 1.5f), BoundsSpecified.All);
+
+        Assert.Equal(before, control.ItemHeight);
+    }
+
     public static IEnumerable<object[]> Items_CustomCreateItemCollection_TestData()
     {
         yield return new object[] { null };


### PR DESCRIPTION
Fixes #6382

## Proposed changes

An `OwnerDrawFixed` `ListBox` keeps its fixed `ItemHeight` (the reporter's sample sets `25`) when the
control is autoscaled. At higher DPI the font grows but the rows stay their design-time height, so the
items look cramped. .NET Framework scaled the item height; .NET (Core) doesn't.

- Scale the `OwnerDrawFixed` item height by `factor.Height` in `ListBox.ScaleControl`; the same
  scaling pass that already scales padding and margin. The result is clamped to `[1, 255]`, and a
  height-axis guard keeps a partial pass from applying the factor twice.
- `ScaleControl` is the entry point that both `AutoScaleMode.Font`/`Dpi` and PerMonitorV2 route
  through, so no per-DPI-message hook is needed.

## Customer Impact

- Owner-draw fixed `ListBox` items are the correct height at higher DPI instead of the design-time
  height. Long-standing customer report; does not occur on .NET Framework.

## Regression?

- Versus .NET Framework: yes (Framework scaled it, Core didn't). Not a recent .NET regression.

## Risk

- Low. Runs only for `OwnerDrawFixed` during a real scaling pass, reuses the `ItemHeight` setter, and
  clamps so it can't throw. `Normal`/`OwnerDrawVariable` unaffected.

## Screenshots

Sample is `HighDpiMode.SystemAware` (reads DPI at startup): change the scale, then **relaunch** to

### Before
<img width="272" height="238" alt="before-150" src="https://github.com/user-attachments/assets/1e6d7a54-3b80-4b33-ab9f-7663dc54f663" />

150%: rows stay at `ItemHeight = 25` while the font scales up (cramped).

### After
<img width="290" height="215" alt="after-150" src="https://github.com/user-attachments/assets/0716dfc7-c6e5-4124-9835-8f32870a5d3d" />

150%: item height scales (25 > ~38), keeping the 100% proportions.

## Test methodology

- Unit tests

## Accessibility testing

- No accessibility surface change; item height only affects layout.

## Test environment(s)

- 11.0.100-preview.5.26302.115
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14740)