### PR TITLE
Fix issue 14859: CheckBox and RadioButton ignore explicit BackColor values in VisualStylesMode.Net11

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/CheckBoxModernAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/CheckBoxModernAdapter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
@@ -80,7 +80,10 @@ internal sealed class CheckBoxModernAdapter : CheckBoxBaseAdapter
     private void PaintCore(PaintEventArgs e)
     {
         Graphics graphics = e.GraphicsInternal;
-        if (!Control.UseVisualStyleBackColor && !Control.BackColor.HasTransparency())
+        bool useControlBackColor = !Control.BackColor.HasTransparency()
+            && (Control.ShouldSerializeBackColor() || !Control.UseVisualStyleBackColor);
+
+        if (useControlBackColor)
         {
             using var backBrush = Control.BackColor.GetCachedSolidBrushScope();
             graphics.FillRectangle(backBrush, Control.ClientRectangle);
@@ -98,11 +101,6 @@ internal sealed class CheckBoxModernAdapter : CheckBoxBaseAdapter
         AdjustFocusRectangle(layout);
         PaintBackgroundImage(e);
 
-        Color? customOnColor = Control.ShouldSerializeBackColor()
-            && Control.BackColor.A == byte.MaxValue
-                ? Control.BackColor
-                : null;
-
         Color? customBorderColor = Control.FlatAppearance.BorderColor.IsEmpty
             ? null
             : Control.FlatAppearance.BorderColor;
@@ -115,7 +113,7 @@ internal sealed class CheckBoxModernAdapter : CheckBoxBaseAdapter
             Control.Enabled,
             Control.MouseIsOver,
             Control.Focused && Control.ShowFocusCues,
-            customOnColor,
+            customOnColor: null,
             customBorderColor);
 
         PaintImage(e, layout);
@@ -125,11 +123,16 @@ internal sealed class CheckBoxModernAdapter : CheckBoxBaseAdapter
             : Application.IsDarkModeEnabled
                 ? Color.FromArgb(0xF0, 0xF0, 0xF0)
                 : SystemColors.WindowText;
+        Color disabledTextBackColor = Control.ShouldSerializeBackColor()
+            && Control.BackColor.A == byte.MaxValue
+                ? Control.BackColor
+                : Control.Parent?.BackColor ?? Control.BackColor;
+
         Color textColor = Control.Enabled
             ? preferredTextColor
             : ModernControlColorMath.GetDisabledTextColor(
                 preferredTextColor,
-                Control.Parent?.BackColor ?? Control.BackColor);
+                disabledTextBackColor);
 
         PaintField(e, layout, PaintRender(e).Calculate(), textColor, drawFocus: true);
     }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/CheckBoxModernAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/CheckBoxModernAdapter.cs
