### PR TITLE
Fix icons of PropertyGrid control are not scaled well on 100% secondary monitor

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
@@ -1753,12 +1753,19 @@ public partial class PropertyGrid : ContainerControl, IComPropertyBrowser, IProp
         EventHandler eventHandler,
         bool useRadioButtonRole = false)
     {
+        // ToolStripItem/ToolStripButton bake Margin and the minimum button width from
+        // ScaleHelper.InitialSystemDpi (the process's startup DPI) at construction time. Re-apply both
+        // explicitly so a button (re)created after a runtime DPI change reflects the grid's actual current
+        // DPI; DeviceDpi routes through ToolStripButton's own existing, correct DeviceDpi setter override.
+        // See https://github.com/dotnet/winforms/issues/8268.
         PropertyGridToolStripButton button = new(this, useRadioButtonRole)
         {
             Text = toolTipText,
             AutoToolTip = true,
             DisplayStyle = ToolStripItemDisplayStyle.Image,
-            ImageIndex = imageIndex
+            ImageIndex = imageIndex,
+            Margin = ScaleHelper.ScaleToDpi(new Padding(0, 1, 0, 2), DeviceDpi),
+            DeviceDpi = DeviceDpi
         };
 
         button.Click += eventHandler;
@@ -2106,7 +2113,7 @@ public partial class PropertyGrid : ContainerControl, IComPropertyBrowser, IProp
             ImageSize = s_largeButtonSize
         };
 
-        if (ScaleHelper.IsScalingRequired)
+        if (ScaleHelper.IsScalingRequirementMet)
         {
             AddLargeImage(_alphaBitmap);
             AddLargeImage(_categoryBitmap);
@@ -2140,7 +2147,7 @@ public partial class PropertyGrid : ContainerControl, IComPropertyBrowser, IProp
         }
     }
 
-    // This method should be called only inside a if (DpiHelper.IsScalingRequired) clause.
+    // This method should be called only inside a if (ScaleHelper.IsScalingRequirementMet) clause.
     private void AddLargeImage(Bitmap? originalBitmap)
     {
         if (originalBitmap is null)
@@ -3874,10 +3881,17 @@ public partial class PropertyGrid : ContainerControl, IComPropertyBrowser, IProp
         {
             _normalButtonImages?.Dispose();
             _normalButtonImages = new ImageList();
-            if (ScaleHelper.IsScalingRequired)
+            if (ScaleHelper.IsScalingRequirementMet)
             {
                 _normalButtonImages.ImageSize = s_normalButtonSize;
             }
+        }
+
+        // A ToolStripItem's size is computed once, at creation, and never revisited on its own; set
+        // ImageScalingSize (drives ToolStripItem.PreferredImageSize) before CreatePushButton runs below.
+        if (!LargeButtons)
+        {
+            _toolStrip.ImageScalingSize = _normalButtonImages.ImageSize;
         }
 
         // Setup our event handlers.
@@ -4012,6 +4026,9 @@ public partial class PropertyGrid : ContainerControl, IComPropertyBrowser, IProp
         }
 
         _toolStrip.ImageList = LargeButtons ? _largeButtonImages : _normalButtonImages;
+
+        // Covers LargeButtons only (_largeButtonImages isn't ready earlier); a no-op otherwise.
+        _toolStrip.ImageScalingSize = LargeButtons ? _largeButtonImages!.ImageSize : _normalButtonImages!.ImageSize;
 
         using (SuspendLayoutScope scope = new(_toolStrip))
         {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
@@ -3887,13 +3887,6 @@ public partial class PropertyGrid : ContainerControl, IComPropertyBrowser, IProp
             }
         }
 
-        // A ToolStripItem's size is computed once, at creation, and never revisited on its own; set
-        // ImageScalingSize (drives ToolStripItem.PreferredImageSize) before CreatePushButton runs below.
-        if (!LargeButtons)
-        {
-            _toolStrip.ImageScalingSize = _normalButtonImages.ImageSize;
-        }
-
         // Setup our event handlers.
         EventHandler tabButtonHandler = OnViewTabButtonClick;
         EventHandler sortButtonHandler = OnViewSortButtonClick;
