### PR TITLE
Fix issue 14807: CheckBox/RadioButton: ToggleSwitch renders black background when BackColor is Transparent

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/CheckBoxModernAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/CheckBoxModernAdapter.cs
@@ -1,4 +1,4 @@
-﻿﻿// Licensed to the .NET Foundation under one or more agreements.
+﻿﻿﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/CheckBoxModernAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/CheckBoxModernAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+﻿﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/CheckBoxModernAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/CheckBoxModernAdapter.cs
@@ -1,4 +1,4 @@
-﻿﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/CheckBoxModernAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/CheckBoxModernAdapter.cs
@@ -1,4 +1,4 @@
-﻿﻿﻿﻿// Licensed to the .NET Foundation under one or more agreements.
+﻿﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/CheckBoxModernAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/CheckBoxModernAdapter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
@@ -91,8 +91,9 @@ internal sealed class CheckBoxModernAdapter : CheckBoxBaseAdapter
         PaintBackgroundImage(e);
 
         Color? customOnColor = Control.ShouldSerializeBackColor()
-            ? Control.BackColor
-            : null;
+            && Control.BackColor.A == byte.MaxValue
+                ? Control.BackColor
+                : null;
 
         Color? customBorderColor = Control.FlatAppearance.BorderColor.IsEmpty
             ? null

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/CheckBoxModernAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/CheckBoxModernAdapter.cs
@@ -1,4 +1,4 @@
-﻿﻿﻿// Licensed to the .NET Foundation under one or more agreements.
+﻿﻿﻿﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/RadioButtonModernAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/RadioButtonModernAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/RadioButtonModernAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/RadioButtonModernAdapter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
@@ -90,8 +90,9 @@ internal sealed class RadioButtonModernAdapter : RadioButtonBaseAdapter
         PaintBackgroundImage(e);
 
         Color? customOnColor = Control.ShouldSerializeBackColor()
-            ? Control.BackColor
-            : null;
+            && Control.BackColor.A == byte.MaxValue
+                ? Control.BackColor
+                : null;
 
         Color? customBorderColor = Control.FlatAppearance.BorderColor.IsEmpty
             ? null

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
@@ -88,7 +88,7 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
             metrics,
             textSize);
 
-        graphics.Clear(Control.BackColor);
+        PaintControlBackground(graphics);
 
         if (contentBounds.Width <= 0 || contentBounds.Height <= 0)
         {
@@ -327,6 +327,25 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
         _onAmountStart = _onAmountCurrent;
         _onAmountTarget = _onAmountCurrent;
         _positionInitialized = true;
+    }
+
+    private void PaintControlBackground(Graphics graphics)
+    {
+        if (Control.BackgroundImage is null && !Control.BackColor.HasTransparency())
+        {
+            graphics.Clear(Control.BackColor);
+            return;
+        }
+
+        Rectangle clipRectangle = Rectangle.Ceiling(graphics.ClipBounds);
+        clipRectangle.Intersect(Control.ClientRectangle);
+        if (clipRectangle.Width <= 0 || clipRectangle.Height <= 0)
+        {
+            return;
+        }
+
+        using PaintEventArgs paintEventArgs = new(graphics, clipRectangle);
+        Control.PaintBackground(paintEventArgs, clipRectangle);
     }
 
     private static float EaseOut(float value)

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
@@ -218,7 +218,7 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
         Color circleColor = Control.Enabled
             ? highContrast
                 ? highContrastForeground
-                : PopupButtonColorMath.GetReadableForeColor(offColor, onColor)
+                : PopupButtonColorMath.GetReadableForeColor(backgroundColor)
             : SystemColors.GrayText;
         circleColor = ApplyInteractionShade(circleColor, focus);
         borderColor = ApplyInteractionShade(borderColor, focus);

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/RadioButton/AnimatedRadioGlyphRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/RadioButton/AnimatedRadioGlyphRenderer.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/RadioButton/AnimatedRadioGlyphRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/RadioButton/AnimatedRadioGlyphRenderer.cs
@@ -123,10 +123,10 @@ internal sealed class AnimatedRadioGlyphRenderer : AnimatedControlRenderer
         borderColor = ApplyInteractionShade(borderColor, focus);
         backColor = ApplyInteractionShade(backColor, focus);
 
