### PR TITLE
Fix issue 14808: CheckBox/RadioButton: ToggleSwitch overlaps text when RightToLeft is enabled and AutoSize is false

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
@@ -219,6 +219,16 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
 
     private TextFormatFlags GetTextFormatFlags() => Control switch
     {
+        Forms.CheckBox { FlatStyle: FlatStyle.System } checkBox => ControlPaint.CreateTextFormatFlags(
+            checkBox,
+            checkBox.TextAlign,
+            checkBox.ShowToolTip,
+            checkBox.UseMnemonic),
+        Forms.RadioButton { FlatStyle: FlatStyle.System } radioButton => ControlPaint.CreateTextFormatFlags(
+            radioButton,
+            radioButton.TextAlign,
+            radioButton.ShowToolTip,
+            radioButton.UseMnemonic),
         Forms.CheckBox checkBox => checkBox.CreateTextFormatFlags(),
         Forms.RadioButton radioButton => radioButton.CreateTextFormatFlags(),
         _ => TextFormatFlags.WordBreak | TextFormatFlags.TextBoxControl

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
@@ -77,14 +77,19 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
             focused: Control.Focused && ShowFocusCues);
 
         ToggleSwitchMetrics metrics = ToggleSwitchMetrics.Create(Control);
-        Size textSize = TextRenderer.MeasureText(Control.Text, Control.Font);
+        TextFormatFlags textFormatFlags = GetTextFormatFlags(Control);
+        Size textSize = MeasureText(Control, textFormatFlags);
         Rectangle contentBounds = ToggleSwitchMetrics.GetContentBounds(Control);
         Rectangle switchBounds = GetSwitchBounds(
             Control,
             RtlTranslatedCheckAlign,
             metrics,
             textSize);
-        Rectangle textBounds = GetTextBounds(contentBounds, switchBounds, metrics, RtlTranslatedCheckAlign);
+        Rectangle textBounds = GetTextBounds(
+            contentBounds,
+            switchBounds,
+            metrics,
+            RtlTranslatedCheckAlign);
 
         PaintControlBackground(graphics);
 
@@ -94,7 +99,7 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
         }
 
         RenderSwitch(graphics, switchBounds, metrics);
-        RenderText(graphics, textBounds);
+        RenderText(graphics, textBounds, textFormatFlags);
 
         if (Control.Focused && ShowFocusCues)
         {
@@ -138,11 +143,14 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
         Control control,
         ContentAlignment checkAlign,
         ToggleSwitchMetrics metrics)
-        => GetSwitchBounds(
+    {
+        TextFormatFlags textFormatFlags = GetTextFormatFlags(control);
+        return GetSwitchBounds(
             control,
             checkAlign,
             metrics,
-            TextRenderer.MeasureText(control.Text, control.Font));
+            MeasureText(control, textFormatFlags));
+    }
 
     private static Rectangle GetSwitchBounds(
         Control control,
@@ -170,7 +178,8 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
         ContentAlignment checkAlign,
         ToggleSwitchMetrics metrics)
     {
-        Size textSize = TextRenderer.MeasureText(control.Text, control.Font);
+        TextFormatFlags textFormatFlags = GetTextFormatFlags(control);
+        Size textSize = MeasureText(control, textFormatFlags);
         Rectangle contentBounds = ToggleSwitchMetrics.GetContentBounds(control);
         Rectangle switchBounds = GetSwitchBounds(control, checkAlign, metrics, textSize);
         return GetTextBounds(contentBounds, switchBounds, metrics, checkAlign);
@@ -182,31 +191,46 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
         ToggleSwitchMetrics metrics,
         ContentAlignment checkAlign)
     {
-        int thresholdExtension = Math.Max(1, metrics.BorderThickness / 2) + 1;
+        // Keep a small symmetric inset between the switch track and text to avoid visual collision
+        // with the rounded switch border in high DPI while preserving readability in narrow widths.
+        int textGapInset = GetSwitchTextInset(metrics);
+        int minimumTextGap = Math.Max(0, metrics.TextGap - textGapInset);
+
         if (IsSwitchOnRight(checkAlign))
         {
             int right = Math.Min(
                 contentBounds.Right,
-                switchBounds.Left - Math.Max(0, metrics.TextGap - thresholdExtension));
+                switchBounds.Left - minimumTextGap);
             right = Math.Max(contentBounds.Left, right);
             return Rectangle.FromLTRB(contentBounds.Left, contentBounds.Top, right, contentBounds.Bottom);
         }
 
         int left = Math.Max(
             contentBounds.Left,
-            switchBounds.Right + Math.Max(0, metrics.TextGap - thresholdExtension));
+            switchBounds.Right + minimumTextGap);
         left = Math.Min(contentBounds.Right, left);
         return Rectangle.FromLTRB(left, contentBounds.Top, contentBounds.Right, contentBounds.Bottom);
     }
 
