### PR TITLE
Fix editable control border color in NET11 visual styles

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.ModernComboAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.ModernComboAdapter.cs
@@ -418,7 +418,7 @@ public partial class ComboBox
 
             return useAccent
                 ? Application.SystemVisualSettings.AccentColor
-                : comboBox.ForeColor;
+                : ModernControlColorMath.TextControlBorderColor;
         }
 
         private static int GetBorderThickness(ComboBox comboBox)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TextBox/TextBoxBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TextBox/TextBoxBase.cs
@@ -2665,7 +2665,9 @@ public abstract partial class TextBoxBase : Control
 
         Color clientBackColor = BackColor;
         Color parentBackColor = Parent?.BackColor ?? BackColor;
-        Color adornerColor =  ModernControlColorMath.TextControlBorderColor;
+        Color adornerColor = Enabled
+            ? ModernControlColorMath.TextControlBorderColor
+            : ModernControlColorMath.GetDisabledBorderColor();
 
         using var clientBackgroundBrush = clientBackColor.GetCachedSolidBrushScope();
         using var adornerBrush = adornerColor.GetCachedSolidBrushScope();

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TextBox/TextBoxBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TextBox/TextBoxBase.cs
@@ -2663,10 +2663,9 @@ public abstract partial class TextBoxBase : Control
         int borderThickness = Math.Max(focusBorderMetrics.Width, focusBorderMetrics.Height);
         int focusBandHeight = GetVisualStylesFocusBandHeight();
 
-        Color adornerColor = ForeColor;
-
         Color clientBackColor = BackColor;
         Color parentBackColor = Parent?.BackColor ?? BackColor;
+        Color adornerColor =  ModernControlColorMath.TextControlBorderColor;
 
         using var clientBackgroundBrush = clientBackColor.GetCachedSolidBrushScope();
         using var adornerBrush = adornerColor.GetCachedSolidBrushScope();

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.cs
@@ -1084,10 +1084,9 @@ public abstract partial class UpDownBase : ContainerControl
         int cornerRadius = LogicalToDeviceUnits(ModernControlVisualStyles.UpDownCornerRadius);
         int borderThickness = LogicalToDeviceUnits(ModernControlVisualStyles.BorderThickness);
 
-        // The adorner (border) color matches the modern TextBox chrome, which uses the fore color.
-        Color adornerColor = ForeColor;
         Color parentBackColor = Parent?.BackColor ?? BackColor;
         Color clientBackColor = BackColor;
+        Color adornerColor = ModernControlColorMath.TextControlBorderColor;
 
         using var clientBackgroundBrush = clientBackColor.GetCachedSolidBrushScope();
         using var adornerPen = adornerColor.GetCachedPenScope(borderThickness);

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.cs
@@ -1086,7 +1086,9 @@ public abstract partial class UpDownBase : ContainerControl
 
         Color parentBackColor = Parent?.BackColor ?? BackColor;
         Color clientBackColor = BackColor;
-        Color adornerColor = ModernControlColorMath.TextControlBorderColor;
+        Color adornerColor = Enabled
+            ? ModernControlColorMath.TextControlBorderColor
+            : ModernControlColorMath.GetDisabledBorderColor();
 
         using var clientBackgroundBrush = clientBackColor.GetCachedSolidBrushScope();
         using var adornerPen = adornerColor.GetCachedPenScope(borderThickness);

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/ModernControlColorMath.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/ModernControlColorMath.cs
@@ -27,6 +27,9 @@ internal static class ModernControlColorMath
     private static readonly Color s_darkModeDisabledForeground = Color.FromArgb(0x88, 0x88, 0x88);
     private static readonly Color s_lightModeDisabledForeground = Color.FromArgb(0xA0, 0xA0, 0xA0);
 