-        // Blend the outer circle toward the accent as checked progress advances so the checked
-        // surface follows the current personalization color, matching modern checkbox behavior.
+        // Blend the outer circle toward the accent based on animated checked progress
+        // (_dotScaleCurrent), so check and uncheck transitions stay smooth and symmetric.
         float checkedProgress = Math.Clamp(
-            Math.Max(_dotScaleCurrent, _dotScaleTarget),
+            _dotScaleCurrent,
             0f,
             1f);
         Color activeBackColor = LerpColor(backColor, onColor, checkedProgress);

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/RadioButton/AnimatedRadioGlyphRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/RadioButton/AnimatedRadioGlyphRenderer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
@@ -123,6 +123,15 @@ internal sealed class AnimatedRadioGlyphRenderer : AnimatedControlRenderer
         borderColor = ApplyInteractionShade(borderColor, focus);
         backColor = ApplyInteractionShade(backColor, focus);
 
+        // Blend the outer circle toward the accent as checked progress advances so the checked
+        // surface follows the current personalization color, matching modern checkbox behavior.
+        float checkedProgress = Math.Clamp(
+            Math.Max(_dotScaleCurrent, _dotScaleTarget),
+            0f,
+            1f);
+        Color activeBackColor = LerpColor(backColor, onColor, checkedProgress);
+        Color activeBorderColor = LerpColor(borderColor, onColor, checkedProgress);
+
         float normalOuterScale = 1f / HoverGrowth;
         float outerScale = Lerp(normalOuterScale, 1f, enabled ? _hoverCurrent : 0f);
         RectangleF outerBounds = ScaleFromCenter(bounds, outerScale);
@@ -133,7 +142,7 @@ internal sealed class AnimatedRadioGlyphRenderer : AnimatedControlRenderer
         {
             graphics.SmoothingMode = SmoothingMode.AntiAlias;
 
-            using (var brush = backColor.GetCachedSolidBrushScope())
+            using (var brush = activeBackColor.GetCachedSolidBrushScope())
             {
                 graphics.FillEllipse(brush, outerBounds);
             }
@@ -142,7 +151,7 @@ internal sealed class AnimatedRadioGlyphRenderer : AnimatedControlRenderer
                 1,
                 Control.LogicalToDeviceUnits(flatStyle == FlatStyle.Popup ? 2 : 1));
 
-            using (var pen = new Pen(borderColor, borderThickness))
+            using (var pen = new Pen(activeBorderColor, borderThickness))
             {
                 graphics.DrawEllipse(pen, outerBounds);
             }
@@ -156,22 +165,11 @@ internal sealed class AnimatedRadioGlyphRenderer : AnimatedControlRenderer
                     dotDiameter,
                     dotDiameter);
 
-                Color dotOutlineColor = highContrast
+                Color dotColor = highContrast
                     ? SystemColors.HighlightText
-                    : PopupButtonColorMath.GetReadableForeColor(onColor, backColor);
-                int outlineThickness = Math.Max(1, Control.LogicalToDeviceUnits(1));
-                using var outlineBrush = dotOutlineColor.GetCachedSolidBrushScope();
-                graphics.FillEllipse(outlineBrush, dotRectangle);
-
-                RectangleF accentRectangle = RectangleF.Inflate(
-                    dotRectangle,
-                    -outlineThickness,
-                    -outlineThickness);
-                if (accentRectangle.Width > 0 && accentRectangle.Height > 0)
-                {
-                    using var dotBrush = onColor.GetCachedSolidBrushScope();
-                    graphics.FillEllipse(dotBrush, accentRectangle);
-                }
+                    : PopupButtonColorMath.GetReadableForeColor(onColor);
+                using var dotBrush = dotColor.GetCachedSolidBrushScope();
+                graphics.FillEllipse(dotBrush, dotRectangle);
             }
         }
         finally
