### PR TITLE
Enable dark mode for TreeView and ListView mouse tooltips

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
@@ -4695,15 +4695,18 @@ public partial class ListView : Control
 
             // Apply dark mode theme to the ListView Tooltip
             HWND toolTipHandle = (HWND)PInvokeCore.SendMessage(
-               this,
-               PInvoke.LVM_GETTOOLTIPS,
-               (WPARAM)0,
-               (LPARAM)0);
+                this,
+                PInvoke.LVM_GETTOOLTIPS,
+                (WPARAM)0,
+                (LPARAM)0);
 
-            PInvoke.SetWindowTheme(
-                toolTipHandle,
-                $"{DarkModeIdentifier}_{ExplorerThemeIdentifier}",
-                null);
+            if (!toolTipHandle.IsNull)
+            {
+                _ = PInvoke.SetWindowTheme(
+                    toolTipHandle,
+                    $"{DarkModeIdentifier}_{ExplorerThemeIdentifier}",
+                    null);
+            }
 
             // Get the ListView's ColumnHeader handle:
             HWND columnHeaderHandle = (HWND)PInvokeCore.SendMessage(

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.cs
@@ -4693,6 +4693,18 @@ public partial class ListView : Control
                 $"{DarkModeIdentifier}_{ExplorerThemeIdentifier}",
                 null);
 
+            // Apply dark mode theme to the ListView Tooltip
+            HWND toolTipHandle = (HWND)PInvokeCore.SendMessage(
+               this,
+               PInvoke.LVM_GETTOOLTIPS,
+               (WPARAM)0,
+               (LPARAM)0);
+
+            PInvoke.SetWindowTheme(
+                toolTipHandle,
+                $"{DarkModeIdentifier}_{ExplorerThemeIdentifier}",
+                null);
+
             // Get the ListView's ColumnHeader handle:
             HWND columnHeaderHandle = (HWND)PInvokeCore.SendMessage(
                 this,

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -2023,6 +2023,20 @@ public partial class TreeView : Control
             PInvokeCore.SetWindowLong(this, WINDOW_LONG_PTR_INDEX.GWL_STYLE, style);
         }
 
+        if (Application.IsDarkModeEnabled && DarkModeRequestState is true)
+        {
+            HWND toolTipHandle = (HWND)PInvokeCore.SendMessage(
+                this,
+                PInvoke.TVM_GETTOOLTIPS,
+                (WPARAM)0,
+                (LPARAM)0);
+
+            PInvoke.SetWindowTheme(
+                toolTipHandle,
+                $"{DarkModeIdentifier}_{ExplorerThemeIdentifier}",
+                null);
+        }
+
         Color c = BackColor;
 
         if (c != SystemColors.Window || Application.IsDarkModeEnabled)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -2031,10 +2031,13 @@ public partial class TreeView : Control
                 (WPARAM)0,
                 (LPARAM)0);
 
-            PInvoke.SetWindowTheme(
-                toolTipHandle,
-                $"{DarkModeIdentifier}_{ExplorerThemeIdentifier}",
-                null);
+            if (!toolTipHandle.IsNull)
+            {
+                _ = PInvoke.SetWindowTheme(
+                    toolTipHandle,
+                    $"{DarkModeIdentifier}_{ExplorerThemeIdentifier}",
+                    null);
+            }
         }
 
         Color c = BackColor;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14878

## Root Cause

TreeView and ListView use native tooltip windows for mouse-hover tooltips. Dark mode was applied to the controls themselves and to managed keyboard tooltips, but not to these native tooltip windows.

## Proposed changes

- Retrieve the native tooltip handles using `TVM_GETTOOLTIPS` and `LVM_GETTOOLTIPS`,  then apply the `DarkMode_Explorer` theme when dark mode is enabled for the control.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

-  Applications using **TreeView** or **ListView** in dark mode now provide visually consistent tooltips. 

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

With `SystemColorMode.Dark` enabled, mouse-hover tooltips for TreeView and ListView were rendered using the light theme. Keyboard tooltips were already rendered in dark mode.

<img width="301" height="262" alt="Image" src="https://github.com/user-attachments/assets/9dcdb803-e60a-4070-9d0d-60cede624008" />

### After

Mouse-hover and keyboard tooltips for TreeView and ListView are consistently rendered in dark mode when SystemColorMode.Dark is enabled.

<img width="267" height="236" alt="image" src="https://github.com/user-attachments/assets/a8f92ef6-5f88-430b-9279-b1e401301a99" />

<img width="288" height="213" alt="image" src="https://github.com/user-attachments/assets/4ad2e2b9-6807-48ae-bd01-54d6f0623ad5" />

## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-rc.1.26411.119


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14889)