@@ -80,10 +80,10 @@ internal sealed class CheckBoxModernAdapter : CheckBoxBaseAdapter
     private void PaintCore(PaintEventArgs e)
     {
         Graphics graphics = e.GraphicsInternal;
-        bool useControlBackColor = !Control.BackColor.HasTransparency()
-            && (Control.ShouldSerializeBackColor() || !Control.UseVisualStyleBackColor);
+        bool useExplicitBackColor = Control.ShouldSerializeBackColor() || !Control.UseVisualStyleBackColor;
+        bool hasTransparentBackColor = Control.BackColor.HasTransparency();
 
-        if (useControlBackColor)
+        if (useExplicitBackColor && !hasTransparentBackColor)
         {
             using var backBrush = Control.BackColor.GetCachedSolidBrushScope();
             graphics.FillRectangle(backBrush, Control.ClientRectangle);
@@ -95,6 +95,12 @@ internal sealed class CheckBoxModernAdapter : CheckBoxBaseAdapter
                 graphics,
                 Control.ClientRectangle,
                 Control.BackColor);
+
+            if (useExplicitBackColor && hasTransparentBackColor && Control.BackColor.A > 0)
+            {
+                using var backBrush = Control.BackColor.GetCachedSolidBrushScope();
+                graphics.FillRectangle(backBrush, Control.ClientRectangle);
+            }
         }
 
         LayoutData layout = Layout(e).Layout();

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/CheckBoxModernAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/CheckBoxModernAdapter.cs
@@ -80,11 +80,19 @@ internal sealed class CheckBoxModernAdapter : CheckBoxBaseAdapter
     private void PaintCore(PaintEventArgs e)
     {
         Graphics graphics = e.GraphicsInternal;
-        ParentBackgroundRenderer.Paint(
-            Control,
-            graphics,
-            Control.ClientRectangle,
-            Control.BackColor);
+        if (!Control.UseVisualStyleBackColor && !Control.BackColor.HasTransparency())
+        {
+            using var backBrush = Control.BackColor.GetCachedSolidBrushScope();
+            graphics.FillRectangle(backBrush, Control.ClientRectangle);
+        }
+        else
+        {
+            ParentBackgroundRenderer.Paint(
+                Control,
+                graphics,
+                Control.ClientRectangle,
+                Control.BackColor);
+        }
 
         LayoutData layout = Layout(e).Layout();
         AdjustFocusRectangle(layout);

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/RadioButtonModernAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/RadioButtonModernAdapter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
@@ -79,7 +79,10 @@ internal sealed class RadioButtonModernAdapter : RadioButtonBaseAdapter
     private void PaintCore(PaintEventArgs e)
     {
         Graphics graphics = e.GraphicsInternal;
-        if (!Control.UseVisualStyleBackColor && !Control.BackColor.HasTransparency())
+        bool useControlBackColor = !Control.BackColor.HasTransparency()
+            && (Control.ShouldSerializeBackColor() || !Control.UseVisualStyleBackColor);
+
+        if (useControlBackColor)
         {
             using var backBrush = Control.BackColor.GetCachedSolidBrushScope();
             graphics.FillRectangle(backBrush, Control.ClientRectangle);
@@ -97,11 +100,6 @@ internal sealed class RadioButtonModernAdapter : RadioButtonBaseAdapter
         AdjustFocusRectangle(layout);
         PaintBackgroundImage(e);
 
-        Color? customOnColor = Control.ShouldSerializeBackColor()
-            && Control.BackColor.A == byte.MaxValue
-                ? Control.BackColor
-                : null;
-
         Color? customBorderColor = Control.FlatAppearance.BorderColor.IsEmpty
             ? null
             : Control.FlatAppearance.BorderColor;
@@ -114,7 +112,7 @@ internal sealed class RadioButtonModernAdapter : RadioButtonBaseAdapter
             Control.Enabled,
             Control.MouseIsOver,
             Control.Focused && Control.ShowFocusCues,
-            customOnColor,
+            customOnColor: null,
             customBorderColor);
 
         PaintImage(e, layout);
@@ -124,11 +122,16 @@ internal sealed class RadioButtonModernAdapter : RadioButtonBaseAdapter
             : Application.IsDarkModeEnabled
                 ? Color.FromArgb(0xF0, 0xF0, 0xF0)
                 : SystemColors.WindowText;
+        Color disabledTextBackColor = Control.ShouldSerializeBackColor()
+            && Control.BackColor.A == byte.MaxValue
+                ? Control.BackColor
+                : Control.Parent?.BackColor ?? Control.BackColor;
+
         Color textColor = Control.Enabled
             ? preferredTextColor
             : ModernControlColorMath.GetDisabledTextColor(
                 preferredTextColor,
-                Control.Parent?.BackColor ?? Control.BackColor);
+                disabledTextBackColor);
 
         PaintField(e, layout, PaintRender(e).Calculate(), textColor, drawFocus: true);
     }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/RadioButtonModernAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/RadioButtonModernAdapter.cs
