### PR TITLE
Fix ControlPaint.Dark interpolation for SystemColors.Control

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint.HLSColor.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint.HLSColor.cs
@@ -111,10 +111,13 @@ public static partial class ControlPaint
                     ARGB dark = SystemColors.ControlDark;
                     ARGB darkDark = SystemColors.ControlDarkDark;
 
+                    static byte Interpolate(byte darkChannel, byte darkDarkChannel, float percentDarker) =>
+                        unchecked((byte)(darkChannel - (int)((darkChannel - darkDarkChannel) * percentDarker)));
+
                     return Color.FromArgb(
-                        (byte)(dark.R - (byte)((dark.R - darkDark.R) * percDarker)),
-                        (byte)(dark.G - (byte)((dark.G - darkDark.G) * percDarker)),
-                        (byte)(dark.B - (byte)((dark.B - darkDark.B) * percDarker)));
+                        Interpolate(dark.R, darkDark.R, percDarker),
+                        Interpolate(dark.G, darkDark.G, percDarker),
+                        Interpolate(dark.B, darkDark.B, percDarker));
                 }
             }
         }


### PR DESCRIPTION
This change fixes the test failures in codeflow PR https://github.com/dotnet/winforms/pull/14825

Fix  ControlPaint.Dark(Color, float) for the SystemColors.Control  special-case path.

Problem

ControlPaint_Dark_InvokeColorFloat_ReturnsExpected  was failing for  SystemColors.Control  with negative darkening percentages because the interpolation logic performed an intermediate byte cast, producing incorrect channel values.

Solution

Perform the interpolation in  int  and cast to  byte  only once at the end of the calculation.

Testing

•  System.Windows.Forms.Tests.ControlPaint_Dark_InvokeColorFloat_ReturnsExpected 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14829)