### PR TITLE
Fix Issue 14793: ToolStripTextBox renders incorrectly when hosted in MenuStrip

### DIFF
--- a/src/System.Windows.Forms/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/PublicAPI.Unshipped.txt
@@ -101,6 +101,7 @@ override System.Windows.Forms.RadioButton.OnPaint(System.Windows.Forms.PaintEven
 override System.Windows.Forms.RadioButton.OnSystemColorsChanged(System.EventArgs! e) -> void
 override System.Windows.Forms.RadioButton.OnVisualStylesModeChanged(System.EventArgs! e) -> void
 override System.Windows.Forms.UpDownBase.OnVisualStylesModeChanged(System.EventArgs! e) -> void
+override System.Windows.Forms.ToolStripControlHost.OnOwnerChanged(System.EventArgs! e) -> void
 static System.Windows.Forms.Application.DefaultVisualStylesMode.get -> System.Windows.Forms.VisualStylesMode
 static System.Windows.Forms.Application.SetDefaultVisualStylesMode(System.Windows.Forms.VisualStylesMode styleSetting) -> void
 virtual System.Windows.Forms.Control.DefaultVisualStylesMode.get -> System.Windows.Forms.VisualStylesMode

--- a/src/System.Windows.Forms/System/Windows/Forms/Control.VisualStylesMode.Docs.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Control.VisualStylesMode.Docs.cs
@@ -27,6 +27,9 @@ public partial class Control
     ///   shrink slightly. Prefer <see cref="TableLayoutPanel"/> or <see cref="FlowLayoutPanel"/> for adaptive layouts.
     ///  </para>
     ///  <para>
+    ///   This setting is not applied to controls hosted through <see cref="ToolStripControlHost"/>.
+    ///  </para>
+    ///  <para>
     ///   High Contrast resolves the effective mode to classic rendering. See the
     ///   <see href="https://github.com/dotnet/winforms/blob/main/docs/net11-visualstyles-layout-guidance.md">
     ///   .NET 11 VisualStyles layout guidance</see> for migration patterns.

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripControlHost.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripControlHost.cs
@@ -586,6 +586,21 @@ public partial class ToolStripControlHost : ToolStripItem
             return;
         }
 
+        // If the consumer explicitly requests a non-modern mode while hosted, stop tracking a prior
+        // forced Classic so we don't "restore" a stale modern mode when the host is removed.
+        if (_hostedControlVisualStylesModeForced
+            && _control is not null
+            && ShouldForceHostedControlClassicVisualStylesMode())
+        {
+            VisualStylesMode mode = _control.VisualStylesMode;
+            if (mode is VisualStylesMode.Classic or VisualStylesMode.Disabled)
+            {
+                _hostedControlVisualStylesModeBeforeForce = mode;
+                _hostedControlVisualStylesModeForced = false;
+                return;
+            }
+        }
+
         ApplyHostedControlVisualStylesModePolicy();
     }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripControlHost.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripControlHost.cs
@@ -17,6 +17,9 @@ public partial class ToolStripControlHost : ToolStripItem
     private int _suspendSyncSizeCount;
     private ContentAlignment _controlAlign = ContentAlignment.MiddleCenter;
     private bool _inSetVisibleCore;
+    private bool _isUpdatingHostedControlVisualStylesMode;
+    private bool _hostedControlVisualStylesModeForced;
+    private VisualStylesMode _hostedControlVisualStylesModeBeforeForce = VisualStylesMode.Inherit;
 
     internal static readonly object s_gotFocusEvent = new();
     internal static readonly object s_lostFocusEvent = new();
@@ -576,6 +579,16 @@ public partial class ToolStripControlHost : ToolStripItem
 
     private void HandleTextChanged(object? sender, EventArgs e) => OnTextChanged(e);
 