+    /// <summary>
+    ///  Gets the stable border color for modern editable text controls when enabled.
+    /// </summary>
     internal static Color TextControlBorderColor
         => Application.IsDarkModeEnabled
             ? SystemColors.WindowText

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/ModernControlColorMath.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/ModernControlColorMath.cs
@@ -27,7 +27,10 @@ internal static class ModernControlColorMath
     private static readonly Color s_darkModeDisabledForeground = Color.FromArgb(0x88, 0x88, 0x88);
     private static readonly Color s_lightModeDisabledForeground = Color.FromArgb(0xA0, 0xA0, 0xA0);
 
-    internal static Color TextControlBorderColor => SystemColors.ControlDarkDark;
+    internal static Color TextControlBorderColor
+        => Application.IsDarkModeEnabled
+            ? SystemColors.WindowText
+            : SystemColors.WindowFrame;
 
     /// <summary>
     ///  Gets the surface color for a disabled modern control, honoring the current color mode

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/ModernControlColorMath.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/ModernControlColorMath.cs
@@ -27,6 +27,8 @@ internal static class ModernControlColorMath
     private static readonly Color s_darkModeDisabledForeground = Color.FromArgb(0x88, 0x88, 0x88);
     private static readonly Color s_lightModeDisabledForeground = Color.FromArgb(0xA0, 0xA0, 0xA0);
 
+    internal static Color TextControlBorderColor => SystemColors.ControlDarkDark;
+
     /// <summary>
     ///  Gets the surface color for a disabled modern control, honoring the current color mode
     ///  and high contrast settings.

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ComboBoxTests.cs
@@ -503,7 +503,7 @@ public class ComboBoxTests
 
         Color expectedBorder = usesAccent
             ? Application.SystemVisualSettings.AccentColor
-            : control.ForeColor;
+            : ModernControlColorMath.TextControlBorderColor;
         Assert.True(
             CountPixels(
                 actual,
@@ -642,13 +642,9 @@ public class ComboBoxTests
 
         if (flatStyle != FlatStyle.Popup)
         {
-            // Standard and Flat use the ForeColor for the border; it must be absent when disabled.
             Assert.True(
-                CountPixels(enabledBitmap, customForeColor, channelTolerance: 16) > 0,
-                "Enabled ComboBox should render border with ForeColor.");
-            Assert.True(
-                CountPixels(disabledBitmap, customForeColor, channelTolerance: 16) == 0,
-                "Disabled ComboBox must not render border with the ForeColor.");
+                CountPixels(enabledBitmap, ModernControlColorMath.TextControlBorderColor, channelTolerance: 16) > 0,
+                "Enabled ComboBox should render border with TextControlBorderColor.");
             Assert.True(
                 CountPixels(
                     disabledBitmap,


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14847


## Proposed changes

 Introduce shared editable-control border color logic in `ModernControlColorMath` and use it across NET11 editable renderers.

- Uses a **stable border color** instead of `ForeColor`.
- Applies the shared border color to `TextBoxBase`, `ComboBox.ModernComboAdapter`, and `UpDownBase`.
- Uses a visible dark-mode border color.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

-  Customers using VisualStylesMode.Net11 can customize editable-control text colors without unintentionally changing the control border. 

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Changing ForeColor on editable controls in VisualStylesMode.Net11  also change the border color.

<img width="1346" height="498" alt="Image" src="https://github.com/user-attachments/assets/6a02d9ad-8d23-4321-88af-47bb07786236" />

### After

Editable-control border color is independent from ForeColor.

Light mode:

<img width="1360" height="1083" alt="image" src="https://github.com/user-attachments/assets/6fb7f983-f4e4-4089-87cf-73f832278040" />


Dark mode:
<img width="1356" height="1076" alt="image" src="https://github.com/user-attachments/assets/4c82addf-169a-4ab5-91c6-2b44409d70fc" />

## Test methodology <!-- How did you ensure quality? -->

- Manually
 

## Test environment(s) <!-- Remove any that don't apply -->

- .net11.0.0-rc.1.26404.101


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14853)