@@ -79,10 +79,10 @@ internal sealed class RadioButtonModernAdapter : RadioButtonBaseAdapter
     private void PaintCore(PaintEventArgs e)
     {
         Graphics graphics = e.GraphicsInternal;
-        bool useControlBackColor = !Control.BackColor.HasTransparency()
-            && (Control.ShouldSerializeBackColor() || !Control.UseVisualStyleBackColor);
+        bool useExplicitBackColor = Control.ShouldSerializeBackColor() || !Control.UseVisualStyleBackColor;
+        bool hasTransparentBackColor = Control.BackColor.HasTransparency();
 
-        if (useControlBackColor)
+        if (useExplicitBackColor && !hasTransparentBackColor)
         {
             using var backBrush = Control.BackColor.GetCachedSolidBrushScope();
             graphics.FillRectangle(backBrush, Control.ClientRectangle);
@@ -94,6 +94,12 @@ internal sealed class RadioButtonModernAdapter : RadioButtonBaseAdapter
                 graphics,
                 Control.ClientRectangle,
                 Control.BackColor);
+
+            if (useExplicitBackColor && hasTransparentBackColor && Control.BackColor.A > 0)
+            {
+                using var backBrush = Control.BackColor.GetCachedSolidBrushScope();
+                graphics.FillRectangle(backBrush, Control.ClientRectangle);
+            }
         }
 
         LayoutData layout = Layout(e).Layout();

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/RadioButtonModernAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/RadioButtonModernAdapter.cs
@@ -79,11 +79,19 @@ internal sealed class RadioButtonModernAdapter : RadioButtonBaseAdapter
     private void PaintCore(PaintEventArgs e)
     {
         Graphics graphics = e.GraphicsInternal;
-        ParentBackgroundRenderer.Paint(
-            Control,
-            graphics,
-            Control.ClientRectangle,
-            Control.BackColor);
+        if (!Control.UseVisualStyleBackColor && !Control.BackColor.HasTransparency())
+        {
+            using var backBrush = Control.BackColor.GetCachedSolidBrushScope();
+            graphics.FillRectangle(backBrush, Control.ClientRectangle);
+        }
+        else
+        {
+            ParentBackgroundRenderer.Paint(
+                Control,
+                graphics,
+                Control.ClientRectangle,
+                Control.BackColor);
+        }
 
         LayoutData layout = Layout(e).Layout();
         AdjustFocusRectangle(layout);

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/CheckBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/CheckBoxTests.cs
@@ -582,6 +582,7 @@ public class CheckBoxTests : AbstractButtonBaseTests
         using CheckBox box = new()
         {
             BackColor = Color.Red,
+            UseVisualStyleBackColor = true,
             CheckState = checkState,
             Size = new Size(40, 24),
             VisualStylesMode = VisualStylesMode.Net11
@@ -595,6 +596,31 @@ public class CheckBoxTests : AbstractButtonBaseTests
         box.CreateStandardAdapter().PaintUp(e, checkState);
 
         Assert.Equal(expectedAccent, CountPixels(bitmap, Color.Red) > 0);
+    }
+
+    [WinFormsFact]
+    public void CheckBox_ModernGlyph_UsesExplicitBackColorWhenVisualStyleBackgroundDisabled()
+    {
+        using Panel parent = new() { BackColor = Color.White };
+        using CheckBox box = new()
+        {
+            BackColor = Color.Aqua,
+            CheckState = CheckState.Unchecked,
+            Text = string.Empty,
+            Size = new Size(40, 24),
+            VisualStylesMode = VisualStylesMode.Net11
+        };
+
+        parent.Controls.Add(box);
+
+        using Bitmap bitmap = new(box.Width, box.Height);
+        using Graphics graphics = Graphics.FromImage(bitmap);
+        PaintEventArgs e = new(graphics, box.ClientRectangle);
+
+        box.CreateStandardAdapter().PaintUp(e, box.CheckState);
+
+        Color backgroundPixel = bitmap.GetPixel(box.Width - 2, box.Height / 2);
+        Assert.Equal(Color.Aqua.ToArgb(), backgroundPixel.ToArgb());
     }
 
     [WinFormsFact]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/CheckBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/CheckBoxTests.cs
@@ -571,7 +571,7 @@ public class CheckBoxTests : AbstractButtonBaseTests
     [InlineData(CheckState.Unchecked, false)]
     [InlineData(CheckState.Checked, true)]
     [InlineData(CheckState.Indeterminate, true)]
-    public void CheckBox_ModernGlyph_RendersAccentForCheckedStates(CheckState checkState, bool expectedAccent)
+    public void CheckBox_ModernGlyph_UsesExplicitBackColorWithoutTintingCheckedGlyph(CheckState checkState, bool expectedAccent)
     {
         if (SystemInformation.HighContrast)
         {
@@ -595,7 +595,11 @@ public class CheckBoxTests : AbstractButtonBaseTests
 
         box.CreateStandardAdapter().PaintUp(e, checkState);
 
-        Assert.Equal(expectedAccent, CountPixels(bitmap, Color.Red) > 0);
+        Color backgroundPixel = bitmap.GetPixel(box.Width - 2, box.Height / 2);
+        Assert.Equal(Color.Red.ToArgb(), backgroundPixel.ToArgb());
+        Assert.Equal(
+            expectedAccent,
+            CountPixels(bitmap, Application.SystemVisualSettings.AccentColor) > 0);
     }
 
     [WinFormsFact]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/CheckBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/CheckBoxTests.cs
@@ -578,10 +578,16 @@ public class CheckBoxTests : AbstractButtonBaseTests
             return;
         }
 
+        Color accentColor = Application.SystemVisualSettings.AccentColor;
+        Color backgroundColor = Color.FromArgb(
+            accentColor.R ^ 0xFF,
+            accentColor.G ^ 0xFF,
+            accentColor.B ^ 0xFF);
+
         using Panel parent = new() { BackColor = Color.White };
         using CheckBox box = new()
         {
-            BackColor = Color.Red,
+            BackColor = backgroundColor,
             UseVisualStyleBackColor = true,
             CheckState = checkState,
             Size = new Size(40, 24),
@@ -596,10 +602,10 @@ public class CheckBoxTests : AbstractButtonBaseTests
         box.CreateStandardAdapter().PaintUp(e, checkState);
 
         Color backgroundPixel = bitmap.GetPixel(box.Width - 2, box.Height / 2);
-        Assert.Equal(Color.Red.ToArgb(), backgroundPixel.ToArgb());
+        Assert.Equal(backgroundColor.ToArgb(), backgroundPixel.ToArgb());
         Assert.Equal(
             expectedAccent,
-            CountPixels(bitmap, Application.SystemVisualSettings.AccentColor) > 0);
+            CountPixels(bitmap, accentColor) > 0);
     }
 
     [WinFormsFact]