@@ -4028,7 +4021,7 @@ public partial class PropertyGrid : ContainerControl, IComPropertyBrowser, IProp
         _toolStrip.ImageList = LargeButtons ? _largeButtonImages : _normalButtonImages;
 
         // Covers LargeButtons only (_largeButtonImages isn't ready earlier); a no-op otherwise.
-        _toolStrip.ImageScalingSize = LargeButtons ? _largeButtonImages!.ImageSize : _normalButtonImages!.ImageSize;
+        _toolStrip.ImageScalingSize = _toolStrip.ImageList!.ImageSize;
 
         using (SuspendLayoutScope scope = new(_toolStrip))
         {


### PR DESCRIPTION
Fixes #8268

## Proposed changes

`PropertyGrid`'s toolbar icons (sort-alphabetically / sort-by-category / property-pages buttons) didn't rescale correctly after a PerMonitorV2 DPI change. Root-caused to two independent, stacked defects in the toolbar rebuild path (`PropertyGrid.SetupToolbar`/`CreatePushButton`):

- `SetupToolbar()` rebuilt the toolbar's `ImageList` at the new DPI but never updated `ToolStrip.ImageScalingSize` (what actually drives rendered icon size), and the `ImageList.ImageSize` assignment itself was gated on `ScaleHelper.IsScalingRequired`, which only reflects the _process's_ startup DPI rather than whether the app is PerMonitorV2-aware. Fixed by always setting `ImageScalingSize` right after the `ImageList` is rebuilt; before any button is created, since a `ToolStripItem`'s size is computed once and never revisited later; and switching to `ScaleHelper.IsScalingRequirementMet`.
- `ToolStripItem`/`ToolStripButton` bake their default `Margin` and minimum button width from `ScaleHelper.InitialSystemDpi` (again the process's startup DPI) at construction time, so a button (re)created after a runtime DPI change still inherits sizing baked in for whatever DPI the process happened to start at. Fixed by having `CreatePushButton` explicitly re-apply `Margin` and `DeviceDpi` using the grid's current DPI; `DeviceDpi` routes through `ToolStripButton`'s own already-correct `DeviceDpi` setter override, which recomputes the minimum width but was never being invoked for ordinary toolbar buttons.

Together these explain the issue's reported asymmetry: sizing baked in for a _higher_ DPI and later applied at a _lower_ one is very visibly wrong (oversized icons/buttons); the reverse just leaves a little extra room, so it's easy to miss.

## Customer Impact

- Apps using `PerMonitorV2` render `PropertyGrid` toolbar icons at the wrong size after the app moves between monitors with different DPI, until the process restarts. Visual/readability issue only; the grid remains fully usable.

## Regression?

- Yes, relative to .NET Framework; not a regression within .NET Core/5+ (reproduces on .NET 6/7/8 alike per the issue).

## Risk

- All changes are scoped to `PropertyGrid`'s own toolbar-button construction/rebuild path; none affect `SystemAware`/`DpiUnaware` apps or any other control. The `DeviceDpi`/`IsScalingRequirementMet` changes invoke existing, already-correct framework code paths rather than introducing new logic.

### Before

- Started form at 100% scale and took screenshot at 225. Blurry icons:
<img width="804" height="667" alt="before_started_100_scaled_to_225 png" src="https://github.com/user-attachments/assets/d3080246-a3aa-405b-bba1-9bd20af4cbdc" />

- Started form at 225% scale and took screenshot at 100. Buttons stretched horizontally:
<img width="670" height="501" alt="before_started_225_scaled_to_100" src="https://github.com/user-attachments/assets/32c74ea2-d354-468c-b6dc-49e6fccb1232" />

### After

- Started form at 100% scale and took screenshot at 225. Crisp icons:
<img width="1128" height="671" alt="after_started_100_scaled_to_225" src="https://github.com/user-attachments/assets/64fbe75c-cbc3-4253-8510-014230af2946" />

- Started form at 225% scale and took screenshot at 100. buttons sized accordingly:
<img width="802" height="632" alt="after_started_225_scaled_to_100" src="https://github.com/user-attachments/assets/90326d6a-5ade-466c-b5b0-9dc60a200d97" />

## Test environment

11.0.100-preview.5.26302.115

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14828)