@@ -225,6 +223,20 @@ internal sealed class AnimatedRadioGlyphRenderer : AnimatedControlRenderer
 
     private static float Lerp(float from, float to, float progress)
         => from + ((to - from) * Math.Clamp(progress, 0f, 1f));
+
+    private static Color LerpColor(Color from, Color to, float progress)
+    {
+        progress = Math.Clamp(progress, 0f, 1f);
+
+        return Color.FromArgb(
+            LerpChannel(from.A, to.A, progress),
+            LerpChannel(from.R, to.R, progress),
+            LerpChannel(from.G, to.G, progress),
+            LerpChannel(from.B, to.B, progress));
+
+        static int LerpChannel(int from, int to, float progress)
+            => from + (int)((to - from) * progress);
+    }
 
     private static RectangleF ScaleFromCenter(Rectangle bounds, float scale)
     {

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/TextRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/TextRenderer.cs
@@ -632,15 +632,15 @@ public static class TextRenderer
             // translation (rotation for example), and this likely impacted the decision to only have a translation
             // flag when this was originally written.
 
-            Debug.Assert(apply.HasFlag(ApplyGraphicsProperties.Clipping)
-               || graphics.Clip is null
-               || graphics.Clip.GetHrgn(graphics) == IntPtr.Zero,
-               "Must preserve Graphics clipping region!");
+            // Debug.Assert(apply.HasFlag(ApplyGraphicsProperties.Clipping)
+            //   || graphics.Clip is null
+            //   || graphics.Clip.GetHrgn(graphics) == IntPtr.Zero,
+            //   "Must preserve Graphics clipping region!");
 
-            Debug.Assert(apply.HasFlag(ApplyGraphicsProperties.TranslateTransform)
-               || graphics.Transform is null
-               || graphics.Transform.IsIdentity,
-               "Must preserve Graphics transformation!");
+            // Debug.Assert(apply.HasFlag(ApplyGraphicsProperties.TranslateTransform)
+            //   || graphics.Transform is null
+            //   || graphics.Transform.IsIdentity,
+            //   "Must preserve Graphics transformation!");
         }
 #endif
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/TextRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/TextRenderer.cs
@@ -632,15 +632,15 @@ public static class TextRenderer
             // translation (rotation for example), and this likely impacted the decision to only have a translation
             // flag when this was originally written.
 
-            // Debug.Assert(apply.HasFlag(ApplyGraphicsProperties.Clipping)
-            //   || graphics.Clip is null
-            //   || graphics.Clip.GetHrgn(graphics) == IntPtr.Zero,
-            //   "Must preserve Graphics clipping region!");
+            Debug.Assert(apply.HasFlag(ApplyGraphicsProperties.Clipping)
+              || graphics.Clip is null
+              || graphics.Clip.GetHrgn(graphics) == IntPtr.Zero,
+              "Must preserve Graphics clipping region!");
 
-            // Debug.Assert(apply.HasFlag(ApplyGraphicsProperties.TranslateTransform)
-            //   || graphics.Transform is null
-            //   || graphics.Transform.IsIdentity,
-            //   "Must preserve Graphics transformation!");
+            Debug.Assert(apply.HasFlag(ApplyGraphicsProperties.TranslateTransform)
+              || graphics.Transform is null
+              || graphics.Transform.IsIdentity,
+              "Must preserve Graphics transformation!");
         }
 #endif
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/TextRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/TextRenderer.cs
@@ -633,14 +633,14 @@ public static class TextRenderer
             // flag when this was originally written.
 
             Debug.Assert(apply.HasFlag(ApplyGraphicsProperties.Clipping)
-              || graphics.Clip is null
-              || graphics.Clip.GetHrgn(graphics) == IntPtr.Zero,
-              "Must preserve Graphics clipping region!");
+               || graphics.Clip is null
+               || graphics.Clip.GetHrgn(graphics) == IntPtr.Zero,
+               "Must preserve Graphics clipping region!");
 
             Debug.Assert(apply.HasFlag(ApplyGraphicsProperties.TranslateTransform)
-              || graphics.Transform is null
-              || graphics.Transform.IsIdentity,
-              "Must preserve Graphics transformation!");
+               || graphics.Transform is null
+               || graphics.Transform.IsIdentity,
+               "Must preserve Graphics transformation!");
         }
 #endif
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/CheckBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/CheckBoxTests.cs
@@ -625,7 +625,43 @@ public class CheckBoxTests : AbstractButtonBaseTests
     }
 
     [WinFormsFact]
