### PR TITLE
Arrow navigation always prioritizes parent DataGridView control regardless of what child control is focused.

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
@@ -21929,6 +21929,14 @@ public partial class DataGridView
 
     protected override bool ProcessKeyPreview(ref Message m)
     {
+        if (m.MsgInternal == PInvokeCore.WM_KEYDOWN || m.MsgInternal == PInvokeCore.WM_SYSKEYDOWN)
+        {
+            if (m.HWND != HWND && (EditingControl is null || m.HWND != EditingControl.HWND))
+            {
+                return base.ProcessKeyPreview(ref m);
+            }
+        }
+
         bool dataGridViewWantsInputKey;
         KeyEventArgs ke = new((Keys)(nint)m.WParamInternal | ModifierKeys);
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
@@ -21929,7 +21929,7 @@ public partial class DataGridView
 
     protected override bool ProcessKeyPreview(ref Message m)
     {
-        if (m.MsgInternal == PInvokeCore.WM_KEYDOWN || m.MsgInternal == PInvokeCore.WM_SYSKEYDOWN)
+        if (m.MsgInternal == PInvokeCore.WM_KEYDOWN || m.MsgInternal == PInvokeCore.WM_SYSKEYDOWN || m.MsgInternal == PInvokeCore.WM_CHAR)
         {
             if (m.HWND != HWND && (EditingControl is null || m.HWND != EditingControl.HWND))
             {

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewTests.cs
@@ -4084,4 +4084,115 @@ public partial class DataGridViewTests : IDisposable
         dataGridView.Dispose();
         toolTipDisposeCount.Should().Be(1);
     }
+
+    [WinFormsFact]
+    public void ProcessKeyPreview_HostedChild_ArrowKey_DoesNotRouteToDataGridView()
+    {
+        using Form form = new();
+        using TestDataGridView dataGridView = CreateGrid();
+        using TextBox hostedTextBox = new();
+
+        form.Controls.Add(dataGridView);
+        dataGridView.Controls.Add(hostedTextBox);
+
+        form.Show();
+        dataGridView.CreateControl();
+        hostedTextBox.CreateControl();
+        hostedTextBox.Focus();
+
+        dataGridView.CurrentCell = dataGridView[0, 0];
+
+        Message message = Message.Create(
+        hostedTextBox.Handle,
+        (int)PInvokeCore.WM_KEYDOWN,
+        (IntPtr)Keys.Down,
+        IntPtr.Zero);
+
+        dataGridView.CallProcessKeyPreview(ref message);
+
+        Assert.False(dataGridView.ProcessDataGridViewKeyCalled);
+        Assert.Equal(0, dataGridView.CurrentCell.RowIndex);
+    }
+
+    [WinFormsFact]
+    public void ProcessKeyPreview_DataGridViewTarget_ArrowKey_StillRoutesToDataGridView()
+    {
+        using Form form = new();
+        using TestDataGridView dataGridView = CreateGrid();
+
+        form.Controls.Add(dataGridView);
+        form.Show();
+        dataGridView.CreateControl();
+        dataGridView.Focus();
+
+        dataGridView.CurrentCell = dataGridView[0, 0];
+
+        Message message = Message.Create(
+        dataGridView.Handle,
+        (int)PInvokeCore.WM_KEYDOWN,
+        (IntPtr)Keys.Down,
+        IntPtr.Zero);
+
+        dataGridView.CallProcessKeyPreview(ref message);
+
+        Assert.True(dataGridView.ProcessDataGridViewKeyCalled);
+    }
+
+    [WinFormsFact]
+    public void ProcessKeyPreview_HostedChild_NonArrowKey_DoesNotUseArrowSuppression()
+    {
+        using Form form = new();
+        using TestDataGridView dataGridView = CreateGrid();
+        using TextBox hostedTextBox = new();
+
+        form.Controls.Add(dataGridView);
+        dataGridView.Controls.Add(hostedTextBox);
+
+        form.Show();
+        dataGridView.CreateControl();
+        hostedTextBox.CreateControl();
+        hostedTextBox.Focus();
+
+        Message message = Message.Create(
+        hostedTextBox.Handle,
+        (int)PInvokeCore.WM_KEYDOWN,
+        (IntPtr)Keys.Enter,
+        IntPtr.Zero);
+
+        dataGridView.CallProcessKeyPreview(ref message);
+
+        // This test is weaker than the arrow-key tests, but still verifies
+        // that the arrow-specific logic is not applied to Enter.
+        Assert.False(dataGridView.ProcessDataGridViewKeyCalled);
+    }
+
+    private static TestDataGridView CreateGrid()
+    {
+        TestDataGridView grid = new()
+        {
+            Width = 300,
+            Height = 200
+        };
+
+        grid.Columns.Add("Col1", "Col1");
+        grid.Columns.Add("Col2", "Col2");
+        grid.Rows.Add("A1", "B1");
+        grid.Rows.Add("A2", "B2");
+
+        return grid;
+    }
+
+    private sealed class TestDataGridView : DataGridView
+    {
+        public bool ProcessDataGridViewKeyCalled { get; private set; }
+
+        public bool CallProcessKeyPreview(ref Message m)
+        => ProcessKeyPreview(ref m);
+
+        protected override bool ProcessDataGridViewKey(KeyEventArgs e)
+        {
+            ProcessDataGridViewKeyCalled = true;
+            return base.ProcessDataGridViewKey(e);
+        }
+    }
 }


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes https://github.com/dotnet/winforms/issues/6361


## Proposed changes

- Added an early check in ProcessKeyPreview for WM_KEYDOWN / WM_SYSKEYDOWN and WM_SYSCHAR.
- Skipped DataGridView preview handling when the key message targets a hosted child control instead of the DataGridView itself.
- Preserved existing behavior for the active EditingControl to avoid edit-mode regressions.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Fixes an issue where arrow keys intended for hosted child controls could be intercepted by the parent DataGridView.
- Improves keyboard navigation behavior for controls hosted inside DataGridView.Controls.

## Regression? 

- No

## Risk

- Low — the change is scoped to key preview handling and preserves existing behavior for the DataGridView and its EditingControl.

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

NA

## Test methodology <!-- How did you ensure quality? -->

- Added tests for arrow key messages targeted at hosted child controls.
- Verified that normal DataGridView arrow-key behavior remains unchanged when the grid itself is the target.
- Verified that existing edit-mode behavior is preserved for the EditingControl.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
N/A — no UI or accessibility surface change.
 

## Test environment(s)

- Windows 11
- .NET SDK: 11.0.100-preview.3.26170.106
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14744)