### PR TITLE
System font scaling not working on the fly

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Control.cs
@@ -12262,36 +12262,6 @@ public unsafe partial class Control :
     }
 
     /// <summary>
-    ///  Called when the system default font has changed (e.g. via Accessibility → Text Size in Windows Settings).
-    ///  Notifies this control and all descendants that use the default font so that they update their font handle
-    ///  and raise <see cref="OnFontChanged"/>, which in turn causes <see cref="ContainerControl"/> to invoke
-    ///  <see cref="ContainerControl.PerformAutoScale"/> and resize controls immediately without an app restart.
-    ///  Controls that have an explicitly set font are intentionally skipped.
-    /// </summary>
-    private void OnSystemFontChanged()
-    {
-        // Only notify controls that are using the ambient/default font — i.e., no explicit font was set.
-        if (!IsFontSet())
-        {
-            // Discard the per-control cached font handle so it is recreated from the updated default font.
-            DisposeFontHandle();
-
-            // Raising OnFontChanged will clear _currentAutoScaleDimensions in ContainerControl and trigger
-            // PerformAutoScale, which recalculates AutoScaleFactor and resizes all child controls.
-            OnFontChanged(EventArgs.Empty);
-        }
-
-        // Propagate to all immediate children regardless; each child decides for itself whether to act.
-        if (ChildControls is { } children)
-        {
-            for (int i = 0; i < children.Count; i++)
-            {
-                children[i].OnSystemFontChanged();
-            }
-        }
-    }
-
-    /// <summary>
     ///  Processes Windows messages.
     /// </summary>
     /// <remarks>
@@ -12656,7 +12626,7 @@ public unsafe partial class Control :
                         // s_defaultFont = Application.DefaultFont ?? SystemFonts.MessageBoxFont;
                         // So we need to check both variants - manually set font (Application.DefaultFont is not null) and auto system font
 
-                        bool fontChanged = false;
+                        bool defaultFontChanged = false;
                         if (Application.DefaultFont is null) // auto system font
                         {
                             if (s_defaultFont is not null) // we need to check only if s_defaultFont already set
@@ -12665,7 +12635,7 @@ public unsafe partial class Control :
                                 if (!s_defaultFont.Equals(font)) // the font has changed
                                 {
                                     s_defaultFont = font;
-                                    fontChanged = true;
+                                    defaultFontChanged = true;
                                 }
                                 else
                                 {
@@ -12675,22 +12645,25 @@ public unsafe partial class Control :
                         }
                         else // manually set font
                         {
-                            Font? oldFont = s_defaultFont;
+                            Font? previousDefaultFont = s_defaultFont;
                             Application.ScaleDefaultFont(); // will update Application.s_defaultFont or Application.s_defaultFontScaled only if needed
                             s_defaultFont = Application.DefaultFont; // Application.s_defaultFontScaled ?? Application.s_defaultFont
-                            fontChanged = oldFont != s_defaultFont;
+                            defaultFontChanged = !s_defaultFont.Equals(previousDefaultFont);
                         }
 
                         // When the system default font changes and controls are using it, notify them so that
                         // AutoScaleMode.Font can immediately re-scale controls and update their sizes without
                         // requiring an application restart.
-                        if (fontChanged)
+                        if (defaultFontChanged)
                         {
-                            // Invalidate the cached default font handle so it gets recreated from the new font.
                             s_defaultFontHandleWrapper?.Dispose();
                             s_defaultFontHandleWrapper = null;
+                        }
 
-                            OnSystemFontChanged();
+                        if (defaultFontChanged && !TryGetExplicitlySetFont(out _))
+                        {
+                            DisposeFontHandle();
+                            OnFontChanged(EventArgs.Empty);
                         }
                     }
                 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Control.cs
@@ -12262,6 +12262,36 @@ public unsafe partial class Control :
     }
 
     /// <summary>
