### PR TITLE
Document ToggleSwitch CheckAlign behavior for CheckBox and RadioButton

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/CheckBox.Appearance.Docs.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/CheckBox.Appearance.Docs.cs
@@ -12,7 +12,7 @@ public partial class CheckBox
     /// </summary>
     /// <remarks>
     ///  <para>
-    ///   <see cref="Forms.Appearance.ToggleSwitch"/> selects the framework's owner-drawn toggle renderer for a
+    ///   <see cref="Appearance.ToggleSwitch"/> selects the framework's owner-drawn toggle renderer for a
     ///   two-state check box in an effective .NET 11-or-later mode. Because a native check box cannot render a
     ///   toggle switch, this appearance intentionally takes precedence over <see cref="ButtonBase.FlatStyle"/> when
     ///   that property is <see cref="FlatStyle.System"/>. A check box with <see cref="ThreeState"/> enabled retains

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/CheckBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/CheckBox.cs
@@ -165,6 +165,18 @@ public partial class CheckBox : ButtonBase
     /// <summary>
     ///  Gets or sets the horizontal and vertical alignment of a check box on a check box control.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   When <see cref="Appearance"/> is <see cref="Appearance.ToggleSwitch"/> and the control renders as a toggle
+    ///   switch in an effective .NET 11-or-later mode,
+    ///   <see cref="ContentAlignment.TopLeft"/>, <see cref="ContentAlignment.MiddleLeft"/>,
+    ///   <see cref="ContentAlignment.BottomLeft"/>, <see cref="ContentAlignment.TopCenter"/>,
+    ///   <see cref="ContentAlignment.MiddleCenter"/>, and <see cref="ContentAlignment.BottomCenter"/> are treated
+    ///   like left-aligned values, and
+    ///   <see cref="ContentAlignment.TopRight"/>, <see cref="ContentAlignment.MiddleRight"/>, and
+    ///   <see cref="ContentAlignment.BottomRight"/> are treated like right-aligned values.
+    ///  </para>
+    /// </remarks>
     [Bindable(true)]
     [Localizable(true)]
     [SRCategory(nameof(SR.CatAppearance))]

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/RadioButton.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/RadioButton.cs
@@ -75,6 +75,15 @@ public partial class RadioButton : ButtonBase
     /// <summary>
     ///  Gets or sets the appearance of the radio button control is drawn.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see cref="Appearance.ToggleSwitch"/> selects the framework's owner-drawn toggle renderer in an
+    ///   effective .NET 11-or-later mode. High Contrast resolves to classic rendering. Modern toggle metrics can
+    ///   increase preferred size; see the
+    ///   <see href="https://github.com/dotnet/winforms/blob/main/docs/net11-visualstyles-layout-guidance.md">
+    ///   .NET 11 VisualStyles layout guidance</see>.
+    ///  </para>
+    /// </remarks>
     [DefaultValue(Appearance.Normal)]
     [SRCategory(nameof(SR.CatAppearance))]
     [Localizable(true)]
@@ -124,6 +133,18 @@ public partial class RadioButton : ButtonBase
     /// <summary>
     ///  Gets or sets the location of the check box portion of the radio button control.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   When <see cref="Appearance"/> is <see cref="Appearance.ToggleSwitch"/> and the control renders as a toggle
+    ///   switch in an effective .NET 11-or-later mode,
+    ///   <see cref="ContentAlignment.TopLeft"/>, <see cref="ContentAlignment.MiddleLeft"/>,
+    ///   <see cref="ContentAlignment.BottomLeft"/>, <see cref="ContentAlignment.TopCenter"/>,
+    ///   <see cref="ContentAlignment.MiddleCenter"/>, and <see cref="ContentAlignment.BottomCenter"/> are treated
+    ///   like left-aligned values, and
+    ///   <see cref="ContentAlignment.TopRight"/>, <see cref="ContentAlignment.MiddleRight"/>, and
+    ///   <see cref="ContentAlignment.BottomRight"/> are treated like right-aligned values.
+    ///  </para>
+    /// </remarks>
     [Localizable(true)]
     [SRCategory(nameof(SR.CatAppearance))]
     [DefaultValue(ContentAlignment.MiddleLeft)]

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/RadioButton.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/RadioButton.cs
@@ -73,7 +73,7 @@ public partial class RadioButton : ButtonBase
     }
 
     /// <summary>
-    ///  Gets or sets the appearance of the radio button control is drawn.
+    ///  Gets or sets the value that determines the appearance of the radio button.
     /// </summary>
     /// <remarks>
     ///  <para>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14810


## Proposed changes

- Added XML remarks for `CheckBox.CheckAlign` and `RadioButton.CheckAlign`.
- Documented how `CheckAlign` values are handled when the control renders as a toggle switch in **.NET 11-or-later** visual styles mode:
    - Left and center alignments are treated as left-aligned.
    - Right alignments are treated as right-aligned.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Customers can now understand from the API docs that centered `CheckAlign` values do not center the toggle switch when using `Appearance.ToggleSwitch`. This clarifies the intended behavior and reduces confusion.

## Regression? 

-  No

## Risk

- Low

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net11.0.0-rc.1.26410.101
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14880)