-    private void RenderText(Graphics graphics, Rectangle textBounds)
+    private static int GetSwitchTextInset(ToggleSwitchMetrics metrics)
+        => Math.Max(1, (metrics.BorderThickness / 2) + 1);
+
+    private static Size MeasureText(Control control, TextFormatFlags textFormatFlags)
+        => TextRenderer.MeasureText(
+            text: control.Text,
+            font: control.Font,
+            proposedSize: new Size(int.MaxValue, int.MaxValue),
+            flags: textFormatFlags);
+
+    private void RenderText(
+        Graphics graphics,
+        Rectangle textBounds,
+        TextFormatFlags textFormatFlags)
     {
         if (textBounds.Width <= 0 || textBounds.Height <= 0)
         {
             return;
         }
-
-        TextFormatFlags flags = GetTextFormatFlags();
 
         TextRenderer.DrawText(
             graphics,
@@ -214,10 +238,10 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
             Control.Font,
             textBounds,
             GetTextColor(),
-            flags);
+            textFormatFlags);
     }
 
-    private TextFormatFlags GetTextFormatFlags() => Control switch
+    private static TextFormatFlags GetTextFormatFlags(Control control) => control switch
     {
         Forms.CheckBox { FlatStyle: FlatStyle.System } checkBox => ControlPaint.CreateTextFormatFlags(
             checkBox,

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
@@ -162,9 +162,13 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
         int totalHeight = Math.Max(textSize.Height, metrics.SwitchHeight);
         int contentTop = contentBounds.Top + Math.Max(0, (contentBounds.Height - totalHeight) / 2);
         int switchY = contentTop + ((totalHeight - metrics.SwitchHeight) / 2);
-        int switchX = IsSwitchOnRight(checkAlign)
-            ? Math.Max(contentBounds.Left, contentBounds.Right - metrics.SwitchWidth)
-            : contentBounds.Left;
+        int minimumSwitchX = contentBounds.Left;
+        int maximumSwitchX = Math.Max(minimumSwitchX, contentBounds.Right - metrics.SwitchWidth);
+        int edgeInset = Math.Max(1, (metrics.BorderThickness / 2) + 1);
+        int targetSwitchX = IsSwitchOnRight(checkAlign)
+            ? maximumSwitchX - edgeInset
+            : minimumSwitchX + edgeInset;
+        int switchX = Math.Max(minimumSwitchX, Math.Min(maximumSwitchX, targetSwitchX));
 
         return new Rectangle(switchX, switchY, metrics.SwitchWidth, metrics.SwitchHeight);
     }
@@ -186,13 +190,20 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
         ToggleSwitchMetrics metrics,
         ContentAlignment checkAlign)
     {
+        int thresholdExtension = Math.Max(1, metrics.BorderThickness / 2) + 1;
         if (IsSwitchOnRight(checkAlign))
         {
-            int right = Math.Max(contentBounds.Left, switchBounds.Left - metrics.TextGap);
+            int right = Math.Min(
+                contentBounds.Right,
+                switchBounds.Left - Math.Max(0, metrics.TextGap - thresholdExtension));
+            right = Math.Max(contentBounds.Left, right);
             return Rectangle.FromLTRB(contentBounds.Left, contentBounds.Top, right, contentBounds.Bottom);
         }
 
-        int left = Math.Min(contentBounds.Right, switchBounds.Right + metrics.TextGap);
+        int left = Math.Max(
+            contentBounds.Left,
+            switchBounds.Right + Math.Max(0, metrics.TextGap - thresholdExtension));
+        left = Math.Min(contentBounds.Right, left);
         return Rectangle.FromLTRB(left, contentBounds.Top, contentBounds.Right, contentBounds.Bottom);
     }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
