### PR TITLE
Fix ErrorProvider tooltip rendering in dark mode

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/ErrorProvider/ErrorProvider.ErrorWindow.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/ErrorProvider/ErrorProvider.ErrorWindow.cs
@@ -118,6 +118,14 @@ public partial class ErrorProvider
             _tipWindow = new NativeWindow();
             _tipWindow.CreateHandle(cparams);
 
+            if (!SystemInformation.HighContrast && Application.IsDarkModeEnabled)
+            {
+                PInvoke.SetWindowTheme(
+                    _tipWindow.HWND,
+                    $"{Control.DarkModeIdentifier}_{Control.ExplorerThemeIdentifier}",
+                    null);
+            }
+
             PInvokeCore.SendMessage(
                 _tipWindow,
                 PInvoke.TTM_SETMAXTIPWIDTH,


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14879

## Root Cause

`ErrorProvider` creates its own native tooltip window, bypassing the dark-mode theme setup used by the standard `ToolTip` component. As a result, the tooltip retained its light theme after `Application.SetColorMode(SystemColorMode.Dark)`.

## Proposed changes

-  Apply the native `DarkMode_Explorer` theme to the ErrorProvider tooltip window when dark mode is enabled and high contrast mode is inactive.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Applications using ErrorProvider in dark mode now provide a consistent tooltip appearance and improved readability.  

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

ErrorProvider tooltips rendered with a light background and dark text in dark mode, making them visually inconsistent with the application.

<img width="660" height="262" alt="Image" src="https://github.com/user-attachments/assets/e8cb99a0-7a40-47db-a9af-82cef3ff62fe" />

### After

ErrorProvider tooltips render using the native dark theme. High contrast and non-dark modes retain their existing behavior.

<img width="519" height="164" alt="image" src="https://github.com/user-attachments/assets/7776f57e-f751-4f4d-ab34-da39b55b0fbc" />


## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-rc.1.26411.119


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14888)