### PR TITLE
Fixes PrintPreviewControl displays a black preview page after assigning an empty PrintDocument

### DIFF
--- a/src/System.Windows.Forms/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/PublicAPI.Unshipped.txt
@@ -109,3 +109,5 @@ virtual System.Windows.Forms.Control.OnParentVisualStylesModeChanged(System.Even
 virtual System.Windows.Forms.Control.OnVisualStylesModeChanged(System.EventArgs! e) -> void
 virtual System.Windows.Forms.Control.VisualStylesMode.get -> System.Windows.Forms.VisualStylesMode
 virtual System.Windows.Forms.Control.VisualStylesMode.set -> void
+override System.Windows.Forms.PrintPreviewControl.ForeColor.get -> System.Drawing.Color
+override System.Windows.Forms.PrintPreviewControl.ForeColor.set -> void

--- a/src/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -691,8 +691,10 @@ public partial class PrintPreviewControl : Control
                 Rectangle box = pageRenderArea[i];
                 g.DrawRectangle(Pens.Black, box);
 
-                // Page background is fixed white; ForeColor is unrelated (it colors message text only).
-                using (var brush = Color.White.GetCachedSolidBrushScope())
+                // Default page fill is white (paper); an explicitly set ForeColor is still honored,
+                // as it always has been.
+                Color pageColor = _isForeColorSet ? ForeColor : Color.White;
+                using (var brush = pageColor.GetCachedSolidBrushScope())
                 {
                     g.FillRectangle(brush, box);
                 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -58,7 +58,6 @@ public partial class PrintPreviewControl : Control
     {
         ResetBackColor();
         ResetForeColor();
-        ForeColorChanged += (_, _) => _isForeColorSet = true;
         Size = new Size(100, 100);
         SetStyle(ControlStyles.ResizeRedraw, false);
         SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.UserPaint | ControlStyles.OptimizedDoubleBuffer, true);
@@ -295,6 +294,22 @@ public partial class PrintPreviewControl : Control
     public override void ResetBackColor() => BackColor = SystemColors.AppWorkspace;
 
     internal override bool ShouldSerializeBackColor() => !BackColor.Equals(SystemColors.AppWorkspace);
+
+    /// <summary>
+    ///  Gets or sets the foreground color of the "no printable content" message text, and (when
+    ///  explicitly set) each previewed page's background.
+    /// </summary>
+    public override Color ForeColor
+    {
+        get => base.ForeColor;
+        set
+        {
+            // Tracked here, not via ForeColorChanged: that event only fires on an actual value
+            // change, so reassigning the current value would otherwise look like "never set".
+            _isForeColorSet = true;
+            base.ForeColor = value;
+        }
+    }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public override void ResetForeColor()
@@ -691,8 +706,7 @@ public partial class PrintPreviewControl : Control
                 Rectangle box = pageRenderArea[i];
                 g.DrawRectangle(Pens.Black, box);
 
-                // Default page fill is white (paper); an explicitly set ForeColor is still honored,
-                // as it always has been.
+                // Default page fill is white; an explicitly set ForeColor is still honored, as it always has been.
                 Color pageColor = _isForeColorSet ? ForeColor : Color.White;
                 using (var brush = pageColor.GetCachedSolidBrushScope())
                 {

--- a/src/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -690,7 +690,9 @@ public partial class PrintPreviewControl : Control
             {
                 Rectangle box = pageRenderArea[i];
                 g.DrawRectangle(Pens.Black, box);
-                using (var brush = ForeColor.GetCachedSolidBrushScope())
+
+                // Page background is fixed white; ForeColor is unrelated (it colors message text only).
+                using (var brush = Color.White.GetCachedSolidBrushScope())
                 {
                     g.FillRectangle(brush, box);
                 }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControlTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControlTests.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System.Drawing;
+using System.Drawing.Printing;
 
 namespace System.Windows.Forms.Tests;
 
@@ -66,6 +67,32 @@ public class PrintPreviewControlTests
 
         Assert.False(control.TestAccessor.Dynamic.ShouldSerializeForeColor());
         Assert.Equal(SystemColors.ControlText.ToArgb(), control.ForeColor.ToArgb());
+    }
+
+    [WinFormsFact]
+    public void PrintPreviewControl_PageWithNoImage_RendersWhiteNotForeColor()
+    {
+        // Regression test for #14838: a page with no drawable content (e.g. from an empty
+        // PrintDocument) must render as white paper, not as a solid ForeColor rectangle.
+        using PrintPreviewControl control = new()
+        {
+            ForeColor = Color.Black,
+            Size = new Size(200, 200)
+        };
+
+        control.CreateControl();
+
+        PreviewPageInfo[] pageInfo = [new(image: null, physicalSize: new Size(850, 1100))];
+        control.TestAccessor.Dynamic._pageInfo = pageInfo;
+
+        using Bitmap bitmap = new(control.Width, control.Height);
+        control.DrawToBitmap(bitmap, new Rectangle(Point.Empty, control.Size));
+
+        // The single page fills nearly the whole control, so the center pixel lands well
+        // inside the page interior, away from its 1px black border.
+        Color centerPixel = bitmap.GetPixel(bitmap.Width / 2, bitmap.Height / 2);
+
+        Assert.Equal(Color.White.ToArgb(), centerPixel.ToArgb());
     }
 
     [Fact]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControlTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControlTests.cs
@@ -45,7 +45,7 @@ public class PrintPreviewControlTests
     [Fact]
     public void PrintPreviewControl_ForeColorWhiteExplicitlySet_ShouldSerializeReturnsTrue()
     {
-        // Regression: #14420 - explicitly setting White must be distinguishable from the default.
+        // Regression: #14420 (explicitly setting White must be distinguishable from the default).
         PrintPreviewControl control = new() { ForeColor = Color.White };
 
         Assert.True(control.TestAccessor.Dynamic.ShouldSerializeForeColor());
@@ -73,8 +73,8 @@ public class PrintPreviewControlTests
     public void PrintPreviewControl_PageWithNoImage_DefaultForeColor_RendersWhite()
     {
         // Regression test for #14838: a page with no drawable content (e.g. from an empty
-        // PrintDocument), with ForeColor left at its default, must render as white paper,
-        // not as a solid black rectangle.
+        // PrintDocument), with ForeColor left at its default, must render as white paper, not as
+        // a solid black rectangle.
         using PrintPreviewControl control = new()
         {
             Size = new Size(200, 200)
@@ -98,9 +98,8 @@ public class PrintPreviewControlTests
     [WinFormsFact]
     public void PrintPreviewControl_PageWithNoImage_ExplicitForeColor_RendersForeColor()
     {
-        // ForeColor has driven the page background fill since the original .NET Framework port;
-        // an explicitly set value must still be honored (see PR #14857 discussion), not overridden
-        // by the white default that only applies when ForeColor was never set.
+        // ForeColor has driven the page background since the .NET Framework days; an explicit
+        // value must still be honored, not overridden by the white-when-unset default.
         using PrintPreviewControl control = new()
         {
             ForeColor = Color.Red,
@@ -118,6 +117,31 @@ public class PrintPreviewControlTests
         Color centerPixel = bitmap.GetPixel(bitmap.Width / 2, bitmap.Height / 2);
 
         Assert.Equal(Color.Red.ToArgb(), centerPixel.ToArgb());
+    }
+
+    [WinFormsFact]
+    public void PrintPreviewControl_PageWithNoImage_ExplicitForeColorMatchingDefault_RendersForeColor()
+    {
+        // Assigning ForeColor to the value it already holds must still count as explicit, even
+        // though ForeColorChanged doesn't fire for a same-value reassignment.
+        using PrintPreviewControl control = new()
+        {
+            Size = new Size(200, 200)
+        };
+        control.ForeColor = SystemColors.ControlText;
+
+        control.CreateControl();
+
+        PreviewPageInfo[] pageInfo = [new(image: null, physicalSize: new Size(850, 1100))];
+        control.TestAccessor.Dynamic._pageInfo = pageInfo;
+
+        using Bitmap bitmap = new(control.Width, control.Height);
+        control.DrawToBitmap(bitmap, new Rectangle(Point.Empty, control.Size));
+
+        Color centerPixel = bitmap.GetPixel(bitmap.Width / 2, bitmap.Height / 2);
+
+        Assert.Equal(SystemColors.ControlText.ToArgb(), centerPixel.ToArgb());
+        Assert.True(control.TestAccessor.Dynamic.ShouldSerializeForeColor());
     }
 
     [Fact]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControlTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/Printing/PrintPreviewControlTests.cs
@@ -70,13 +70,13 @@ public class PrintPreviewControlTests
     }
 
     [WinFormsFact]
-    public void PrintPreviewControl_PageWithNoImage_RendersWhiteNotForeColor()
+    public void PrintPreviewControl_PageWithNoImage_DefaultForeColor_RendersWhite()
     {
         // Regression test for #14838: a page with no drawable content (e.g. from an empty
-        // PrintDocument) must render as white paper, not as a solid ForeColor rectangle.
+        // PrintDocument), with ForeColor left at its default, must render as white paper,
+        // not as a solid black rectangle.
         using PrintPreviewControl control = new()
         {
-            ForeColor = Color.Black,
             Size = new Size(200, 200)
         };
 
@@ -93,6 +93,31 @@ public class PrintPreviewControlTests
         Color centerPixel = bitmap.GetPixel(bitmap.Width / 2, bitmap.Height / 2);
 
         Assert.Equal(Color.White.ToArgb(), centerPixel.ToArgb());
+    }
+
+    [WinFormsFact]
+    public void PrintPreviewControl_PageWithNoImage_ExplicitForeColor_RendersForeColor()
+    {
+        // ForeColor has driven the page background fill since the original .NET Framework port;
+        // an explicitly set value must still be honored (see PR #14857 discussion), not overridden
+        // by the white default that only applies when ForeColor was never set.
+        using PrintPreviewControl control = new()
+        {
+            ForeColor = Color.Red,
+            Size = new Size(200, 200)
+        };
+
+        control.CreateControl();
+
+        PreviewPageInfo[] pageInfo = [new(image: null, physicalSize: new Size(850, 1100))];
+        control.TestAccessor.Dynamic._pageInfo = pageInfo;
+
+        using Bitmap bitmap = new(control.Width, control.Height);
+        control.DrawToBitmap(bitmap, new Rectangle(Point.Empty, control.Size));
+
+        Color centerPixel = bitmap.GetPixel(bitmap.Width / 2, bitmap.Height / 2);
+
+        Assert.Equal(Color.Red.ToArgb(), centerPixel.ToArgb());
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #14838

## Proposed changes

- In `PrintPreviewControl.DrawPages`, the page-background fill now uses `Color.White` only when `ForeColor` was never explicitly set; an explicitly set `ForeColor` is still honored, as it has always been since the original .NET Framework port (uses the existing `_isForeColorSet` flag added by #14424).
- Added unit tests covering both cases: default `ForeColor` renders white, explicit `ForeColor` renders that color.

## Customer Impact

- Fixes the solid-black preview page reported for a `PrintDocument` that produces no printable content, with `ForeColor` left at its default.
- Apps that explicitly set `ForeColor` to customize the page background keep working exactly as before; no behavior change for them.

## Regression?

- Yes. Regression from #14424 (merged 2026-07-02), which correctly changed `ResetForeColor()`'s default from `Color.White` to `SystemColors.ControlText` to fix #14420. `DrawPages()` separately reused `ForeColor` to fill each page's background (present since the original .NET Framework port) and only rendered white by coincidence, because the old default happened to match. This PR doesn't touch #14424's changes (`ForeColor`, `ResetForeColor`, `ShouldSerializeForeColor`, `DrawMessage`), so #14420 stays fixed; it only changes the unrelated page-background fill in `DrawPages`.

## Risk

- Low. Change is scoped to one `Color` expression in `DrawPages`, gated on the existing `_isForeColorSet` flag. Preserves the pre-#14424 behavior for explicit `ForeColor` (per review feedback on this PR: `ForeColor` has driven the page background since .NET Framework), and fixes the black-default regression for everyone else.

## Screenshots

### Before

<img width="798" height="478" alt="before_fix" src="https://github.com/user-attachments/assets/46d7265e-6e20-4228-b245-9a67c1de478e" />

### After

<img width="797" height="477" alt="after_fix" src="https://github.com/user-attachments/assets/d4126465-116c-48fb-87b6-b0c7d77bab7d" />

## Test methodology

- Unit tests

## Test environment(s)

- 11.0.100-preview.6.26359.118

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14857)