@@ -215,7 +215,7 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
     private static int GetSwitchTextInset(ToggleSwitchMetrics metrics)
         => Math.Max(1, (metrics.BorderThickness / 2) + 1);
 
-    private static Size MeasureText(Control control, TextFormatFlags textFormatFlags)
+    internal static Size MeasureText(Control control, TextFormatFlags textFormatFlags)
         => TextRenderer.MeasureText(
             text: control.Text,
             font: control.Font,
@@ -241,7 +241,7 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
             textFormatFlags);
     }
 
-    private static TextFormatFlags GetTextFormatFlags(Control control) => control switch
+    internal static TextFormatFlags GetTextFormatFlags(Control control) => control switch
     {
         Forms.CheckBox { FlatStyle: FlatStyle.System } checkBox => ControlPaint.CreateTextFormatFlags(
             checkBox,
@@ -531,7 +531,8 @@ internal readonly struct ToggleSwitchMetrics
 
     internal Size GetPreferredSize(Control control)
     {
-        Size textSize = TextRenderer.MeasureText(control.Text, control.Font);
+        TextFormatFlags textFormatFlags = AnimatedToggleSwitchRenderer.GetTextFormatFlags(control);
+        Size textSize = AnimatedToggleSwitchRenderer.MeasureText(control, textFormatFlags);
         return new Size(
             SwitchWidth + TextGap + textSize.Width + control.Padding.Horizontal,
             Math.Max(SwitchHeight, textSize.Height) + control.Padding.Vertical);

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
@@ -79,14 +79,12 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
         ToggleSwitchMetrics metrics = ToggleSwitchMetrics.Create(Control);
         Size textSize = TextRenderer.MeasureText(Control.Text, Control.Font);
         Rectangle contentBounds = ToggleSwitchMetrics.GetContentBounds(Control);
-        int totalHeight = Math.Max(textSize.Height, metrics.SwitchHeight);
-        int contentTop = contentBounds.Top + Math.Max(0, (contentBounds.Height - totalHeight) / 2);
-        int textY = contentTop + ((totalHeight - textSize.Height) / 2);
         Rectangle switchBounds = GetSwitchBounds(
             Control,
             RtlTranslatedCheckAlign,
             metrics,
             textSize);
+        Rectangle textBounds = GetTextBounds(contentBounds, switchBounds, metrics, RtlTranslatedCheckAlign);
 
         graphics.Clear(Control.BackColor);
 
@@ -97,14 +95,13 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
 
         if (IsSwitchOnRight(RtlTranslatedCheckAlign))
         {
-            int textX = Math.Max(contentBounds.Left, switchBounds.Left - metrics.TextGap - textSize.Width);
             RenderSwitch(graphics, switchBounds, metrics);
-            RenderText(graphics, new Point(textX, textY));
+            RenderText(graphics, textBounds);
         }
         else
         {
             RenderSwitch(graphics, switchBounds, metrics);
-            RenderText(graphics, new Point(contentBounds.Left + metrics.SwitchWidth + metrics.TextGap, textY));
+            RenderText(graphics, textBounds);
         }
 
         if (Control.Focused && ShowFocusCues)
@@ -172,15 +169,57 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
         return new Rectangle(switchX, switchY, metrics.SwitchWidth, metrics.SwitchHeight);
     }
 
-    private void RenderText(Graphics graphics, Point position)
+    internal static Rectangle GetTextBounds(
+        Control control,
+        ContentAlignment checkAlign,
+        ToggleSwitchMetrics metrics)
     {
+        Size textSize = TextRenderer.MeasureText(control.Text, control.Font);
+        Rectangle contentBounds = ToggleSwitchMetrics.GetContentBounds(control);
+        Rectangle switchBounds = GetSwitchBounds(control, checkAlign, metrics, textSize);
+        return GetTextBounds(contentBounds, switchBounds, metrics, checkAlign);
+    }
+
+    private static Rectangle GetTextBounds(
+        Rectangle contentBounds,
+        Rectangle switchBounds,
+        ToggleSwitchMetrics metrics,
+        ContentAlignment checkAlign)
+    {
+        if (IsSwitchOnRight(checkAlign))
+        {
+            int right = Math.Max(contentBounds.Left, switchBounds.Left - metrics.TextGap);
+            return Rectangle.FromLTRB(contentBounds.Left, contentBounds.Top, right, contentBounds.Bottom);
+        }
+
+        int left = Math.Min(contentBounds.Right, switchBounds.Right + metrics.TextGap);
+        return Rectangle.FromLTRB(left, contentBounds.Top, contentBounds.Right, contentBounds.Bottom);
+    }
+
+    private void RenderText(Graphics graphics, Rectangle textBounds)
+    {
+        if (textBounds.Width <= 0 || textBounds.Height <= 0)
+        {
+            return;
+        }
+
+        TextFormatFlags flags = GetTextFormatFlags();
+
         TextRenderer.DrawText(
             graphics,
             Control.Text,
             Control.Font,
-            position,
-            GetTextColor());
+            textBounds,
+            GetTextColor(),
+            flags);
     }
+
+    private TextFormatFlags GetTextFormatFlags() => Control switch
+    {
+        Forms.CheckBox checkBox => checkBox.CreateTextFormatFlags(),
+        Forms.RadioButton radioButton => radioButton.CreateTextFormatFlags(),
+        _ => TextFormatFlags.WordBreak | TextFormatFlags.TextBoxControl
+    };
 
     internal Color GetTextColor()
         => Control.Enabled

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
@@ -86,23 +86,15 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
             textSize);
         Rectangle textBounds = GetTextBounds(contentBounds, switchBounds, metrics, RtlTranslatedCheckAlign);
 
