### PR TITLE
Fix Button click after Dark to Light color mode switch

### DIFF
--- a/src/System.Windows.Forms/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+override System.Windows.Forms.ButtonBase.OnSystemColorsChanged(System.EventArgs! e) -> void

--- a/src/System.Windows.Forms/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Control.cs
@@ -12608,6 +12608,12 @@ public unsafe partial class Control :
 
                     // Left here for debugging purposes.
                     // string? text = m.LParamInternal == 0 ? null : new((char*)m.LParamInternal);
+                    if (m.LParamInternal != 0
+                        && Application.ColorModeSet
+                        && new string((char*)m.LParamInternal) is "ImmersiveColorSet")
+                    {
+                        OnSystemColorsChanged(EventArgs.Empty);
+                    }
 
                     if (action is SYSTEM_PARAMETERS_INFO_ACTION.SPI_SETNONCLIENTMETRICS && m.LParamInternal == 0)
                     {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonBase.cs
@@ -1429,5 +1429,54 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
                     break;
             }
         }
+
+        // WM_SETTINGCHANGE is handled outside the OwnerDraw branches so that theme updates
+        // are applied regardless of the current FlatStyle or dark-mode render path.
+        if (m.MsgInternal == PInvokeCore.WM_SETTINGCHANGE && IsImmersiveColorSet(m.LParamInternal))
+        {
+            ApplyDarkModeOnDemand();
+        }
+
+        base.WndProc(ref m);
+    }
+
+    /// <summary>
+    ///  Returns <see langword="true"/> if the <see cref="PInvokeCore.WM_SETTINGCHANGE"/>
+    ///  message signals an immersive color-set change (i.e. the user toggled dark/light mode).
+    /// </summary>
+    private static unsafe bool IsImmersiveColorSet(IntPtr lParam)
+        => lParam != IntPtr.Zero
+            && new string((char*)lParam).Equals("ImmersiveColorSet", StringComparison.Ordinal);
+
+    /// <summary>
+    ///  Applies the button theme for the current color mode and repaints the control.
+    /// </summary>
+    private void ApplyDarkModeOnDemand()
+    {
+        if (!IsHandleCreated)
+        {
+            return;
+        }
+
+        PInvoke.SetWindowTheme(
+            HWND,
+            Application.IsDarkModeEnabled ? $"{DarkModeIdentifier}_{ExplorerThemeIdentifier}" : null,
+            pszSubIdList: null);
+
+        Invalidate();
+    }
+
+    /// <inheritdoc cref="Control.OnHandleCreated(EventArgs)"/>
+    protected override void OnHandleCreated(EventArgs e)
+    {
+        base.OnHandleCreated(e);
+
+        // base.OnHandleCreated already applies SetWindowTheme for dark mode (both initial
+        // creation and handle recreation). Only call ApplyDarkModeOnDemand when in light
+        // mode to ensure a previously applied dark theme is reset on handle recreation.
+        if (!Application.IsDarkModeEnabled)
+        {
+            ApplyDarkModeOnDemand();
+        }
     }
 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonBase.cs
@@ -1306,6 +1306,12 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
         }
     }
 
+    protected override void OnSystemColorsChanged(EventArgs e)
+    {
+        UpdateOwnerDraw();
+        base.OnSystemColorsChanged(e);
+    }
+
     /// <summary>
     ///  Determines whether to use compatible text rendering engine (GDI+) or not (GDI).
     /// </summary>
@@ -1428,55 +1434,6 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
                     base.WndProc(ref m);
                     break;
             }