+    private void HandleVisualStylesModeChanged(object? sender, EventArgs e)
+    {
+        if (_isUpdatingHostedControlVisualStylesMode)
+        {
+            return;
+        }
+
+        ApplyHostedControlVisualStylesModePolicy();
+    }
+
     private void HandleControlVisibleChanged(object? sender, EventArgs e)
     {
         // check the STATE_VISIBLE flag rather than using Control.Visible.
@@ -684,6 +697,8 @@ public partial class ToolStripControlHost : ToolStripItem
     {
         if (oldParent is not null && Owner is null && newParent is null && _control is not null)
         {
+            RestoreHostedControlVisualStylesMode();
+
             // if we've really been removed from the item collection,
             // politely remove ourselves from the control collection
             ReadOnlyControlCollection? oldControlCollection
@@ -696,6 +711,20 @@ public partial class ToolStripControlHost : ToolStripItem
         }
 
         base.OnParentChanged(oldParent, newParent);
+    }
+
+    protected override void OnOwnerChanged(EventArgs e)
+    {
+        base.OnOwnerChanged(e);
+
+        if (Owner is null)
+        {
+            RestoreHostedControlVisualStylesMode();
+        }
+        else
+        {
+            ApplyHostedControlVisualStylesModePolicy();
+        }
     }
 
     /// <summary>
@@ -739,6 +768,7 @@ public partial class ToolStripControlHost : ToolStripItem
             control.RightToLeftChanged += HandleRightToLeftChanged;
             control.TextChanged += HandleTextChanged;
             control.VisibleChanged += HandleControlVisibleChanged;
+            control.VisualStylesModeChanged += HandleVisualStylesModeChanged;
             control.Validating += HandleValidating;
             control.Validated += HandleValidated;
         }
@@ -784,6 +814,7 @@ public partial class ToolStripControlHost : ToolStripItem
             control.RightToLeftChanged -= HandleRightToLeftChanged;
             control.TextChanged -= HandleTextChanged;
             control.VisibleChanged -= HandleControlVisibleChanged;
+            control.VisualStylesModeChanged -= HandleVisualStylesModeChanged;
             control.Validating -= HandleValidating;
             control.Validated -= HandleValidated;
         }
@@ -803,6 +834,52 @@ public partial class ToolStripControlHost : ToolStripItem
     {
         ReadOnlyControlCollection? newControls = GetControlCollection(ParentInternal);
         newControls?.AddInternal(_control);
+        ApplyHostedControlVisualStylesModePolicy();
+    }
+
+    private bool ShouldForceHostedControlClassicVisualStylesMode()
+        => Owner is not null;
+
+    private void ApplyHostedControlVisualStylesModePolicy()
+    {
+        if (_control is null || !ShouldForceHostedControlClassicVisualStylesMode())
+        {
+            return;
+        }
+
+        VisualStylesMode mode = _control.VisualStylesMode;
+        if (mode is VisualStylesMode.Classic or VisualStylesMode.Disabled)
+        {
+            return;
+        }
+
+        _hostedControlVisualStylesModeBeforeForce = mode;
+        _hostedControlVisualStylesModeForced = true;
+        UpdateHostedControlVisualStylesMode(VisualStylesMode.Classic);
+    }
+
+    private void RestoreHostedControlVisualStylesMode()
+    {
+        if (!_hostedControlVisualStylesModeForced || _control is null)
+        {
+            return;
+        }
+
+        UpdateHostedControlVisualStylesMode(_hostedControlVisualStylesModeBeforeForce);
+        _hostedControlVisualStylesModeForced = false;
+    }
+
+    private void UpdateHostedControlVisualStylesMode(VisualStylesMode mode)
+    {
+        _isUpdatingHostedControlVisualStylesMode = true;
+        try
+        {
+            _control.VisualStylesMode = mode;
+        }
+        finally
+        {
+            _isUpdatingHostedControlVisualStylesMode = false;
+        }
     }
 
     protected virtual void OnHostedControlResize(EventArgs e)

--- a/src/System.Windows.Forms/System/Windows/Forms/VisualStylesMode.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/VisualStylesMode.cs
@@ -56,6 +56,9 @@ public enum VisualStylesMode : short
     ///   Controls opt into the .NET 11 rendering changes they support. For example, support for
     ///   <see cref="Appearance.ToggleSwitch"/> depends on the control and its current state.
     ///  </para>
+    ///  <para>
+    ///   For controls hosted through <see cref="ToolStripControlHost"/>, this mode is not applied.
+    ///  </para>
     /// </remarks>
     Net11 = 2,
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripControlHostTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripControlHostTests.cs
@@ -4557,6 +4557,52 @@ public class ToolStripControlHostTests
         Assert.Equal(2, callCount);
     }
 