-        graphics.Clear(Control.BackColor);
+        PaintControlBackground(graphics);
 
         if (contentBounds.Width <= 0 || contentBounds.Height <= 0)
         {
             return;
         }
 
-        if (IsSwitchOnRight(RtlTranslatedCheckAlign))
-        {
-            RenderSwitch(graphics, switchBounds, metrics);
-            RenderText(graphics, textBounds);
-        }
-        else
-        {
-            RenderSwitch(graphics, switchBounds, metrics);
-            RenderText(graphics, textBounds);
-        }
+        RenderSwitch(graphics, switchBounds, metrics);
+        RenderText(graphics, textBounds);
 
         if (Control.Focused && ShowFocusCues)
         {
@@ -377,6 +369,25 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
         _onAmountStart = _onAmountCurrent;
         _onAmountTarget = _onAmountCurrent;
         _positionInitialized = true;
+    }
+
+    private void PaintControlBackground(Graphics graphics)
+    {
+        if (Control.BackgroundImage is null && !Control.BackColor.HasTransparency())
+        {
+            graphics.Clear(Control.BackColor);
+            return;
+        }
+
+        Rectangle clipRectangle = Rectangle.Ceiling(graphics.ClipBounds);
+        clipRectangle.Intersect(Control.ClientRectangle);
+        if (clipRectangle.Width <= 0 || clipRectangle.Height <= 0)
+        {
+            return;
+        }
+
+        using PaintEventArgs paintEventArgs = new(graphics, clipRectangle);
+        Control.PaintBackground(paintEventArgs, clipRectangle);
     }
 
     private static float EaseOut(float value)

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/CheckBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/CheckBoxTests.cs
@@ -773,12 +773,12 @@ public class CheckBoxTests : AbstractButtonBaseTests
             metrics);
         Rectangle contentBounds = Rendering.CheckBox.ToggleSwitchMetrics.GetContentBounds(box);
 
-        const int EdgeTolerance = 2;
+        int edgeTolerance = Math.Max(1, (metrics.BorderThickness / 2) + 1);
         if (switchOnRight)
         {
             Assert.InRange(
                 switchBounds.Right,
-                contentBounds.Right - EdgeTolerance,
+                contentBounds.Right - edgeTolerance,
                 contentBounds.Right);
         }
         else
@@ -786,8 +786,38 @@ public class CheckBoxTests : AbstractButtonBaseTests
             Assert.InRange(
                 switchBounds.Left,
                 contentBounds.Left,
-                contentBounds.Left + EdgeTolerance);
+                contentBounds.Left + edgeTolerance);
         }
