### PR TITLE
Hide the VisualStylesModeChanged event of the PropertyGrid

### DIFF
--- a/src/System.Windows.Forms/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 static System.Windows.Forms.Application.SystemVisualSettings.get -> System.Windows.Forms.SystemVisualSettings!
 static System.Windows.Forms.Application.SystemVisualSettingsChanged -> System.Windows.Forms.SystemVisualSettingsChangedEventHandler?
+System.Windows.Forms.PropertyGrid.VisualStylesModeChanged -> System.EventHandler?
 virtual System.Windows.Forms.Control.OnSystemVisualSettingsChanged(System.Windows.Forms.SystemVisualSettingsChangedEventArgs! e) -> void
 System.Windows.Forms.Control.SystemVisualSettingsChanged -> System.Windows.Forms.SystemVisualSettingsChangedEventHandler?
 System.Windows.Forms.SystemVisualSettings.AccentColor.get -> System.Drawing.Color

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
@@ -856,6 +856,14 @@ public partial class PropertyGrid : ContainerControl, IComPropertyBrowser, IProp
         set => _requestedVisualStylesMode = value;
     }
 
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public new event EventHandler? VisualStylesModeChanged
+    {
+        add => base.VisualStylesModeChanged += value;
+        remove => base.VisualStylesModeChanged -= value;
+    }
+
     /// <summary>
     ///  Sets or gets the current property sort type, which can be
     ///  PropertySort.Categorized or PropertySort.Alphabetical.


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14803

## Root Cause

The `VisualStylesMode` property has been explicitly hidden in `PropertyGrid` (using attributes such as `[Browsable(false)]`), yet the corresponding `VisualStylesModeChanged` event remains visible in the designer's events window.


## Proposed changes

-  Added a hidden `VisualStylesModeChanged` event declaration in `PropertyGrid.cs`, consistent with the already hidden `VisualStylesMode` property.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Developers will not see the unavailable `VisualStylesModeChanged` event in the Events window when using the `PropertyGrid`

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
`PropertyGrid` hides the `VisualStylesMode` property, but the corresponding `VisualStylesModeChanged` event is still exposed in the Events window.

<img width="449" height="393" alt="Image" src="https://github.com/user-attachments/assets/2e980999-f99d-44a3-8e96-3e60847e583f" />

### After
`VisualStylesModeChanged` event is hidden in the Events window

<img width="838" height="330" alt="image" src="https://github.com/user-attachments/assets/0e16ff59-4ab0-4537-aecf-5f15cf5692d9" />


## Test methodology <!-- How did you ensure quality? -->

-  Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-preview.7.26365.101


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14814)