-        }
-
-        // WM_SETTINGCHANGE is handled outside the OwnerDraw branches so that theme updates
-        // are applied regardless of the current FlatStyle or dark-mode render path.
-        if (m.MsgInternal == PInvokeCore.WM_SETTINGCHANGE && IsImmersiveColorSet(m.LParamInternal))
-        {
-            ApplyDarkModeOnDemand();
-        }
-
-        base.WndProc(ref m);
-    }
-
-    /// <summary>
-    ///  Returns <see langword="true"/> if the <see cref="PInvokeCore.WM_SETTINGCHANGE"/>
-    ///  message signals an immersive color-set change (i.e. the user toggled dark/light mode).
-    /// </summary>
-    private static unsafe bool IsImmersiveColorSet(IntPtr lParam)
-        => lParam != IntPtr.Zero
-            && new string((char*)lParam).Equals("ImmersiveColorSet", StringComparison.Ordinal);
-
-    /// <summary>
-    ///  Applies the button theme for the current color mode and repaints the control.
-    /// </summary>
-    private void ApplyDarkModeOnDemand()
-    {
-        if (!IsHandleCreated)
-        {
-            return;
-        }
-
-        PInvoke.SetWindowTheme(
-            HWND,
-            Application.IsDarkModeEnabled ? $"{DarkModeIdentifier}_{ExplorerThemeIdentifier}" : null,
-            pszSubIdList: null);
-
-        Invalidate();
-    }
-
-    /// <inheritdoc cref="Control.OnHandleCreated(EventArgs)"/>
-    protected override void OnHandleCreated(EventArgs e)
-    {
-        base.OnHandleCreated(e);
-
-        // base.OnHandleCreated already applies SetWindowTheme for dark mode (both initial
-        // creation and handle recreation). Only call ApplyDarkModeOnDemand when in light
-        // mode to ensure a previously applied dark theme is reset on handle recreation.
-        if (!Application.IsDarkModeEnabled)
-        {
-            ApplyDarkModeOnDemand();
         }
     }
 }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ButtonBaseTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ButtonBaseTests.cs
@@ -9246,6 +9246,51 @@ public class ButtonBaseTests : AbstractButtonBaseTests
         Assert.Equal(0, createdCallCount);
     }
 
+    [WinFormsFact]
+    public static void ButtonBase_OnSystemColorsChanged_StandardFlatStyle_RestoresOwnerDraw()
+    {
+        using SubButtonBase control = new()
+        {
+            FlatStyle = FlatStyle.Standard
+        };
+
+        control.SetUserPaintAndUserMouseStyles(false);
+
+        Assert.False(control.GetUserPaintStyle());
+        Assert.False(control.GetUserMouseStyle());
+
+        control.OnSystemColorsChangedEntry(EventArgs.Empty);
+
+        Assert.True(control.GetUserPaintStyle());
+        Assert.True(control.GetUserMouseStyle());
+    }
+
+    [WinFormsFact]
+    public static void ButtonBase_OnSystemColorsChanged_SystemFlatStyle_ClassicMode_ClearsOwnerDraw()
+    {
+        RemoteExecutor.Invoke(static () =>
+        {
+#pragma warning disable WFO5001
+            Application.SetColorMode(SystemColorMode.Classic);
+#pragma warning restore WFO5001
+
+            using SubButtonBase control = new()
+            {
+                FlatStyle = FlatStyle.System
+            };
+
+            control.SetUserPaintAndUserMouseStyles(true);
+
+            Assert.True(control.GetUserPaintStyle());
+            Assert.True(control.GetUserMouseStyle());
+
+            control.OnSystemColorsChangedEntry(EventArgs.Empty);
+
+            Assert.False(control.GetUserPaintStyle());
+            Assert.False(control.GetUserMouseStyle());
+        }).Dispose();
+    }
+
     private class SubButton : Button
     {
         public new bool GetStyle(ControlStyles flag) => base.GetStyle(flag);
@@ -9377,6 +9422,17 @@ public class ButtonBaseTests : AbstractButtonBaseTests
         public new void SetStyle(ControlStyles flag, bool value) => base.SetStyle(flag, value);
 
         public new void WndProc(ref Message m) => base.WndProc(ref m);
+        
+        public void OnSystemColorsChangedEntry(EventArgs e) => OnSystemColorsChanged(e);
+
+        public bool GetUserPaintStyle() => GetStyle(ControlStyles.UserPaint);
+
+        public bool GetUserMouseStyle() => GetStyle(ControlStyles.UserMouse);
+
+        public void SetUserPaintAndUserMouseStyles(bool value)
+        {
+            SetStyle(ControlStyles.UserPaint | ControlStyles.UserMouse, value);
+        }
     }
 
     protected override ButtonBase CreateButton() => new Button();

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ControlTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ControlTests.cs
@@ -1201,6 +1201,54 @@ public partial class ControlTests
         control.Region.Should().BeNull();
     }
 