+    }
+
+    [WinFormsFact]
+    public void CheckBox_ToggleSwitch_RtlLongText_AutoSizeFalse_TextBounds_DoNotOverlapSwitch()
+    {
+        using CheckBox box = new()
+        {
+            Appearance = Appearance.ToggleSwitch,
+            AutoSize = false,
+            RightToLeft = RightToLeft.Yes,
+            CheckAlign = ContentAlignment.MiddleLeft,
+            Text = "This is a very long toggle-switch label to verify RTL clipping does not overlap the switch glyph.",
+            Size = new Size(160, 30)
+        };
+
+        box.VisualStylesMode = VisualStylesMode.Net11;
+        box.CreateControl();
+
+        Rendering.CheckBox.ToggleSwitchMetrics metrics = Rendering.CheckBox.ToggleSwitchMetrics.Create(box);
+        Rectangle switchBounds = Rendering.CheckBox.AnimatedToggleSwitchRenderer.GetSwitchBounds(
+            box,
+            box.RtlTranslatedCheckAlign,
+            metrics);
+        Rectangle textBounds = Rendering.CheckBox.AnimatedToggleSwitchRenderer.GetTextBounds(
+            box,
+            box.RtlTranslatedCheckAlign,
+            metrics);
+        Rectangle overlap = Rectangle.Intersect(switchBounds, textBounds);
+
+        Assert.True(overlap.IsEmpty);
     }
 
     [WinFormsTheory]
@@ -1389,10 +1419,10 @@ public class CheckBoxTests : AbstractButtonBaseTests
     }
 
     [WinFormsTheory]
-    [InlineData(Appearance.Button, FlatStyle.Standard,  "Test", 12, 8, 100, 20)]
-    [InlineData(Appearance.Normal, FlatStyle.System,    "Test", 12, 8, 100, 20)]
-    [InlineData(Appearance.Normal, FlatStyle.Flat,      "Test", 12, 8, 100, 20)]
-    [InlineData(Appearance.Normal, FlatStyle.Standard,  "Test", 12, 8, 100, 20)]
+    [InlineData(Appearance.Button, FlatStyle.Standard, "Test", 12, 8, 100, 20)]
+    [InlineData(Appearance.Normal, FlatStyle.System, "Test", 12, 8, 100, 20)]
+    [InlineData(Appearance.Normal, FlatStyle.Flat, "Test", 12, 8, 100, 20)]
+    [InlineData(Appearance.Normal, FlatStyle.Standard, "Test", 12, 8, 100, 20)]
     public void CheckBox_GetPreferredSizeCore_VariousStyles_ReturnsExpected(
         Appearance appearance, FlatStyle flatStyle, string text, int fontSize, int padding, int width, int height)
     {

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/CheckBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/CheckBoxTests.cs
@@ -992,6 +992,25 @@ public class CheckBoxTests : AbstractButtonBaseTests
         Assert.False(box.GetStyle(ControlStyles.UserPaint));
     }
 
+    [WinFormsFact]
+    public void CheckBox_ToggleSwitch_FlatStyleSystem_DrawToBitmap_DoesNotThrow()
+    {
+        using CheckBox box = new()
+        {
+            Appearance = Appearance.ToggleSwitch,
+            FlatStyle = FlatStyle.System,
+            VisualStylesMode = VisualStylesMode.Net11,
+            Text = "Toggle",
+            Size = new Size(120, 30)
+        };
+        using Bitmap bitmap = new(box.Width, box.Height);
+
+        Exception exception = Record.Exception(
+            () => box.DrawToBitmap(bitmap, new Rectangle(Point.Empty, box.Size)));
+
+        Assert.Null(exception);
+    }
+
     private static int CountPixels(Bitmap bitmap, Color color)
     {
         int argb = color.ToArgb();

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/CheckBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/CheckBoxTests.cs
@@ -773,9 +773,21 @@ public class CheckBoxTests : AbstractButtonBaseTests
             metrics);
         Rectangle contentBounds = Rendering.CheckBox.ToggleSwitchMetrics.GetContentBounds(box);
 
-        Assert.Equal(
-            switchOnRight ? contentBounds.Right : contentBounds.Left,
-            switchOnRight ? switchBounds.Right : switchBounds.Left);
+        const int EdgeTolerance = 2;
+        if (switchOnRight)
+        {
+            Assert.InRange(
+                switchBounds.Right,
+                contentBounds.Right - EdgeTolerance,
+                contentBounds.Right);
+        }
+        else
+        {
+            Assert.InRange(
+                switchBounds.Left,
+                contentBounds.Left,
+                contentBounds.Left + EdgeTolerance);
+        }
     }
 
     [WinFormsTheory]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/CheckBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/CheckBoxTests.cs
@@ -820,6 +820,33 @@ public class CheckBoxTests : AbstractButtonBaseTests
         Assert.True(overlap.IsEmpty);
     }
 