@@ -625,6 +631,39 @@ public class CheckBoxTests : AbstractButtonBaseTests
 
         Color backgroundPixel = bitmap.GetPixel(box.Width - 2, box.Height / 2);
         Assert.Equal(Color.Aqua.ToArgb(), backgroundPixel.ToArgb());
+    }
+
+    [WinFormsFact]
+    public void CheckBox_ModernGlyph_UsesTranslucentBackColorWhenVisualStyleBackgroundEnabled()
+    {
+        Color parentBackColor = Color.White;
+        Color translucentBackColor = Color.FromArgb(128, Color.Aqua);
+
+        using Panel parent = new() { BackColor = parentBackColor };
+        using CheckBox box = new()
+        {
+            BackColor = translucentBackColor,
+            UseVisualStyleBackColor = true,
+            CheckState = CheckState.Unchecked,
+            Text = string.Empty,
+            Size = new Size(40, 24),
+            VisualStylesMode = VisualStylesMode.Net11
+        };
+
+        parent.Controls.Add(box);
+
+        using Bitmap bitmap = new(box.Width, box.Height);
+        using Graphics graphics = Graphics.FromImage(bitmap);
+        graphics.Clear(parentBackColor);
+        PaintEventArgs e = new(graphics, box.ClientRectangle);
+
+        box.CreateStandardAdapter().PaintUp(e, box.CheckState);
+
+        Color backgroundPixel = bitmap.GetPixel(box.Width - 2, box.Height / 2);
+        Color expected = BlendColors(parentBackColor, translucentBackColor);
+        Assert.InRange(Math.Abs(backgroundPixel.R - expected.R), 0, 1);
+        Assert.InRange(Math.Abs(backgroundPixel.G - expected.G), 0, 1);
+        Assert.InRange(Math.Abs(backgroundPixel.B - expected.B), 0, 1);
     }
 
     [WinFormsFact]
@@ -1062,6 +1101,18 @@ public class CheckBoxTests : AbstractButtonBaseTests
         }
 
         return count;
+    }
+
+    private static Color BlendColors(Color background, Color overlay)
+    {
+        int alpha = overlay.A;
+        int inverseAlpha = byte.MaxValue - alpha;
+
+        int red = ((overlay.R * alpha) + (background.R * inverseAlpha) + 127) / 255;
+        int green = ((overlay.G * alpha) + (background.G * inverseAlpha) + 127) / 255;
+        int blue = ((overlay.B * alpha) + (background.B * inverseAlpha) + 127) / 255;
+
+        return Color.FromArgb(red, green, blue);
     }
 
     [WinFormsFact]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/RadioButtonTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/RadioButtonTests.cs
