### PR TITLE
[release/6.0] Use build identity for internal feed credentials

### DIFF
--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -50,7 +50,7 @@ jobs:
       filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
       arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
     env:
-      Token: $(dn-bot-dnceng-artifact-feeds-rw)
+      Token: $(System.AccessToken)
 
   - task: MicroBuildSigningPlugin@2
     displayName: Install MicroBuild plugin for Signing


### PR DESCRIPTION
## Summary
Replace the retired `dn-bot-dnceng-artifact-feeds-rw` PAT with `$(System.AccessToken)` when preparing internal NuGet feeds.

`SetupNugetSources` is retained because it enables the disabled `darc-int-*` sources; only the credential supplied to it changes.

## Evidence
- Failing internal 6.0 build: https://dev.azure.com/dnceng/internal/_build/results?buildId=3032882&view=results
- Equivalent merged 8.0 fix: https://github.com/dotnet/winforms/pull/14750

After this merges, the change should be flowed to the downstream `internal/release/6.0` branch.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14844)