### PR TITLE
[release/8.0] Migrate winforms-pr internal-feed auth off retired PAT to System.AccessToken

### DIFF
--- a/eng/pipelines/build-PR.yml
+++ b/eng/pipelines/build-PR.yml
@@ -47,7 +47,7 @@ jobs:
           filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
           arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
         env:
-          Token: $(dn-bot-dnceng-artifact-feeds-rw)
+          Token: $(System.AccessToken)
 
       - task: MicroBuildSigningPlugin@4
         displayName: Install MicroBuild plugin for Signing


### PR DESCRIPTION
## Summary
The `winforms-pr` pipeline (`eng/pipelines/build-PR.yml`) authenticates internal `darc-int-*` Azure Artifacts feeds during Arcade SDK toolset restore using the `dn-bot-dnceng-artifact-feeds-rw` PAT. That PAT was removed from the arcade secret manifest (arcade #17079, merged 2026-07-08) and **expired 2026-07-11**, so internal `release/8.0` builds now fail with **HTTP 401 (Unauthorized)** during `artifacts/toolset/restore.proj`.

This swaps the credential to `$(System.AccessToken)` (build identity), mirroring what `eng/pipelines/build.yml` (the official CI pipeline) already does on this same branch.

## Root cause / evidence
- **Failing build:** `winforms-pr` on `internal/release/8.0` build [3029632](https://dev.azure.com/dnceng/internal/_build/results?buildId=3029632) (2026-07-23) — `401 (Unauthorized)` on `darc-int-*` feeds fetching `Microsoft.DotNet.Arcade.Sdk`.
- **Regression window:** this pipeline succeeded through 2026-07-07, then began failing 2026-07-16 onward — immediately after the PAT expired.
- The sibling CI file `eng/pipelines/build.yml` on `release/8.0` was already migrated to `$(System.AccessToken)` (which is why `dotnet-winforms CI` passes on the same commit); only `build-PR.yml` was missed. `release/9.0` and `main` are unaffected.

## Verification
Applied this exact change to a test branch off `internal/release/8.0` and queued the `winforms-pr` pipeline: build **3032700 succeeded** (all Windows Debug/Release x64/x86/arm64 legs), the `Setup Private Feeds Credentials` step passed, and the internal-feed restore completed with no 401.

## Change
`eng/pipelines/build-PR.yml` — `Token: $(dn-bot-dnceng-artifact-feeds-rw)` → `Token: $(System.AccessToken)`

Tracked by [AzDO #11679](https://dev.azure.com/dnceng/internal/_workitems/edit/11679).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14817)