-    public void CheckBox_ModernGlyph_BrightAccentUsesReadableCheckmark()
+    public void CheckBox_ModernGlyph_TransparentBackColor_CheckedUsesWindowsAccent()
+    {
+        if (SystemInformation.HighContrast)
+        {
+            return;
+        }
+
+        using Panel parent = new() { BackColor = Color.White };
+        using CheckBox box = new()
+        {
+            BackColor = Color.Transparent,
+            CheckState = CheckState.Checked,
+            Size = new Size(40, 24),
+            VisualStylesMode = VisualStylesMode.Net11
+        };
+        parent.Controls.Add(box);
+
+        using Bitmap bitmap = new(box.Width, box.Height);
+        using Graphics graphics = Graphics.FromImage(bitmap);
+        PaintEventArgs e = new(graphics, box.ClientRectangle);
+
+        box.CreateStandardAdapter().PaintUp(e, box.CheckState);
+
+        Assert.True(CountPixels(bitmap, Application.SystemVisualSettings.AccentColor) > 0);
+    }
+
+    [WinFormsTheory]
+    [InlineData(0xFF, 0xB9, 0x00, 0, 0, 0)]
+    [InlineData(0x00, 0x66, 0xCC, 255, 255, 255)]
+    [InlineData(0x4D, 0x4D, 0x4D, 255, 255, 255)]
+    public void CheckBox_ModernGlyph_AccentUsesReadableCheckmark(
+        int accentR,
+        int accentG,
+        int accentB,
+        int expectedR,
+        int expectedG,
+        int expectedB)
     {
         if (SystemInformation.HighContrast)
         {
@@ -637,7 +673,7 @@ public class CheckBoxTests : AbstractButtonBaseTests
         renderer.NotifyCheckStateChanged(CheckState.Checked);
         using Bitmap bitmap = new(24, 24);
         using Graphics graphics = Graphics.FromImage(bitmap);
-        Color brightAccent = Color.FromArgb(0xFF, 0xB9, 0x00);
+        Color accent = Color.FromArgb(accentR, accentG, accentB);
 
         renderer.DrawGlyph(
             graphics,
@@ -646,10 +682,10 @@ public class CheckBoxTests : AbstractButtonBaseTests
             enabled: true,
             hovered: false,
             focused: false,
-            customOnColor: brightAccent,
+            customOnColor: accent,
             customBorderColor: null);
 
-        Assert.True(CountPixels(bitmap, Color.Black) > 0);
+        Assert.True(CountPixels(bitmap, Color.FromArgb(expectedR, expectedG, expectedB)) > 0);
     }
 
     [WinFormsFact]
@@ -829,6 +865,35 @@ public class CheckBoxTests : AbstractButtonBaseTests
         renderer.RenderControl(graphics);
 
         Assert.True(CountPixels(bitmap, Application.SystemVisualSettings.AccentColor) > 0);
+    }
+
+    [WinFormsFact]
+    public void CheckBox_ToggleSwitch_DarkAccentUsesReadableThumbColor()
+    {
+        if (SystemInformation.HighContrast)
+        {
+            return;
+        }
+
+        using SystemVisualSettingsTestScope settingsScope =
+            new(clientAreaAnimationEnabled: true, accentColor: Color.FromArgb(0x4D, 0x4D, 0x4D));
+        using CheckBox box = new()
+        {
+            Appearance = Appearance.ToggleSwitch,
+            BackColor = Color.Black,
+            Checked = true,
+            Size = new Size(60, 24),
+            VisualStylesMode = VisualStylesMode.Net11
+        };
+        Rendering.CheckBox.AnimatedToggleSwitchRenderer renderer =
+            box.TestAccessor.Dynamic.ToggleSwitchRenderer;
+        renderer.SynchronizeState();
+        using Bitmap bitmap = new(box.Width, box.Height);
+        using Graphics graphics = Graphics.FromImage(bitmap);
+
+        renderer.RenderControl(graphics);
+
+        Assert.True(CountPixels(bitmap, Color.White) > 0);
     }
 
     [WinFormsFact]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/CheckBoxToggleSwitchTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/CheckBoxToggleSwitchTests.cs
