### PR TITLE
Fix issue 14831: TaskDialogPage.GetBoundButtonByID throws IndexOutOfRangeException when TaskDialogIndirect returns unexpected button ID

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Dialogs/TaskDialog/TaskDialog.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Dialogs/TaskDialog/TaskDialog.cs
@@ -1132,7 +1132,11 @@ public partial class TaskDialog : IWin32Window
 
                 case TASKDIALOG_NOTIFICATIONS.TDN_RADIO_BUTTON_CLICKED:
                     int radioButtonID = (int)wParam;
-                    TaskDialogRadioButton radioButton = _boundPage.GetBoundRadioButtonByID(radioButtonID)!;
+                    TaskDialogRadioButton? radioButton = _boundPage.GetBoundRadioButtonByID(radioButtonID);
+                    if (radioButton is null)
+                    {
+                        break;
+                    }
 
                     checked
                     {

--- a/src/System.Windows.Forms/System/Windows/Forms/Dialogs/TaskDialog/TaskDialogPage.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Dialogs/TaskDialog/TaskDialogPage.cs
@@ -717,7 +717,10 @@ public class TaskDialogPage
         // Check if the button is part of the custom buttons.
         if (buttonID >= CustomButtonStartID)
         {
-            return _boundCustomButtons![buttonID - CustomButtonStartID];
+            int customButtonIndex = buttonID - CustomButtonStartID;
+            return (uint)customButtonIndex < (uint)_boundCustomButtons!.Length
+                ? _boundCustomButtons[customButtonIndex]
+                : null;
         }
         else
         {
@@ -736,7 +739,15 @@ public class TaskDialogPage
             throw new InvalidOperationException();
         }
 
-        return buttonID == 0 ? null : _radioButtons[buttonID - RadioButtonStartID];
+        if (buttonID == 0)
+        {
+            return null;
+        }
+
+        int radioButtonIndex = buttonID - RadioButtonStartID;
+        return (uint)radioButtonIndex < (uint)_radioButtons.Count
+            ? _radioButtons[radioButtonIndex]
+            : null;
     }
 
     internal void Validate()

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/TaskDialogTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/TaskDialogTests.cs
@@ -68,7 +68,7 @@ public class TaskDialogTests
         SetPrivateField(page, "_boundCustomButtons", Array.Empty<TaskDialogButton>());
         SetPrivateField(page, "_boundStandardButtonsByID", new Dictionary<int, TaskDialogButton>());
 
-        TaskDialogButton? button = page.GetBoundButtonByID(buttonID: 100);
+        TaskDialogButton button = page.GetBoundButtonByID(buttonID: 100);
 
         Assert.Null(button);
     }
@@ -79,14 +79,14 @@ public class TaskDialogTests
         TaskDialogPage page = new();
         PrepareBoundLikeState(page);
 
