### PR TITLE
Fix ComboBox text clipping in NET11 VisualStylesMode

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.Modern.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.Modern.cs
@@ -167,10 +167,8 @@ public partial class ComboBox
             int bottomInset = chromeInsets.Bottom + Padding.Bottom;
             editBounds.Y += topInset;
 
-            editBounds.Height = Math.Max(
-                1,
-                editBounds.Height - topInset - bottomInset);
-
+            // A single-line EDIT control's text visibility depends on its window height.
+            // Preserve the native height so glyphs are not clipped.
             editBounds.Height = Math.Max(
                 1,
                 Math.Min(

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ComboBoxTests.cs
@@ -814,11 +814,14 @@ public class ComboBoxTests
             Text = "Text with descenders: gjpqy",
             VisualStylesMode = VisualStylesMode.Net11
         };
+
         control.CreateControl();
+        _ = control.Handle;
+        Rectangle nativeEditBounds = control.ModernEditBaseBounds;
+        Assert.False(nativeEditBounds.IsEmpty);
 
         Assert.True(
-            control.GetEditBounds().Height
-                >= control.ModernEditBaseBounds.Height);
+            control.GetEditBounds().Height >= nativeEditBounds.Height);
     }
 
     [WinFormsTheory]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ComboBoxTests.cs
@@ -798,6 +798,32 @@ public class ComboBoxTests
     [WinFormsTheory]
     [InlineData(ComboBoxStyle.DropDown)]
     [InlineData(ComboBoxStyle.Simple)]
+    public void ComboBox_ModernVisualStyles_EditHeightDoesNotClipText(
+        ComboBoxStyle dropDownStyle)
+    {
+        using SystemVisualSettingsTestScope settingsScope = new(
+            clientAreaAnimationEnabled: false,
+            highContrastEnabled: false);
+        using VisualStylesComboBox control = new()
+        {
+            DropDownStyle = dropDownStyle,
+            FlatStyle = FlatStyle.Standard,
+            Size = dropDownStyle == ComboBoxStyle.Simple
+                ? new Size(140, 100)
+                : new Size(140, 40),
+            Text = "Text with descenders: gjpqy",
+            VisualStylesMode = VisualStylesMode.Net11
+        };
+        control.CreateControl();
+
+        Assert.True(
+            control.GetEditBounds().Height
+                >= control.ModernEditBaseBounds.Height);
+    }
+
+    [WinFormsTheory]
+    [InlineData(ComboBoxStyle.DropDown)]
+    [InlineData(ComboBoxStyle.Simple)]
     public void ComboBox_ModernPadding_PositionsEditUsingTopAndBottom(
         ComboBoxStyle dropDownStyle)
     {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

- Fixes #14794

## Root Cause
NET11 modern ComboBox layout reduced the native EDIT child height by vertical padding/chrome. For single-line EDIT, shrinking the window height can clip the text.

## Proposed changes

- Preserve the native single-line EDIT child height in modern `ComboBox `layout.
- Keep bottom-boundary clamping so the EDIT child stays within the modern field.
- Add regression coverage for DropDown and Simple editable ComboBox styles.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- In `VisualStylesMode.Net11` mode, user-entered text is fully displayed, whether at design time or at runtime.

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Editable ComboBox text could be vertically clipped.

<img width="686" height="628" alt="Image" src="https://github.com/user-attachments/assets/985d4553-4196-4184-b4cc-3bf1fa5af387" />

### After
The EDIT child keeps its native height and is only clamped to the available control bounds, so text is no longer clipped under normal sizing.

https://github.com/user-attachments/assets/d171de4a-6e45-4157-adbd-a4a60b2291dd


## Test methodology <!-- How did you ensure quality? -->

- Unit test and manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-rc.1.26410.101


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14874)