### PR TITLE
Fix ControlPaint.Light interpolation for system colors

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint.HLSColor.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/ControlPaint.HLSColor.cs
@@ -162,10 +162,13 @@ public static partial class ControlPaint
                     ARGB light = SystemColors.ControlLight;
                     ARGB lightLight = SystemColors.ControlLightLight;
 
+                    static byte Interpolate(byte lightChannel, byte lightLightChannel, float percentLighter) =>
+                        unchecked((byte)(lightChannel - (int)((lightChannel - lightLightChannel) * percentLighter)));
+
                     return Color.FromArgb(
-                        (byte)(light.R - (byte)((light.R - lightLight.R) * percentLighter)),
-                        (byte)(light.G - (byte)((light.G - lightLight.G) * percentLighter)),
-                        (byte)(light.B - (byte)((light.B - lightLight.B) * percentLighter)));
+                        Interpolate(light.R, lightLight.R, percentLighter),
+                        Interpolate(light.G, lightLight.G, percentLighter),
+                        Interpolate(light.B, lightLight.B, percentLighter));
                 }
             }
             else


### PR DESCRIPTION
Issue: `ControlPaint.Light` returned incorrect colors for `SystemColors.Control` because interpolation performed an intermediate byte cast.

Solution: Perform interpolation using integer arithmetic and cast to byte only once at the end.

Testing: All System.Windows.Forms.Tests.ControlPaintTests now pass successfully
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14833)