@@ -209,7 +209,7 @@ public class RadioButtonTests : AbstractButtonBaseTests
     [WinFormsTheory]
     [InlineData(false, false)]
     [InlineData(true, true)]
-    public void RadioButton_ModernGlyph_RendersAccentWhenChecked(bool isChecked, bool expectedAccent)
+    public void RadioButton_ModernGlyph_UsesExplicitBackColorWithoutTintingCheckedGlyph(bool isChecked, bool expectedAccent)
     {
         if (SystemInformation.HighContrast)
         {
@@ -235,7 +235,11 @@ public class RadioButtonTests : AbstractButtonBaseTests
             e,
             isChecked ? CheckState.Checked : CheckState.Unchecked);
 
-        Assert.Equal(expectedAccent, CountPixels(bitmap, Color.Red) > 0);
+        Color backgroundPixel = bitmap.GetPixel(control.Width - 2, control.Height / 2);
+        Assert.Equal(Color.Red.ToArgb(), backgroundPixel.ToArgb());
+        Assert.Equal(
+            expectedAccent,
+            CountPixels(bitmap, Application.SystemVisualSettings.AccentColor, channelTolerance: 24) > 0);
     }
 
     [WinFormsFact]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/RadioButtonTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/RadioButtonTests.cs
@@ -216,10 +216,16 @@ public class RadioButtonTests : AbstractButtonBaseTests
             return;
         }
 
+        Color accentColor = Application.SystemVisualSettings.AccentColor;
+        Color backgroundColor = Color.FromArgb(
+            accentColor.R ^ 0xFF,
+            accentColor.G ^ 0xFF,
+            accentColor.B ^ 0xFF);
+
         using Panel parent = new() { BackColor = Color.White };
         using RadioButton control = new()
         {
-            BackColor = Color.Red,
+            BackColor = backgroundColor,
             UseVisualStyleBackColor = true,
             Checked = isChecked,
             Size = new Size(40, 24),
@@ -236,10 +242,10 @@ public class RadioButtonTests : AbstractButtonBaseTests
             isChecked ? CheckState.Checked : CheckState.Unchecked);
 
         Color backgroundPixel = bitmap.GetPixel(control.Width - 2, control.Height / 2);
-        Assert.Equal(Color.Red.ToArgb(), backgroundPixel.ToArgb());
+        Assert.Equal(backgroundColor.ToArgb(), backgroundPixel.ToArgb());
         Assert.Equal(
             expectedAccent,
-            CountPixels(bitmap, Application.SystemVisualSettings.AccentColor, channelTolerance: 24) > 0);
+            CountPixels(bitmap, accentColor, channelTolerance: 24) > 0);
     }
 
     [WinFormsFact]
@@ -265,6 +271,39 @@ public class RadioButtonTests : AbstractButtonBaseTests
 
         Color backgroundPixel = bitmap.GetPixel(control.Width - 2, control.Height / 2);
         Assert.Equal(Color.Aqua.ToArgb(), backgroundPixel.ToArgb());
+    }
+
+    [WinFormsFact]
+    public void RadioButton_ModernGlyph_UsesTranslucentBackColorWhenVisualStyleBackgroundEnabled()
+    {
+        Color parentBackColor = Color.White;
+        Color translucentBackColor = Color.FromArgb(128, Color.Aqua);
+
+        using Panel parent = new() { BackColor = parentBackColor };
+        using RadioButton control = new()
+        {
+            BackColor = translucentBackColor,
+            UseVisualStyleBackColor = true,
+            Checked = false,
+            Text = string.Empty,
+            Size = new Size(40, 24),
+            VisualStylesMode = VisualStylesMode.Net11
+        };
+
+        parent.Controls.Add(control);
+
+        using Bitmap bitmap = new(control.Width, control.Height);
+        using Graphics graphics = Graphics.FromImage(bitmap);
+        graphics.Clear(parentBackColor);
+        PaintEventArgs e = new(graphics, control.ClientRectangle);
+
+        control.CreateStandardAdapter().PaintUp(e, CheckState.Unchecked);
+
+        Color backgroundPixel = bitmap.GetPixel(control.Width - 2, control.Height / 2);
+        Color expected = BlendColors(parentBackColor, translucentBackColor);
+        Assert.InRange(Math.Abs(backgroundPixel.R - expected.R), 0, 1);
+        Assert.InRange(Math.Abs(backgroundPixel.G - expected.G), 0, 1);
+        Assert.InRange(Math.Abs(backgroundPixel.B - expected.B), 0, 1);
     }
 
     [WinFormsFact]