+    [WinFormsFact]
+    public void CheckBox_ToggleSwitch_NarrowWidth_TextBoundsCanCollapseWithoutThrowing()
+    {
+        using CheckBox box = new()
+        {
+            Appearance = Appearance.ToggleSwitch,
+            AutoSize = false,
+            Text = "Narrow control text",
+            Size = new Size(8, 30),
+            VisualStylesMode = VisualStylesMode.Net11
+        };
+        using Bitmap bitmap = new(box.Width, box.Height);
+
+        Exception exception = Record.Exception(
+            () => box.DrawToBitmap(bitmap, new Rectangle(Point.Empty, box.Size)));
+
+        Assert.Null(exception);
+
+        Rendering.CheckBox.ToggleSwitchMetrics metrics = Rendering.CheckBox.ToggleSwitchMetrics.Create(box);
+        Rectangle textBounds = Rendering.CheckBox.AnimatedToggleSwitchRenderer.GetTextBounds(
+            box,
+            box.RtlTranslatedCheckAlign,
+            metrics);
+
+        Assert.InRange(textBounds.Width, 0, 1);
+    }
+
     [WinFormsTheory]
     [InlineData(96)]
     [InlineData(120)]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/CheckBoxToggleSwitchTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/CheckBoxToggleSwitchTests.cs
@@ -114,6 +114,31 @@ public class CheckBoxToggleSwitchTests
     }
 
     [WinFormsFact]
+    public void CheckBox_ToggleSwitch_PreferredSize_UseMnemonicFalse_MeasuresLiteralAmpersand()
+    {
+        using CheckBox literalAmpersand = new()
+        {
+            Appearance = Appearance.ToggleSwitch,
+            FlatStyle = FlatStyle.Standard,
+            Text = "A&B",
+            UseMnemonic = false,
+            VisualStylesMode = VisualStylesMode.Net11
+        };
+        using CheckBox escapedMnemonic = new()
+        {
+            Appearance = Appearance.ToggleSwitch,
+            FlatStyle = FlatStyle.Standard,
+            Text = "A&&B",
+            UseMnemonic = true,
+            VisualStylesMode = VisualStylesMode.Net11
+        };
+
+        Assert.Equal(
+            escapedMnemonic.GetPreferredSize(Size.Empty),
+            literalAmpersand.GetPreferredSize(Size.Empty));
+    }
+
+    [WinFormsFact]
     public void CheckBox_Appearance_ToggleSwitch_RoundTrips()
     {
         using CheckBox checkBox = new() { Appearance = Appearance.ToggleSwitch };


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14808 

## Root Cause

In ToggleSwitch mode, text rendering was position-based (DrawText with a point) rather than bounds-based.
When text was longer than available width, there was no hard text layout rectangle excluding the switch glyph area, so text could overlap the toggle or be clipped inconsistently (including mid-word truncation behavior different from Normal mode).

## Proposed changes

- Compute a dedicated textBounds for ToggleSwitch text by subtracting switch glyph width (plus text gap) from the control content bounds.
- Render text using rectangle-based TextRenderer.DrawText(..., textBounds, flags) instead of point-based drawing.
- Keep switch and text in separate layout regions to guarantee no overlap.
- Reuse CheckBox/RadioButton default text format flags (CreateTextFormatFlags) so ToggleSwitch text wrapping/clipping behavior aligns with Normal mode.
- Add/keep regression tests for long text + RTL + AutoSize=false to ensure text does not overlap the toggle glyph.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

Improves text rendering reliability for ToggleSwitch-style CheckBox/RadioButton, especially with long text and constrained widths (AutoSize=false).

- Prevents text from overlapping the toggle glyph.
- Aligns ToggleSwitch text wrapping/clipping behavior with Normal mode for more predictable UI results.
- Improves RTL and long-text layout consistency without changing public APIs.

## Regression? 

- No

## Risk

- Mini

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<img width="860" height="142" alt="image" src="https://github.com/user-attachments/assets/cecca3a3-242a-4974-b619-e1afdfe30d1b" />

### After

https://github.com/user-attachments/assets/88493c03-3e95-43f2-a0ca-269dfb6ea336



## Test methodology <!-- How did you ensure quality? -->

- Manually
 

## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.100-preview.5.26302.115


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14815)