+    ///  Called when the system default font has changed (e.g. via Accessibility → Text Size in Windows Settings).
+    ///  Notifies this control and all descendants that use the default font so that they update their font handle
+    ///  and raise <see cref="OnFontChanged"/>, which in turn causes <see cref="ContainerControl"/> to invoke
+    ///  <see cref="ContainerControl.PerformAutoScale"/> and resize controls immediately without an app restart.
+    ///  Controls that have an explicitly set font are intentionally skipped.
+    /// </summary>
+    private void OnSystemFontChanged()
+    {
+        // Only notify controls that are using the ambient/default font — i.e., no explicit font was set.
+        if (!IsFontSet())
+        {
+            // Discard the per-control cached font handle so it is recreated from the updated default font.
+            DisposeFontHandle();
+
+            // Raising OnFontChanged will clear _currentAutoScaleDimensions in ContainerControl and trigger
+            // PerformAutoScale, which recalculates AutoScaleFactor and resizes all child controls.
+            OnFontChanged(EventArgs.Empty);
+        }
+
+        // Propagate to all immediate children regardless; each child decides for itself whether to act.
+        if (ChildControls is { } children)
+        {
+            for (int i = 0; i < children.Count; i++)
+            {
+                children[i].OnSystemFontChanged();
+            }
+        }
+    }
+
+    /// <summary>
     ///  Processes Windows messages.
     /// </summary>
     /// <remarks>
@@ -12626,6 +12656,7 @@ public unsafe partial class Control :
                         // s_defaultFont = Application.DefaultFont ?? SystemFonts.MessageBoxFont;
                         // So we need to check both variants - manually set font (Application.DefaultFont is not null) and auto system font
 
+                        bool fontChanged = false;
                         if (Application.DefaultFont is null) // auto system font
                         {
                             if (s_defaultFont is not null) // we need to check only if s_defaultFont already set
@@ -12634,6 +12665,7 @@ public unsafe partial class Control :
                                 if (!s_defaultFont.Equals(font)) // the font has changed
                                 {
                                     s_defaultFont = font;
+                                    fontChanged = true;
                                 }
                                 else
                                 {
@@ -12643,8 +12675,22 @@ public unsafe partial class Control :
                         }
                         else // manually set font
                         {
+                            Font? oldFont = s_defaultFont;
                             Application.ScaleDefaultFont(); // will update Application.s_defaultFont or Application.s_defaultFontScaled only if needed
                             s_defaultFont = Application.DefaultFont; // Application.s_defaultFontScaled ?? Application.s_defaultFont
+                            fontChanged = oldFont != s_defaultFont;
+                        }
+
+                        // When the system default font changes and controls are using it, notify them so that
+                        // AutoScaleMode.Font can immediately re-scale controls and update their sizes without
+                        // requiring an application restart.
+                        if (fontChanged)
+                        {
+                            // Invalidate the cached default font handle so it gets recreated from the new font.
+                            s_defaultFontHandleWrapper?.Dispose();
+                            s_defaultFontHandleWrapper = null;
+
+                            OnSystemFontChanged();
                         }
                     }
                 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes https://github.com/dotnet/winforms/issues/3583


## Proposed changes
- Updated default font change handling to react when the system/default font changes at runtime.
- Cleared cached default/control font handles before raising `OnFontChanged`.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- WinForms apps using inherited/default fonts now refresh more reliably when system text size/font changes.
- Reduces inconsistent UI states where text updates but controls do not visually refresh correctly until restart.

## Regression? 

- No

## Risk

- Low to medium: touches runtime font-change handling, but only for controls using the default/inherited font path.

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
<img width="444" height="348" alt="image" src="https://github.com/user-attachments/assets/9e04c0af-907b-45a4-b211-35eaf2e42c79" />

### After
<img width="601" height="454" alt="image" src="https://github.com/user-attachments/assets/f79751cc-9da4-4dfa-a71c-c5b35afb0b6c" />

## Test methodology <!-- How did you ensure quality? -->
- Verified behavior manually with a WinForms sample using `AutoScaleMode.Font`.
- Tested runtime increase/decrease of system text size/font and observed control refresh behavior.
- Confirmed explicitly set control fonts are not affected by the default/inherited font update path.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- No accessibility behavior change expected. This change only updates runtime font refresh behavior for controls using the default/inherited font.

## Test environment(s)

- Windows 11
- .NET SDK: 11.0.100-preview.3.26170.106
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14748)