-        TaskDialogRadioButton? radioButton = page.GetBoundRadioButtonByID(buttonID: 1);
+        TaskDialogRadioButton radioButton = page.GetBoundRadioButtonByID(buttonID: 1);
 
         Assert.Null(radioButton);
     }
 
     private static void PrepareBoundLikeState(TaskDialogPage page)
     {
-        ConstructorInfo? constructor = typeof(TaskDialog).GetConstructor(
+        ConstructorInfo constructor = typeof(TaskDialog).GetConstructor(
             BindingFlags.Instance | BindingFlags.NonPublic,
             binder: null,
             Type.EmptyTypes,
@@ -99,7 +99,7 @@ public class TaskDialogTests
 
     private static void SetPrivateField(object instance, string fieldName, object value)
     {
-        FieldInfo? field = instance.GetType().GetField(
+        FieldInfo field = instance.GetType().GetField(
             fieldName,
             BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.NotNull(field);

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/TaskDialogTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/TaskDialogTests.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using Microsoft.DotNet.RemoteExecutor;
+using System.Reflection;
 
 namespace System.Windows.Forms.Tests;
 
@@ -57,5 +58,51 @@ public class TaskDialogTests
 
         // verify the remote process succeeded
         Assert.Equal(RemoteExecutor.SuccessExitCode, invokerHandle.ExitCode);
+    }
+
+    [WinFormsFact]
+    public void TaskDialogPage_GetBoundButtonByID_CustomRangeOutOfBounds_ReturnsNull()
+    {
+        TaskDialogPage page = new();
+        PrepareBoundLikeState(page);
+        SetPrivateField(page, "_boundCustomButtons", Array.Empty<TaskDialogButton>());
+        SetPrivateField(page, "_boundStandardButtonsByID", new Dictionary<int, TaskDialogButton>());
+
+        TaskDialogButton? button = page.GetBoundButtonByID(buttonID: 100);
+
+        Assert.Null(button);
+    }
+
+    [WinFormsFact]
+    public void TaskDialogPage_GetBoundRadioButtonByID_OutOfBounds_ReturnsNull()
+    {
+        TaskDialogPage page = new();
+        PrepareBoundLikeState(page);
+
+        TaskDialogRadioButton? radioButton = page.GetBoundRadioButtonByID(buttonID: 1);
+
+        Assert.Null(radioButton);
+    }
+
+    private static void PrepareBoundLikeState(TaskDialogPage page)
+    {
+        ConstructorInfo? constructor = typeof(TaskDialog).GetConstructor(
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            Type.EmptyTypes,
+            modifiers: null);
+        Assert.NotNull(constructor);
+
+        TaskDialog dialog = (TaskDialog)constructor.Invoke(null);
+        SetPrivateField(page, "<BoundDialog>k__BackingField", dialog);
+    }
+
+    private static void SetPrivateField(object instance, string fieldName, object value)
+    {
+        FieldInfo? field = instance.GetType().GetField(
+            fieldName,
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        field.SetValue(instance, value);
     }
 }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/TaskDialogTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/TaskDialogTests.cs
@@ -65,8 +65,9 @@ public class TaskDialogTests
     {
         TaskDialogPage page = new();
         PrepareBoundLikeState(page);
-        SetPrivateField(page, "_boundCustomButtons", Array.Empty<TaskDialogButton>());
-        SetPrivateField(page, "_boundStandardButtonsByID", new Dictionary<int, TaskDialogButton>());
+        dynamic access = page.TestAccessor.Dynamic;
+        access._boundCustomButtons = Array.Empty<TaskDialogButton>();
+        access._boundStandardButtonsByID = new Dictionary<int, TaskDialogButton>();
 
         TaskDialogButton button = page.GetBoundButtonByID(buttonID: 100);
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14831 

## Root Cause

`TaskDialogPage.GetBoundButtonByID` and `GetBoundRadioButtonByID` map the ID returned by the native API directly to an array index without performing bounds checking.
If `TaskDialogIndirect` returns an ID outside the current page configuration during an abnormal closure (e.g., an ID in the "custom" range when no custom buttons are defined), an `IndexOutOfRangeException` is triggered, preventing the intended fallback logic from executing.

## Proposed changes

- Add bounds checking for the `custom-button` index in `GetBoundButtonByID`; return `null` if the index is out of bounds.
- Add bounds checking for the `radio-button` index in `GetBoundRadioButtonByID`; return `null` if the index is out of bounds.
- Handle the `null` return value in the `TaskDialog` `TDN_RADIO_BUTTON_CLICKED` callback to prevent potential dereferencing issues.
- Add unit tests to cover the scenario where an out-of-bounds ID returns `null` instead of throwing an exception.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Eliminated the risk of process crashes (IndexOutOfRangeException) in this code path.
- Improved the robustness of TaskDialog when encountering exceptional or unexpected native return values, ensuring it correctly enters existing fault-tolerance branches.
- Maintained the behavior of standard execution paths and public APIs, focusing solely on enhancing reliability and fault tolerance.

## Regression? 

- No

## Risk

- Mini

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

https://github.com/user-attachments/assets/fa56332d-4815-48e8-bd71-358ebfdbaa02

### After

https://github.com/user-attachments/assets/761be2d2-ffa0-4db7-81f4-cd1ff2b41024


## Test methodology <!-- How did you ensure quality? -->

- Manually
- Automated test cases

## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.0-preview.7.26381.103

## Test Project

[TaskDialogIssue14831.zip](https://github.com/user-attachments/files/30690631/TaskDialogIssue14831.zip)


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14842)