### PR TITLE
Fix vertical scrollbar not rendering in RTL multiline TextBox

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TextBox/TextBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TextBox/TextBox.cs
@@ -440,7 +440,14 @@ public partial class TextBox : TextBoxBase
 
         if (Multiline && (_scrollBars & ScrollBars.Vertical) != 0)
         {
-            padding.Right = SystemInformation.GetVerticalScrollBarWidthForDpi(DeviceDpiInternal);
+            if (RightToLeft == RightToLeft.Yes)
+            {
+                padding.Left = SystemInformation.GetVerticalScrollBarWidthForDpi(DeviceDpiInternal);
+            }
+            else
+            {
+                padding.Right = SystemInformation.GetVerticalScrollBarWidthForDpi(DeviceDpiInternal);
+            }
         }
 
         return padding;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TextBox/TextBoxBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TextBox/TextBoxBase.cs
@@ -1028,7 +1028,18 @@ public abstract partial class TextBoxBase : Control
 
         if (hasVScroll)
         {
-            padding.Right += SystemInformation.GetVerticalScrollBarWidthForDpi(DeviceDpiInternal);
+            WINDOW_EX_STYLE exStyle = (WINDOW_EX_STYLE)PInvokeCore.GetWindowLong(
+                this,
+                WINDOW_LONG_PTR_INDEX.GWL_EXSTYLE);
+
+            if ((exStyle & WINDOW_EX_STYLE.WS_EX_LEFTSCROLLBAR) != 0)
+            {
+                padding.Left += SystemInformation.GetVerticalScrollBarWidthForDpi(DeviceDpiInternal);
+            }
+            else
+            {
+                padding.Right += SystemInformation.GetVerticalScrollBarWidthForDpi(DeviceDpiInternal);
+            }
         }
 
         return padding;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14801

## Root Cause
Vertical scrollbar not rendered in RTL multiline TextBox on .NET 11 because `GetScrollBarPadding()` doesn't check `WS_EX_LEFTSCROLLBAR` flag. 

## Proposed changes

- TextBoxBase.GetScrollBarPadding(): Check `WS_EX_LEFTSCROLLBAR` flag; put scrollbar width in `padding.Left` if set, `padding.Right `otherwise.
- TextBox.GetScrollBarPadding(): Override for design-time; check `RightToLeft` property when handle not created.


## Customer Impact

- Vertical scrollbar renders correctly in RTL multiline TextBox on .NET 11

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
After enable RTL, the vertical scrollbar of the multiline TextBox on the left disappears completely,

<img width="761" height="329" alt="image" src="https://github.com/user-attachments/assets/ea99c5bc-42b2-40b7-8dbc-adaa93bca6bc" />

### After

Vertical scrollbar renders correctly in RTL multiline TextBox on .NET 11

<img width="925" height="658" alt="image" src="https://github.com/user-attachments/assets/604e4b2a-012c-4a8c-9777-fb62cf5e132f" />


## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.0-preview.7.26365.101


<!-- Mention language, UI scaling, or anything else that might be relevant -->