+    [WinFormsFact]
+    public void ToolStripControlHost_HostedControlVisualStylesMode_Net11_IsForcedToClassic()
+    {
+        using Control control = new()
+        {
+            VisualStylesMode = VisualStylesMode.Net11
+        };
+        using ToolStripControlHost host = new(control);
+        using ToolStrip toolStrip = new();
+
+        toolStrip.Items.Add(host);
+
+        Assert.Equal(VisualStylesMode.Classic, control.VisualStylesMode);
+    }
+
+    [WinFormsFact]
+    public void ToolStripControlHost_HostedControlVisualStylesMode_SetToNet11WhileHosted_RemainsClassic()
+    {
+        using Control control = new();
+        using ToolStripControlHost host = new(control);
+        using ToolStrip toolStrip = new();
+
+        toolStrip.Items.Add(host);
+        control.VisualStylesMode = VisualStylesMode.Net11;
+
+        Assert.Equal(VisualStylesMode.Classic, control.VisualStylesMode);
+    }
+
+    [WinFormsFact]
+    public void ToolStripControlHost_HostedControlVisualStylesMode_RemovingHost_RestoresRequestedMode()
+    {
+        using Control control = new()
+        {
+            VisualStylesMode = VisualStylesMode.Net11
+        };
+        using ToolStripControlHost host = new(control);
+        using ToolStrip toolStrip = new();
+
+        toolStrip.Items.Add(host);
+        Assert.Equal(VisualStylesMode.Classic, control.VisualStylesMode);
+
+        toolStrip.Items.Remove(host);
+
+        Assert.Equal(VisualStylesMode.Net11, control.VisualStylesMode);
+    }
+
     private class SubControl : Control
     {
         public new void CreateControl() => base.CreateControl();


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14793 

## Root Cause

When a `ToolStripControlHost` hosts a control (such as a `ToolStripTextBox` or `ToolStripComboBox`), the control's own `VisualStylesMode` can still utilize the .NET 11 modern rendering path; however, the rendering models for the non-client areas and borders of the `ToolStrip`/`MenuStrip` (especially when not using the System renderer) do not align with those of the hosted control. This results in rendering pipeline incompatibilities, leading to artifacts such as light-colored blocks or incorrectly drawn borders.

## Proposed changes

- Added a policy within ToolStripControlHost:
  - Once a control is hosted in a ToolStrip or MenuStrip, if its VisualStylesMode is set to a modern mode (such as Net11, Latest, or Inherit), it is forced to Classic mode.
  - If the control is set to Net11 while in the hosted state, it is immediately reverted to Classic.
  - The original requested value is restored after the control is removed from the host (to avoid permanently altering the control's state).
- Comments for Control.VisualStylesMode and VisualStylesMode.Net11 explicitly state that this mode does not apply to ToolStripControlHost scenarios.
- Added unit tests (in ToolStripControlHostTests) to provide coverage:

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

When using Dark Mode with `VisualStylesMode=Net11`, applications utilizing `ToolStripControlHost` exhibit noticeable UI flaws—such as anomalous borders or backgrounds—that compromise interface consistency and a professional appearance. While functionality generally remains intact, visual quality suffers, and the issue is more easily reproduced under `Professional` or `ManagerRenderMode`.
For menus or toolbars relying on `ToolStripTextBox` or `ToolStripComboBox`, this is a highly visible issue that directly impacts the end-user experience.

## Regression? 

- No

## Risk

- Mini

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<img width="357" height="101" alt="image" src="https://github.com/user-attachments/assets/11cf06e9-8c15-4b39-8aab-8f52d7521725" />

### After

<img width="1132" height="630" alt="image" src="https://github.com/user-attachments/assets/cc89edaf-1ded-4012-bfd5-eda052588d63" />

<img width="1147" height="626" alt="image" src="https://github.com/user-attachments/assets/0f619632-b70e-4a53-b1bd-9df16d839fd4" />


## Test methodology <!-- How did you ensure quality? -->

- Manually
- Automated test cases

## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.0-preview.7.26381.103


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14873)