@@ -402,6 +441,18 @@ public class RadioButtonTests : AbstractButtonBaseTests
 
     private static int CountPixels(Bitmap bitmap, Color color)
         => CountPixels(bitmap, color, channelTolerance: 0);
+
+    private static Color BlendColors(Color background, Color overlay)
+    {
+        int alpha = overlay.A;
+        int inverseAlpha = byte.MaxValue - alpha;
+
+        int red = ((overlay.R * alpha) + (background.R * inverseAlpha) + 127) / 255;
+        int green = ((overlay.G * alpha) + (background.G * inverseAlpha) + 127) / 255;
+        int blue = ((overlay.B * alpha) + (background.B * inverseAlpha) + 127) / 255;
+
+        return Color.FromArgb(red, green, blue);
+    }
 
     private static int CountPixels(Bitmap bitmap, Color color, int channelTolerance)
     {

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/RadioButtonTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/RadioButtonTests.cs
@@ -220,6 +220,7 @@ public class RadioButtonTests : AbstractButtonBaseTests
         using RadioButton control = new()
         {
             BackColor = Color.Red,
+            UseVisualStyleBackColor = true,
             Checked = isChecked,
             Size = new Size(40, 24),
             VisualStylesMode = VisualStylesMode.Net11
@@ -235,6 +236,31 @@ public class RadioButtonTests : AbstractButtonBaseTests
             isChecked ? CheckState.Checked : CheckState.Unchecked);
 
         Assert.Equal(expectedAccent, CountPixels(bitmap, Color.Red) > 0);
+    }
+
+    [WinFormsFact]
+    public void RadioButton_ModernGlyph_UsesExplicitBackColorWhenVisualStyleBackgroundDisabled()
+    {
+        using Panel parent = new() { BackColor = Color.White };
+        using RadioButton control = new()
+        {
+            BackColor = Color.Aqua,
+            Checked = false,
+            Text = string.Empty,
+            Size = new Size(40, 24),
+            VisualStylesMode = VisualStylesMode.Net11
+        };
+
+        parent.Controls.Add(control);
+
+        using Bitmap bitmap = new(control.Width, control.Height);
+        using Graphics graphics = Graphics.FromImage(bitmap);
+        PaintEventArgs e = new(graphics, control.ClientRectangle);
+
+        control.CreateStandardAdapter().PaintUp(e, CheckState.Unchecked);
+
+        Color backgroundPixel = bitmap.GetPixel(control.Width - 2, control.Height / 2);
+        Assert.Equal(Color.Aqua.ToArgb(), backgroundPixel.ToArgb());
     }
 
     [WinFormsFact]


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14859 

## Root Cause

The NET11 Visual Styles rendering path overrides the `BackColor` explicitly set by the user, causing `CheckBox` and `RadioButton` controls to deviate from the standard WinForms property precedence rules.

## Proposed changes

- Retain the default appearance of .NET 11 visual styles, but if the developer explicitly sets the BackColor, render using the developer-specified value.
- Add test cases for CheckBox and RadioButton.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

Restore existing WinForms behavior, namely, when the user sets the BackColor for CheckBox and RadioButton, the controls will be drawn with reference to the set value.

## Regression? 

- No

## Risk

- Mini

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<img width="649" height="584" alt="image" src="https://github.com/user-attachments/assets/d1e4867d-d5f1-4b79-94ed-d4bb106b3803" />


### After

**DarkMode:**

https://github.com/user-attachments/assets/0c5be72d-e6c7-482d-89af-063aa3e13028

**Light:**

https://github.com/user-attachments/assets/777934ac-d97b-4560-a1e1-19dd77f90e06

## Test methodology <!-- How did you ensure quality? -->

- Manually
- Automated test cases

## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.0-preview.7.26381.103


<!-- Mention language, UI scaling, or anything else that might be relevant -->