+    [WinFormsFact]
+    public static void Control_WndProc_WM_SETTINGCHANGE_ImmersiveColorSet_RaisesSystemColorsChanged()
+    {
+        RemoteExecutor.Invoke(static () =>
+        {
+#pragma warning disable WFO5001
+            Application.SetColorMode(SystemColorMode.System);
+#pragma warning restore WFO5001
+
+            using SubSystemColorsChangedForm form = new();
+
+            int systemColorsChangedCallCount = 0;
+            form.SystemColorsChanged += (_, _) => systemColorsChangedCallCount++;
+
+            Assert.NotEqual(IntPtr.Zero, form.Handle);
+
+            form.SendWmSettingChange("ImmersiveColorSet");
+
+            Assert.Equal(1, systemColorsChangedCallCount);
+            Assert.Equal(1, form.OnSystemColorsChangedCallCount);
+        }).Dispose();
+    }
+
+    private class SubSystemColorsChangedForm : Form
+    {
+        public int OnSystemColorsChangedCallCount { get; private set; }
+
+        public unsafe void SendWmSettingChange(string settingName)
+        {
+            fixed (char* settingNamePtr = settingName)
+            {
+                Message message = Message.Create(
+                    Handle,
+                    (int)PInvokeCore.WM_SETTINGCHANGE,
+                    wparam: IntPtr.Zero,
+                    lparam: (IntPtr)settingNamePtr);
+
+                WndProc(ref message);
+            }
+        }
+
+        protected override void OnSystemColorsChanged(EventArgs e)
+        {
+            OnSystemColorsChangedCallCount++;
+            base.OnSystemColorsChanged(e);
+        }
+    }
+
     private class OnCreateControlCounter : Control
     {
         public int OnCreateControlCount { get; set; }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes https://github.com/dotnet/winforms/issues/13636


## Proposed changes

- Handle `WM_SETTINGCHANGE` with `ImmersiveColorSet` in `Control.WndProc`.
- Raise `OnSystemColorsChanged` when the application color mode is set and the OS dark/light mode changes.
- Update `ButtonBase.OnSystemColorsChanged` to refresh the owner-draw state.
- Ensure `Button`, `CheckBox`, and `RadioButton` update their dark-mode rendering path after OS color mode changes.

### Root cause

- When the application starts in Dark mode, button-based controls initialize their rendering path based on the current dark-mode state.
- When the OS color mode changes from Dark to Light while the application is running, WinForms receives `WM_SETTINGCHANGE` with `ImmersiveColorSet`.
- This message was not updating the ButtonBase owner-draw state.
- As a result, ButtonBase-derived controls could remain in an outdated rendering state after the OS color mode changed.
- This caused `Button.Click` to stop firing in the Dark-to-Light transition scenario.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Fixes an issue where `Button.Click` stops working after switching the Windows OS color mode from Dark to Light.
- Ensures ButtonBase-derived controls correctly refresh their rendering state when the OS color mode changes.
- Improves dark-mode transition behavior for `Button`, `CheckBox`, and `RadioButton`.
- Preserves existing behavior for unrelated system setting changes.

## Regression? 

- No

## Risk

- Low.
- The change is limited to handling `ImmersiveColorSet` system setting changes and refreshing ButtonBase owner-draw state.
- Existing `WM_SETTINGCHANGE` behavior is preserved for unrelated settings.
- The fix uses the existing `OnSystemColorsChanged` flow instead of adding separate Button-specific system message handling.
- The update applies only when application color mode has been configured.

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

https://github.com/user-attachments/assets/d246fe8c-63dd-48ab-b8ac-ac3e3e672fc6


### After

https://github.com/user-attachments/assets/5b03ca81-c8bd-4e4c-8e87-4c4cd63a9d18


## Test methodology <!-- How did you ensure quality? -->

- Reproduced the issue with `Application.SetColorMode(SystemColorMode.System)`.
- Verified the issue occurs when:
  - Windows starts in Dark mode.
  - The application starts in Dark mode.
  - Windows color mode is switched from Dark to Light.
  - Button click stops working before the fix.
- Verified that after the fix, Button click continues to work after the Dark-to-Light transition.
- Verified Light-to-Dark transition continues to work.
- Verified the fix across ButtonBase-derived controls:
  - `Button`
  - `CheckBox`
  - `RadioButton`
- Verified multiple `FlatStyle` values:
  - `Standard`
  - `System`
  - `Flat`
  - `Popup`
- Verified owner-draw and non-owner-draw paths.
- Added unit test coverage for `WM_SETTINGCHANGE` with `ImmersiveColorSet`.
- Added unit test coverage to ensure `ButtonBase` refreshes owner-draw state on system color changes.
- Ran related WinForms unit tests to ensure no regressions were introduced.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.100-preview.5.26302.115

<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14785)