### PR TITLE
Fix PictureBox frame callback handle race in OnFrameChanged

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PictureBox/PictureBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PictureBox/PictureBox.cs
@@ -1050,7 +1050,7 @@ public partial class PictureBox : Control, ISupportInitialize
         }
 
         // Handle should be created, before calling the BeginInvoke.
-        if (InvokeRequired && IsHandleCreated)
+        if (IsHandleCreated && InvokeRequired)
         {
             lock (_internalSyncObject)
             {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14823

## Root Cause

During animated image updates, `OnFrameChanged` could evaluate `InvokeRequired` before checking `IsHandleCreated`.
In rare timing windows (handle create/destroy while animation callback is running), this can lead to unstable handle state and an occasional "Error creating window handle".

## Proposed changes

- In `PictureBox.OnFrameChanged`, check `IsHandleCreated` first, then `InvokeRequired`.
This allows for an immediate short-circuit when the handle does not exist, avoiding the more complex `InvokeRequired` path (which involves parent chain traversal, thread checks, and race conditions regarding handle state). 
It also ensures consistency with similar controls, such as `Label` and `ButtonBase`, which likewise check `IsHandleCreated` first.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Reduces intermittent "Error creating window handle" for apps using animated images in PictureBox.

## Regression? 

- No

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net11.0.0-preview.7.26365.101


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14826)