@@ -226,4 +226,30 @@ public class CheckBoxToggleSwitchTests
 
         Assert.Equal(VisualStylesMode.Inherit, checkBox.VisualStylesMode);
     }
+
+    [WinFormsTheory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CheckBox_ToggleSwitch_TransparentBackColor_DoesNotThrow(bool useBackgroundImage)
+    {
+        using SystemVisualSettingsTestScope settingsScope = new(
+            clientAreaAnimationEnabled: false,
+            highContrastEnabled: false);
+        using Bitmap backgroundImage = new(10, 10);
+        using Panel parent = new() { BackColor = Color.LightBlue, Size = new Size(200, 100) };
+        using CheckBox checkBox = new()
+        {
+            Parent = parent,
+            Appearance = Appearance.ToggleSwitch,
+            VisualStylesMode = VisualStylesMode.Net11,
+            BackColor = Color.Transparent,
+            BackgroundImage = useBackgroundImage ? backgroundImage : null,
+            Size = new Size(140, 36),
+            Text = "Matrix"
+        };
+        parent.CreateControl();
+        using Bitmap bitmap = new(checkBox.Width, checkBox.Height);
+
+        checkBox.DrawToBitmap(bitmap, new Rectangle(Point.Empty, checkBox.Size));
+    }
 }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/RadioButtonTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/RadioButtonTests.cs
@@ -265,7 +265,47 @@ public class RadioButtonTests : AbstractButtonBaseTests
     }
 
     [WinFormsFact]
-    public void RadioButton_ModernGlyph_BrightAccentUsesContrastingDotOutline()
+    public void RadioButton_ModernGlyph_TransparentBackColor_CheckedUsesWindowsAccent()
+    {
+        if (SystemInformation.HighContrast)
+        {
+            return;
+        }
+
+        using Panel parent = new() { BackColor = Color.White };
+        using RadioButton control = new()
+        {
+            BackColor = Color.Transparent,
+            Checked = true,
+            Size = new Size(40, 24),
+            VisualStylesMode = VisualStylesMode.Net11
+        };
+        parent.Controls.Add(control);
+
+        using Bitmap bitmap = new(control.Width, control.Height);
+        using Graphics graphics = Graphics.FromImage(bitmap);
+        PaintEventArgs e = new(graphics, control.ClientRectangle);
+
+        control.CreateStandardAdapter().PaintUp(e, CheckState.Checked);
+
+        Assert.True(
+            CountPixels(
+                bitmap,
+                Application.SystemVisualSettings.AccentColor,
+                channelTolerance: 24) > 0);
+    }
+
+    [WinFormsTheory]
+    [InlineData(0xFF, 0xB9, 0x00, 0, 0, 0)]
+    [InlineData(0x00, 0x66, 0xCC, 255, 255, 255)]
+    [InlineData(0x4D, 0x4D, 0x4D, 255, 255, 255)]
+    public void RadioButton_ModernGlyph_AccentUsesReadableDot(
+        int accentR,
+        int accentG,
+        int accentB,
+        int expectedR,
+        int expectedG,
+        int expectedB)
     {
         if (SystemInformation.HighContrast)
         {
@@ -277,7 +317,7 @@ public class RadioButtonTests : AbstractButtonBaseTests
         renderer.NotifyCheckedChanged(newChecked: true);
         using Bitmap bitmap = new(24, 24);
         using Graphics graphics = Graphics.FromImage(bitmap);
-        Color brightAccent = Color.FromArgb(0xFF, 0xB9, 0x00);
+        Color accent = Color.FromArgb(accentR, accentG, accentB);
 
         renderer.DrawGlyph(
             graphics,
@@ -286,10 +326,10 @@ public class RadioButtonTests : AbstractButtonBaseTests
             enabled: true,
             hovered: false,
             focused: false,
-            customOnColor: brightAccent,
+            customOnColor: accent,
             customBorderColor: null);
 
-        Assert.True(CountPixels(bitmap, Color.Black) > 0);
+        Assert.True(CountPixels(bitmap, Color.FromArgb(expectedR, expectedG, expectedB)) > 0);
     }
 
     [WinFormsFact]
@@ -331,15 +371,20 @@ public class RadioButtonTests : AbstractButtonBaseTests
     }
 
     private static int CountPixels(Bitmap bitmap, Color color)
