### PR TITLE
Fix ComboBox drop-down button incorrectly uses BackColor

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.ModernComboAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.ModernComboAdapter.cs
@@ -253,10 +253,10 @@ public partial class ComboBox
         }
 
         private static Color GetDropDownButtonBaseColor(ComboBox comboBox)
-             => Application.IsDarkModeEnabled
-                 && comboBox.DarkModeRequestState is true
-                     ? SystemColors.ControlDark
-                     : SystemColors.Window;
+            => Application.IsDarkModeEnabled
+                && comboBox.DarkModeRequestState is true
+                    ? SystemColors.ControlDark
+                    : SystemColors.Window;
 
         private void DrawDropDownListText(
             ComboBox comboBox,

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.ModernComboAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.ModernComboAdapter.cs
@@ -201,7 +201,7 @@ public partial class ComboBox
                 return;
             }
 
-            Color background = GetEffectiveBackColor(comboBox);
+            Color background = GetDropDownButtonBaseColor(comboBox);
             Color buttonColor = comboBox._mousePressed
                 ? PopupButtonColorMath.Blend(
                     background,
@@ -251,6 +251,12 @@ public partial class ComboBox
             using var pen = chevronColor.GetCachedPenScope(stroke);
             graphics.DrawLines(pen, points);
         }
+
+        private static Color GetDropDownButtonBaseColor(ComboBox comboBox)
+             => Application.IsDarkModeEnabled
+                 && comboBox.DarkModeRequestState is true
+                     ? SystemColors.ControlDark
+                     : SystemColors.Window;
 
         private void DrawDropDownListText(
             ComboBox comboBox,


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14849

## Root Cause

The NET11 ModernComboAdapter treated ComboBox.BackColor as the base color for the drop-down button. As a result, assigning a custom field background also tinted the button, unlike Classic mode where the button remains system-rendered.

## Proposed changes

- Update the NET11 `ComboBox `renderer so the drop-down button no longer derives its surface color from `ComboBox.BackColor`.


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Setting `BackColor `customizes only the editable field, the drop-down button retains a neutral system appearance.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Editable field and drop-down button both use/tint from `BackColor`.

<img width="665" height="188" alt="Image" src="https://github.com/user-attachments/assets/c41113ee-65c2-439b-ae86-3b86d0347b84" />

### After

Only the editable field uses `BackColor`, the drop-down button retains neutral system chrome.

DarkMode:
<img width="1352" height="411" alt="image" src="https://github.com/user-attachments/assets/30621c35-8aca-47be-ac20-42807de8f012" />

Light mode:
<img width="1347" height="406" alt="image" src="https://github.com/user-attachments/assets/239c687d-5340-457d-9d4c-e57b1dd70545" />

## Test methodology <!-- How did you ensure quality? -->

-  Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-rc.1.26405.103


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14861)