+        => CountPixels(bitmap, color, channelTolerance: 0);
+
+    private static int CountPixels(Bitmap bitmap, Color color, int channelTolerance)
     {
-        int argb = color.ToArgb();
         int count = 0;
 
         for (int y = 0; y < bitmap.Height; y++)
         {
             for (int x = 0; x < bitmap.Width; x++)
             {
-                if (bitmap.GetPixel(x, y).ToArgb() == argb)
+                Color pixel = bitmap.GetPixel(x, y);
+                if (Math.Abs(pixel.R - color.R) <= channelTolerance
+                    && Math.Abs(pixel.G - color.G) <= channelTolerance
+                    && Math.Abs(pixel.B - color.B) <= channelTolerance)
                 {
                     count++;
                 }


### PR DESCRIPTION


<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14807 

## Root Cause

AnimatedToggleSwitchRenderer.RenderControl currently clears with graphics.Clear(Control.BackColor). This bypasses the normal WinForms background pipeline (parent background, transparent background, background image/custom-painted parent), which can cause visual regressions on complex backgrounds.
Using the standard WinForms background painting path (e.g., Control.PaintBackground(...) with PaintEventArgs and ClientRectangle) instead of direct Clear. That preserves both:

parent/transparent background semantics, and
proper BackColor blending behavior (including semi-transparent colors).

## Proposed changes

Implemented a background-painting optimization in AnimatedToggleSwitchRenderer to balance rendering correctness and animation performance. Replaced the unconditional Control.PaintBackground(...) call with a new helper: PaintControlBackground(Graphics graphics).
- Added a fast path for the common case (BackgroundImage is null and opaque BackColor) to use graphics.Clear(Control.BackColor) and avoid per-frame PaintEventArgs allocation.
- Kept a fallback path for complex backgrounds (transparent back color or background image) that uses Control.PaintBackground(...) to preserve correct WinForms background behavior.
- In the fallback path, painting is limited to ClipBounds & ClientRectangle to reduce overdraw during animation.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

Improves rendering behavior and animation efficiency for ToggleSwitch-style CheckBox/RadioButton controls.
- Preserves correct background rendering in complex scenarios (transparent backgrounds and background images), reducing visual artifacts.
- Reduces per-frame overhead in common scenarios (opaque solid background), improving animation smoothness.

## Regression? 

- No

## Risk

- Mini

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<img width="1117" height="393" alt="image" src="https://github.com/user-attachments/assets/8d357dbf-6c5f-490d-ba9d-f1448e041c2b" />

### After

<img width="857" height="301" alt="image" src="https://github.com/user-attachments/assets/e88fe7f7-9cd6-48c8-95ac-4422a9c0f52c" />

**Light：**

https://github.com/user-attachments/assets/fdea8e71-03b7-4f0e-9a97-3ed871f8f649


https://github.com/user-attachments/assets/7f8698e1-ca2f-44cf-8527-8a1ac7ad1ca8

**DarkMode:**

https://github.com/user-attachments/assets/899607fd-372b-4d61-8e6d-964e262e1fb2

https://github.com/user-attachments/assets/a185033c-4d53-4205-8a0d-a5953a4124e1

## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.100-preview.5.26302.115


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14813)