### PR TITLE
Fix GroupBox Standard and Popup layout overlap when switching to NET11 visual styles

### DIFF
--- a/docs/net11-visualstyles-layout-guidance.md
+++ b/docs/net11-visualstyles-layout-guidance.md
@@ -180,10 +180,11 @@ serialized only when it differs from `Padding.Empty`.
 
 ## Account for GroupBox DisplayRectangle
 
-In modern `FlatStyle.Standard`, the GroupBox caption sits above a borderless rectangular surface. Its
-`DisplayRectangle` starts lower than the classic etched-frame rectangle and reserves more content space above
-than below. The caption aligns with the control Padding. Docked and anchored children are relaid out against the
-new rectangle.
+In modern `FlatStyle.Standard` and `FlatStyle.Popup`, the GroupBox caption sits above a modern surface while
+the `DisplayRectangle` preserves the classic etched-frame rectangle. `FlatStyle.Popup` uses a subtle
+accent-tinted header band and accent border to distinguish the header without changing the content rectangle.
+The caption aligns with the control Padding, and existing child layouts remain stable when switching visual
+styles.
 
 Use the GroupBox as a real layout container:
 
@@ -207,12 +208,10 @@ TableLayoutPanel addressTable = new()
 addressGroup.Controls.Add(addressTable);
 ```
 
-Avoid positioning children with a fixed Y offset derived from `Font.Height`. The renderer owns caption metrics,
-and `DisplayRectangle` is the supported content boundary.
+Avoid positioning children outside `DisplayRectangle`; it remains the supported content boundary.
 
-The modern caption is derived from the ambient font at paint time. Standard and Popup enlarge the caption; Flat
-keeps the ambient size. If the ambient font is regular and a matching installed Semibold family exists, WinForms
-uses that real face. Otherwise the ambient weight is preserved; already styled fonts are never promoted.
+The modern caption is derived from the ambient font at paint time. WinForms preserves the ambient font family,
+size, and style while still following system text scale.
 
 ## React to live text-scale changes
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/GroupBox/GroupBox.FlatStyle.Docs.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/GroupBox/GroupBox.FlatStyle.Docs.cs
@@ -13,15 +13,14 @@ public partial class GroupBox
     /// <remarks>
     ///  <para>
     ///   In an effective .NET 11-or-later mode, <see cref="FlatStyle.Standard"/> renders a borderless rectangular
-    ///   surface with an enlarged caption, <see cref="FlatStyle.Flat"/> renders a rounded accent outline with an
-    ///   ambient-size inline caption, and <see cref="FlatStyle.Popup"/> renders a Windows-accent header band.
+    ///   surface, <see cref="FlatStyle.Flat"/> renders a rounded accent outline, and <see cref="FlatStyle.Popup"/>
+    ///   renders a rounded accent outline with a subtle accent-tinted header band.
     ///   <see cref="FlatStyle.System"/> remains a native <c>BS_GROUPBOX</c> in every mode.
     ///  </para>
     ///  <para>
-    ///   The modern Standard surface intentionally moves <see cref="Control.DisplayRectangle"/> down and reserves
-    ///   more space above its content than below. Its caption aligns with <see cref="Control.Padding"/>. When the
-    ///   ambient font is regular and a matching installed Semibold family exists, modern captions use that real
-    ///   face; otherwise they preserve the ambient weight. AutoSize layouts remeasure automatically. See the
+    ///   The modern Standard and Popup surfaces preserve the classic <see cref="Control.DisplayRectangle"/> so
+    ///   existing child layouts remain stable when switching visual styles. Modern captions preserve the ambient
+    ///   font family, size, and style while still following system text scale. See the
     ///   <see href="https://github.com/dotnet/winforms/blob/main/docs/net11-visualstyles-layout-guidance.md">
     ///   .NET 11 VisualStyles layout guidance</see>.
     ///  </para>

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/GroupBox/GroupBox.Modern.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/GroupBox/GroupBox.Modern.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Concurrent;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Text;
@@ -12,10 +11,7 @@ namespace System.Windows.Forms;
 
 public partial class GroupBox
 {
-    private const string MissingSemiBoldFamily = "";
-
-    private static readonly ConcurrentDictionary<string, string> s_semiBoldFamilyNames =
-        new(StringComparer.OrdinalIgnoreCase);
+    private const float PopupHeaderAccentBlendAmount = 0.12f;
 
     private Font? _modernCaptionFont;
     private Font? _modernCaptionSourceFont;
@@ -72,67 +68,39 @@ public partial class GroupBox
 
     private Padding GetModernDecorationPadding()
     {
-        int captionHeight = ModernCaptionFont.Height;
+        int displayCaptionHeight = DisplayFontHeight;
 
         switch (FlatStyle)
         {
             case FlatStyle.Standard:
-            {
-                // Card: reserve the caption band plus its visual gap to the card. No internal
-                // horizontal or bottom inset, so a docked child with Padding = 0 fills the card.
-                int gap = ScaleModernMetric(ModernControlVisualStyles.GroupBoxCaptionGap);
-
-                return new Padding(
-                    left: Padding.Left,
-                    top: Padding.Top + captionHeight + gap,
-                    right: Padding.Right,
-                    bottom: Padding.Bottom);
-            }
+            case FlatStyle.Popup:
+            default:
+                {
+                    // Keep the content rectangle compatible with the classic GroupBox while the
+                    // renderer keeps drawing the modern card/header surface and caption.
+                    return new Padding(
+                        left: Padding.Left,
+                        top: Padding.Top + displayCaptionHeight,
+                        right: Padding.Right,
+                        bottom: Padding.Bottom);
+                }
 
             case FlatStyle.Flat:
-            {
-                // Outline: the top border line runs along the caption baseline, so content clears
-                // the descenders that hang below it (descent + 1px leeway). Left/right/bottom sit
-                // just inside the border.
-                (int ascent, int descent) = GetModernCaptionMetrics();
-                int leeway = ScaleModernMetric(
-                    ModernControlVisualStyles.GroupBoxFlatBaselineLeeway);
-                int borderInset = GetModernBorderThickness() + leeway;
+                {
+                    // Outline: the top border line runs along the caption baseline, so content clears
+                    // the descenders that hang below it (descent + 1px leeway). Left/right/bottom sit
+                    // just inside the border.
+                    (int ascent, int descent) = GetModernCaptionMetrics();
+                    int leeway = ScaleModernMetric(
+                        ModernControlVisualStyles.GroupBoxFlatBaselineLeeway);
+                    int borderInset = GetModernBorderThickness() + leeway;
 
-                return new Padding(
-                    left: Padding.Left + borderInset,
-                    top: Padding.Top + ascent + descent + leeway,
-                    right: Padding.Right + borderInset,
-                    bottom: Padding.Bottom + borderInset);
-            }
-
-            case FlatStyle.Popup:
-            {
-                // Accent header: content is flush to the bottom of the filled header rectangle
-                // (0 top gap) with a 2px inset on the remaining sides.
-                int verticalPadding = ScaleModernMetric(
-                    ModernControlVisualStyles.GroupBoxHeaderVerticalPadding);
-                int headerHeight = captionHeight + (2 * verticalPadding);
-                int inset = ScaleModernMetric(
-                    ModernControlVisualStyles.GroupBoxPopupContentInset);
-
-                return new Padding(
-                    left: Padding.Left + inset,
-                    top: Padding.Top + headerHeight,
-                    right: Padding.Right + inset,
-                    bottom: Padding.Bottom + inset);
-            }
-
-            default:
-            {
-                int gap = ScaleModernMetric(ModernControlVisualStyles.GroupBoxCaptionGap);
-
-                return new Padding(
-                    left: Padding.Left,
-                    top: Padding.Top + captionHeight + gap,
-                    right: Padding.Right,
-                    bottom: Padding.Bottom);
-            }
+                    return new Padding(
+                        left: Padding.Left + borderInset,
+                        top: Padding.Top + ascent + descent + leeway,
+                        right: Padding.Right + borderInset,
+                        bottom: Padding.Bottom + borderInset);
+                }
         }
     }
 
@@ -202,13 +170,12 @@ public partial class GroupBox
     private void DrawModernCard(PaintEventArgs e, Rectangle bounds)
     {
         int captionHeight = ModernCaptionFont.Height;
-        int captionGap = ScaleModernMetric(
-            ModernControlVisualStyles.GroupBoxCaptionGap);
+        int frameTop = DisplayFontHeight;
         Rectangle frameBounds = new(
             bounds.Left,
-            bounds.Top + captionHeight + captionGap,
+            bounds.Top + frameTop,
             bounds.Width,
-            Math.Max(0, bounds.Height - captionHeight - captionGap));
+            Math.Max(0, bounds.Height - frameTop));
         Rectangle captionBounds = GetStandardCaptionBounds(
             bounds,
             captionHeight);
@@ -312,11 +279,11 @@ public partial class GroupBox
 
     private void DrawModernPopup(PaintEventArgs e, Rectangle bounds)
     {
-        int verticalPadding = ScaleModernMetric(
-            ModernControlVisualStyles.GroupBoxHeaderVerticalPadding);
         int horizontalPadding = ScaleModernMetric(
             ModernControlVisualStyles.GroupBoxHeaderHorizontalPadding);
-        int headerHeight = ModernCaptionFont.Height + (2 * verticalPadding);
+        int headerHeight = Math.Max(
+            DisplayFontHeight,
+            ModernCaptionFont.Height);
         Rectangle headerBounds = new(
             bounds.Left,
             bounds.Top,
@@ -325,21 +292,24 @@ public partial class GroupBox
 
         Rectangle captionBounds = GetPopupCaptionBounds(
             bounds,
-            ModernCaptionFont.Height,
             horizontalPadding,
-            verticalPadding);
+            headerHeight);
 
         Color bodyColor = BackColor.A == 0
             ? Color.Transparent
             : BackColor;
         Color headerColor = Application.SystemVisualSettings.AccentColor;
+        Color headerSurfaceColor = PopupButtonColorMath.Blend(
+            bodyColor,
+            headerColor,
+            PopupHeaderAccentBlendAmount);
         Color borderColor = PopupButtonColorMath.TowardsContrast(
             headerColor,
             0.2f);
         if (!Enabled)
         {
             bodyColor = PopupButtonColorMath.Mute(bodyColor, 0.55f);
-            headerColor = PopupButtonColorMath.Mute(headerColor, 0.55f);
+            headerSurfaceColor = PopupButtonColorMath.Mute(headerSurfaceColor, 0.55f);
             borderColor = PopupButtonColorMath.Mute(borderColor, 0.55f);
         }
 
@@ -361,7 +331,7 @@ public partial class GroupBox
         using (GraphicsStateScope state = new(e.Graphics))
         {
             e.Graphics.SetClip(headerBounds);
-            using var headerBrush = headerColor.GetCachedSolidBrushScope();
+            using var headerBrush = headerSurfaceColor.GetCachedSolidBrushScope();
             e.Graphics.FillPath(headerBrush, path);
         }
 
@@ -379,12 +349,10 @@ public partial class GroupBox
             GetModernBorderThickness(),
             ParentInternal?.BackColor ?? BackColor);
 
-        Color captionColor = Enabled
-            ? PopupButtonColorMath.GetReadableForeColor(headerColor)
-            : ModernControlColorMath.GetDisabledTextColor(
-                PopupButtonColorMath.GetReadableForeColor(headerColor),
-                headerColor);
-        DrawModernCaption(e.Graphics, captionBounds, captionColor);
+        DrawModernCaption(
+            e.Graphics,
+            captionBounds,
+            GetCaptionColor(headerSurfaceColor));
     }
 
     private Rectangle GetFlatCaptionBounds(
@@ -441,21 +409,20 @@ public partial class GroupBox
 
     private Rectangle GetPopupCaptionBounds(
         Rectangle bounds,
-        int captionHeight,
         int horizontalPadding,
-        int verticalPadding)
+        int headerHeight)
     {
         Rectangle captionBounds = GetStandardCaptionBounds(
             bounds,
-            captionHeight);
+            headerHeight);
 
         return new Rectangle(
             captionBounds.Left + horizontalPadding,
-            captionBounds.Top + verticalPadding,
+            captionBounds.Top,
             Math.Max(
                 0,
                 captionBounds.Width - (2 * horizontalPadding)),
-            captionHeight);
+            headerHeight);
     }
 
     private void DrawRoundedFrame(
@@ -525,74 +492,14 @@ public partial class GroupBox
 
     private Font CreateModernCaptionFont(float textScale)
     {
-        float styleScale = FlatStyle == FlatStyle.Flat
-            ? 1f
-            : ModernControlVisualStyles.GroupBoxCaptionFontScale;
-        string semiBoldFamilyName = Font.Style == FontStyle.Regular
-            ? s_semiBoldFamilyNames.GetOrAdd(
-                Font.FontFamily.Name,
-                FindSemiBoldFamilyName)
-            : MissingSemiBoldFamily;
-
-        if (semiBoldFamilyName.Length == 0)
-        {
-            return new Font(
-                Font.FontFamily,
-                Font.Size * styleScale * textScale,
-                Font.Style,
-                Font.Unit,
-                Font.GdiCharSet,
-                Font.GdiVerticalFont);
-        }
-
-        using FontFamily semiBoldFamily = new(semiBoldFamilyName);
         return new Font(
-            semiBoldFamily,
-            Font.Size * styleScale * textScale,
-            FontStyle.Regular,
+            Font.FontFamily,
+            Font.Size * textScale,
+            Font.Style,
             Font.Unit,
             Font.GdiCharSet,
             Font.GdiVerticalFont);
     }
-
-    internal static string FindSemiBoldFamilyName(string sourceFamilyName)
-    {
-        string baseFamilyName = sourceFamilyName.EndsWith(
-            " Regular",
-            StringComparison.OrdinalIgnoreCase)
-            ? sourceFamilyName[..^" Regular".Length]
-            : sourceFamilyName;
-        string expectedName = IsSemiBoldFamilyName(sourceFamilyName)
-            ? sourceFamilyName
-            : $"{baseFamilyName} Semibold";
-
-        using InstalledFontCollection installedFonts = new();
-        foreach (FontFamily family in installedFonts.Families)
-        {
-            if (family.Name.Equals(
-                expectedName,
-                StringComparison.OrdinalIgnoreCase))
-            {
-                return family.Name;
-            }
-        }
-
-        return MissingSemiBoldFamily;
-    }
-
-    internal static bool IsSemiBoldFamilyName(string familyName)
-        => familyName.Contains(
-            "Semibold",
-            StringComparison.OrdinalIgnoreCase)
-            || familyName.Contains(
-                "Semi Bold",
-                StringComparison.OrdinalIgnoreCase)
-            || familyName.Contains(
-                "Demibold",
-                StringComparison.OrdinalIgnoreCase)
-            || familyName.Contains(
-                "Demi Bold",
-                StringComparison.OrdinalIgnoreCase);
 
     private int GetModernBorderThickness()
     {
@@ -747,17 +654,21 @@ public partial class GroupBox
         if ((e.Changed & SystemVisualSettingsCategories.TextScale) != 0)
         {
             InvalidateModernCaptionFont();
-            CommonProperties.xClearPreferredSizeCache(this);
-            LayoutTransaction.DoLayout(
-                this,
-                this,
-                PropertyNames.SystemVisualSettings);
-            if (ParentInternal is { } parent)
+
+            if (FlatStyle == FlatStyle.Flat)
             {
+                CommonProperties.xClearPreferredSizeCache(this);
                 LayoutTransaction.DoLayout(
-                    parent,
+                    this,
                     this,
                     PropertyNames.SystemVisualSettings);
+                if (ParentInternal is { } parent)
+                {
+                    LayoutTransaction.DoLayout(
+                        parent,
+                        this,
+                        PropertyNames.SystemVisualSettings);
+                }
             }
         }
 
@@ -790,7 +701,9 @@ public partial class GroupBox
         bool newUsesModernMetrics = newMode >= VisualStylesMode.Net11;
 
         return oldUsesModernMetrics != newUsesModernMetrics
-            ? VisualStylesModeChangeImpact.Metrics
+            ? FlatStyle == FlatStyle.Flat
+                ? VisualStylesModeChangeImpact.Metrics
+                : VisualStylesModeChangeImpact.Repaint
             : VisualStylesModeChangeImpact.Repaint;
     }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/GroupBox/GroupBox.Modern.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/GroupBox/GroupBox.Modern.cs
@@ -68,14 +68,28 @@ public partial class GroupBox
 
     private Padding GetModernDecorationPadding()
     {
-        int displayCaptionHeight = DisplayFontHeight;
-
         switch (FlatStyle)
         {
             case FlatStyle.Standard:
+                {
+                    int displayCaptionHeight = string.IsNullOrEmpty(Text)
+                        ? DisplayFontHeight
+                        : Math.Max(DisplayFontHeight, ModernCaptionFont.Height);
+
+                    return new Padding(
+                        left: Padding.Left,
+                        top: Padding.Top + displayCaptionHeight,
+                        right: Padding.Right,
+                        bottom: Padding.Bottom);
+                }
+
             case FlatStyle.Popup:
             default:
                 {
+                    int displayCaptionHeight = Math.Max(
+                        DisplayFontHeight,
+                        ModernCaptionFont.Height);
+
                     // Keep the content rectangle compatible with the classic GroupBox while the
                     // renderer keeps drawing the modern card/header surface and caption.
                     return new Padding(
@@ -126,7 +140,7 @@ public partial class GroupBox
             return (font.Height, 0);
         }
 
-        float lineHeightPixels = font.GetHeight(DeviceDpiInternal);
+        float lineHeightPixels = font.Height;
         int ascent = (int)Math.Ceiling(
             lineHeightPixels * family.GetCellAscent(style) / lineSpacingDesignUnits);
         int descent = (int)Math.Ceiling(
@@ -300,7 +314,7 @@ public partial class GroupBox
             : BackColor;
         Color headerColor = Application.SystemVisualSettings.AccentColor;
         Color headerSurfaceColor = PopupButtonColorMath.Blend(
-            bodyColor,
+            DisabledColor,
             headerColor,
             PopupHeaderAccentBlendAmount);
         Color borderColor = PopupButtonColorMath.TowardsContrast(
@@ -655,7 +669,7 @@ public partial class GroupBox
         {
             InvalidateModernCaptionFont();
 
-            if (FlatStyle == FlatStyle.Flat)
+            if (FlatStyle != FlatStyle.Standard || !string.IsNullOrEmpty(Text))
             {
                 CommonProperties.xClearPreferredSizeCache(this);
                 LayoutTransaction.DoLayout(
@@ -701,9 +715,7 @@ public partial class GroupBox
         bool newUsesModernMetrics = newMode >= VisualStylesMode.Net11;
 
         return oldUsesModernMetrics != newUsesModernMetrics
-            ? FlatStyle == FlatStyle.Flat
-                ? VisualStylesModeChangeImpact.Metrics
-                : VisualStylesModeChangeImpact.Repaint
+            ? VisualStylesModeChangeImpact.Metrics
             : VisualStylesModeChangeImpact.Repaint;
     }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/GroupBox/GroupBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/GroupBox/GroupBox.cs
@@ -149,7 +149,22 @@ public partial class GroupBox : Control
             }
 
             Size size = ClientSize;
+            int displayFontHeight = DisplayFontHeight;
 
+            // For efficiency, so that we don't need to read property store four times
+            Padding padding = Padding;
+            return new Rectangle(
+                padding.Left,
+                displayFontHeight + padding.Top,
+                Math.Max(size.Width - padding.Horizontal, 0),
+                Math.Max(size.Height - displayFontHeight - padding.Vertical, 0));
+        }
+    }
+
+    private int DisplayFontHeight
+    {
+        get
+        {
             if (_fontHeight == -1)
             {
                 _fontHeight = Font.Height;
@@ -163,13 +178,7 @@ public partial class GroupBox : Control
                 _cachedFont = Font;
             }
 
-            // For efficiency, so that we don't need to read property store four times
-            Padding padding = Padding;
-            return new Rectangle(
-                padding.Left,
-                _fontHeight + padding.Top,
-                Math.Max(size.Width - padding.Horizontal, 0),
-                Math.Max(size.Height - _fontHeight - padding.Vertical, 0));
+            return _fontHeight;
         }
     }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/ModernControlVisualStyles.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/ModernControlVisualStyles.cs
@@ -29,20 +29,8 @@ internal static class ModernControlVisualStyles
     /// <summary>Height of the animated focus underline band drawn beneath a focused modern field.</summary>
     internal const int FocusBandHeight = 4;
 
-    /// <summary>Scale factor applied to the GroupBox caption font in modern mode.</summary>
-    internal const float GroupBoxCaptionFontScale = 1.15f;
-
     /// <summary>Gap between the GroupBox caption text and the surrounding frame line.</summary>
     internal const int GroupBoxCaptionGap = 4;
-
-    /// <summary>Inset from the GroupBox bottom frame to its content area.</summary>
-    internal const int GroupBoxContentBottomInset = 4;
-
-    /// <summary>Inset from the GroupBox left/right frame to its content area.</summary>
-    internal const int GroupBoxContentHorizontalInset = 8;
-
-    /// <summary>Inset from the GroupBox top frame (below the caption) to its content area.</summary>
-    internal const int GroupBoxContentTopInset = 8;
 
     /// <summary>Corner radius of the GroupBox rounded frame.</summary>
     internal const int GroupBoxCornerRadius = 8;
@@ -52,12 +40,6 @@ internal static class ModernControlVisualStyles
 
     /// <summary>Horizontal padding around the GroupBox header text.</summary>
     internal const int GroupBoxHeaderHorizontalPadding = 10;
-
-    /// <summary>Vertical padding around the GroupBox header text.</summary>
-    internal const int GroupBoxHeaderVerticalPadding = 5;
-
-    /// <summary>Extra content inset for the modern Popup-style GroupBox, applied on top of the header height.</summary>
-    internal const int GroupBoxPopupContentInset = 2;
 
     /// <summary>
     ///  Inset between a control's border and its content, shared by modern text fields and the up-down

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/GroupBoxModernPopupTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/GroupBoxModernPopupTests.cs
@@ -1,0 +1,137 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Drawing;
+using System.Windows.Forms.Rendering.Button;
+
+namespace System.Windows.Forms.Tests;
+
+public class GroupBoxModernPopupTests
+{
+    [WinFormsFact]
+    public void GroupBox_ModernStandard_WithCaptionTextScaleChangeRemeasuresParent()
+    {
+        SystemVisualSettings previous = SystemVisualSettingsTracker.CurrentSettings;
+        SystemVisualSettings initial = new(
+            previous.AccentColor,
+            1f,
+            highContrastEnabled: false,
+            previous.ClientAreaAnimationEnabled,
+            previous.KeyboardCuesVisible,
+            previous.FocusBorderMetrics);
+        SystemVisualSettings scaled = new(
+            previous.AccentColor,
+            1.5f,
+            highContrastEnabled: false,
+            previous.ClientAreaAnimationEnabled,
+            previous.KeyboardCuesVisible,
+            previous.FocusBorderMetrics);
+
+        try
+        {
+            SystemVisualSettingsTracker.ResetForTesting(initial);
+            using Panel parent = new();
+            using DpiGroupBox control = new()
+            {
+                FlatStyle = FlatStyle.Standard,
+                Text = "Header",
+                VisualStylesMode = VisualStylesMode.Net11
+            };
+            parent.Controls.Add(control);
+            int originalTop = control.DisplayRectangle.Top;
+            int layoutCallCount = 0;
+            parent.Layout += (sender, e) => layoutCallCount++;
+
+            SystemVisualSettingsTracker.ResetForTesting(scaled);
+            control.RaiseSystemVisualSettingsChanged(initial, scaled);
+
+            Assert.True(control.DisplayRectangle.Top > originalTop);
+            Assert.True(layoutCallCount > 0);
+        }
+        finally
+        {
+            SystemVisualSettingsTracker.ResetForTesting(previous);
+        }
+    }
+
+    [WinFormsFact]
+    public void GroupBox_ModernFlat_CaptionMetricsUseFontPixelHeightAtHighDpi()
+    {
+        using SystemVisualSettingsTestScope settingsScope = new(
+            clientAreaAnimationEnabled: false,
+            highContrastEnabled: false);
+        using DpiGroupBox control = new()
+        {
+            FlatStyle = FlatStyle.Flat,
+            Text = "Header",
+            VisualStylesMode = VisualStylesMode.Net11
+        };
+        control.SetTestDeviceDpi(192);
+        (int ascent, int descent) = control.ModernCaptionMetrics;
+
+        Assert.InRange(ascent, 1, control.ModernCaptionHeight);
+        Assert.InRange(ascent + descent, 1, control.ModernCaptionHeight + 1);
+    }
+
+    [WinFormsFact]
+    public void GroupBox_ModernPopup_TransparentBackColorPaintsHeaderOverParent()
+    {
+        using SystemVisualSettingsTestScope settingsScope = new(
+            clientAreaAnimationEnabled: false,
+            highContrastEnabled: false);
+        Color parentBackColor = Color.CornflowerBlue;
+        using Panel parent = new()
+        {
+            BackColor = parentBackColor,
+            Size = new Size(100, 70)
+        };
+        using GroupBox control = new()
+        {
+            BackColor = Color.Transparent,
+            FlatStyle = FlatStyle.Popup,
+            Size = parent.Size,
+            Text = string.Empty,
+            VisualStylesMode = VisualStylesMode.Net11
+        };
+        parent.Controls.Add(control);
+        parent.CreateControl();
+        control.CreateControl();
+        using Bitmap actual = new(control.Width, control.Height);
+
+        control.DrawToBitmap(
+            actual,
+            new Rectangle(Point.Empty, control.Size));
+
+        Color expectedHeaderColor = PopupButtonColorMath.Blend(
+            parentBackColor,
+            Application.SystemVisualSettings.AccentColor,
+            0.12f);
+        Color actualHeaderColor = actual.GetPixel(
+            actual.Width / 2,
+            control.Font.Height / 2);
+
+        Assert.Equal(expectedHeaderColor.ToArgb(), actualHeaderColor.ToArgb());
+        Assert.NotEqual(parentBackColor.ToArgb(), actualHeaderColor.ToArgb());
+    }
+
+    private sealed class DpiGroupBox : GroupBox
+    {
+        public int ModernCaptionHeight
+            => ((Font)this.TestAccessor.Dynamic.ModernCaptionFont).Height;
+
+        public (int Ascent, int Descent) ModernCaptionMetrics
+            => ((int, int))this.TestAccessor.Dynamic.GetModernCaptionMetrics();
+
+        public void SetTestDeviceDpi(int deviceDpi)
+            => DeviceDpiInternal = deviceDpi;
+
+        public void RaiseSystemVisualSettingsChanged(
+            SystemVisualSettings oldSettings,
+            SystemVisualSettings newSettings)
+            => OnSystemVisualSettingsChanged(
+                new SystemVisualSettingsChangedEventArgs(
+                    oldSettings,
+                    newSettings,
+                    SystemVisualSettingsCategories.TextScale));
+    }
+}

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/GroupBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/GroupBoxTests.cs
@@ -144,7 +144,6 @@ public class GroupBoxTests
             VisualStylesMode = VisualStylesMode.Net11
         };
 
-        Font captionFont = control.ModernCaptionFont;
         Padding padding = control.Padding;
         int deviceDpi = control.DeviceDpi;
 
@@ -152,55 +151,45 @@ public class GroupBoxTests
         switch (flatStyle)
         {
             case FlatStyle.Standard:
-            {
-                // Card reserves only the caption band plus its gap at the top; no internal
-                // horizontal or bottom inset, so a docked child can fill the card.
-                int top = captionFont.Height
-                    + ScaleHelper.ScaleToDpi(
-                        ModernControlVisualStyles.GroupBoxCaptionGap,
-                        deviceDpi);
-                expectedInsets = new Padding(
-                    padding.Left,
-                    padding.Top + top,
-                    padding.Right,
-                    padding.Bottom);
-                break;
-            }
+                {
+                    // Card keeps the classic content rectangle while the renderer draws the modern surface.
+                    int top = control.Font.Height;
+                    expectedInsets = new Padding(
+                        padding.Left,
+                        padding.Top + top,
+                        padding.Right,
+                        padding.Bottom);
+                    break;
+                }
 
             case FlatStyle.Flat:
-            {
-                // Content clears the descenders below the baseline border line, and sits just
-                // inside the border on the other sides.
-                (int ascent, int descent) = control.ModernCaptionMetrics;
-                int leeway = ScaleHelper.ScaleToDpi(
-                    ModernControlVisualStyles.GroupBoxFlatBaselineLeeway,
-                    deviceDpi);
-                int borderInset = control.ModernBorderThickness + leeway;
-                expectedInsets = new Padding(
-                    padding.Left + borderInset,
-                    padding.Top + ascent + descent + leeway,
-                    padding.Right + borderInset,
-                    padding.Bottom + borderInset);
-                break;
-            }
+                {
+                    // Content clears the descenders below the baseline border line, and sits just
+                    // inside the border on the other sides.
+                    (int ascent, int descent) = control.ModernCaptionMetrics;
+                    int leeway = ScaleHelper.ScaleToDpi(
+                        ModernControlVisualStyles.GroupBoxFlatBaselineLeeway,
+                        deviceDpi);
+                    int borderInset = control.ModernBorderThickness + leeway;
+                    expectedInsets = new Padding(
+                        padding.Left + borderInset,
+                        padding.Top + ascent + descent + leeway,
+                        padding.Right + borderInset,
+                        padding.Bottom + borderInset);
+                    break;
+                }
 
             case FlatStyle.Popup:
-            {
-                // Content is flush to the header rectangle (0 top gap) with a 2px inset elsewhere.
-                int headerHeight = captionFont.Height
-                    + (2 * ScaleHelper.ScaleToDpi(
-                        ModernControlVisualStyles.GroupBoxHeaderVerticalPadding,
-                        deviceDpi));
-                int inset = ScaleHelper.ScaleToDpi(
-                    ModernControlVisualStyles.GroupBoxPopupContentInset,
-                    deviceDpi);
-                expectedInsets = new Padding(
-                    padding.Left + inset,
-                    padding.Top + headerHeight,
-                    padding.Right + inset,
-                    padding.Bottom + inset);
-                break;
-            }
+                {
+                    // Popup keeps the classic content rectangle while the renderer draws the modern header.
+                    int top = control.Font.Height;
+                    expectedInsets = new Padding(
+                        padding.Left,
+                        padding.Top + top,
+                        padding.Right,
+                        padding.Bottom);
+                    break;
+                }
 
             default:
                 throw new InvalidOperationException();
@@ -231,10 +220,7 @@ public class GroupBoxTests
             VisualStylesMode = VisualStylesMode.Net11
         };
 
-        int top = control.ModernCaptionFont.Height
-            + ScaleHelper.ScaleToDpi(
-                ModernControlVisualStyles.GroupBoxCaptionGap,
-                control.DeviceDpi);
+        int top = control.Font.Height;
         Rectangle displayRectangle = control.DisplayRectangle;
 
         // With Padding = 0 the content area spans the full width and reaches the bottom edge, so a
@@ -243,6 +229,31 @@ public class GroupBoxTests
         Assert.Equal(top, displayRectangle.Top);
         Assert.Equal(control.ClientSize.Width, displayRectangle.Width);
         Assert.Equal(control.ClientSize.Height, displayRectangle.Bottom);
+    }
+
+    [WinFormsTheory]
+    [InlineData(FlatStyle.Standard)]
+    [InlineData(FlatStyle.Popup)]
+    public void GroupBox_ModernVisualStyles_ModeSwitchPreservesClassicDisplayRectangle(
+        FlatStyle flatStyle)
+    {
+        using SystemVisualSettingsTestScope settingsScope = new(
+            clientAreaAnimationEnabled: false,
+            highContrastEnabled: false);
+        using VisualStylesGroupBox control = new()
+        {
+            FlatStyle = flatStyle,
+            Padding = new Padding(7, 3, 11, 5),
+            Size = new Size(200, 100),
+            Text = "Modern group",
+            VisualStylesMode = VisualStylesMode.Classic
+        };
+        Rectangle classicDisplayRectangle = control.DisplayRectangle;
+
+        control.VisualStylesMode = VisualStylesMode.Net11;
+
+        Assert.Equal(classicDisplayRectangle, control.DisplayRectangle);
+        Assert.False(control.IsHandleCreated);
     }
 
     [WinFormsTheory]
@@ -305,17 +316,14 @@ public class GroupBoxTests
             Application.SystemVisualSettings.TextScaleFactor,
             1f,
             2.25f);
-        float expectedScale = flatStyle == FlatStyle.Flat
-            ? textScale
-            : ModernControlVisualStyles.GroupBoxCaptionFontScale * textScale;
         Assert.Equal(
-            originalFont.Size * expectedScale,
+            originalFont.Size * textScale,
             control.ModernCaptionFont.Size,
             precision: 3);
     }
 
     [WinFormsFact]
-    public void GroupBox_ModernVisualStyles_RegularFontUsesInstalledSemiBoldFaceWhenAvailable()
+    public void GroupBox_ModernVisualStyles_RegularFontPreservesFamilyAndStyle()
     {
         using SystemVisualSettingsTestScope settingsScope = new(
             clientAreaAnimationEnabled: false,
@@ -330,13 +338,9 @@ public class GroupBoxTests
             FlatStyle = FlatStyle.Standard,
             VisualStylesMode = VisualStylesMode.Net11
         };
-        string semiBoldFamilyName = GroupBox.FindSemiBoldFamilyName(
-            regularFont.FontFamily.Name);
 
         Assert.Equal(
-            semiBoldFamilyName.Length == 0
-                ? regularFont.FontFamily.Name
-                : semiBoldFamilyName,
+            regularFont.FontFamily.Name,
             control.ModernCaptionFont.FontFamily.Name,
             ignoreCase: true);
         Assert.Equal(FontStyle.Regular, control.ModernCaptionFont.Style);
@@ -364,14 +368,6 @@ public class GroupBoxTests
             control.ModernCaptionFont.FontFamily.Name,
             ignoreCase: true);
         Assert.Equal(styledFont.Style, control.ModernCaptionFont.Style);
-    }
-
-    [Fact]
-    public void GroupBox_FindSemiBoldFamilyName_MissingFamilyReturnsEmpty()
-    {
-        Assert.Empty(
-            GroupBox.FindSemiBoldFamilyName(
-                $"Missing-{Guid.NewGuid():N}"));
     }
 
     [WinFormsFact]
@@ -402,10 +398,7 @@ public class GroupBoxTests
             actual,
             new Rectangle(Point.Empty, control.Size));
 
-        int frameTop = control.ModernCaptionFont.Height
-            + ScaleHelper.ScaleToDpi(
-                ModernControlVisualStyles.GroupBoxCaptionGap,
-                control.DeviceDpi);
+        int frameTop = control.Font.Height;
         Color expected = PopupButtonColorMath.TowardsContrast(
             control.BackColor,
             0.035f);
@@ -464,7 +457,7 @@ public class GroupBoxTests
     }
 
     [WinFormsFact]
-    public void GroupBox_ModernPopup_PaintsWindowsAccentHeader()
+    public void GroupBox_ModernPopup_PaintsSubtleAccentHeader()
     {
         using SystemVisualSettingsTestScope settingsScope = new(
             clientAreaAnimationEnabled: false,
@@ -484,13 +477,19 @@ public class GroupBoxTests
             actual,
             new Rectangle(Point.Empty, control.Size));
 
+        int headerInteriorY = Math.Min(
+            actual.Height - 1,
+            control.ModernBorderThickness + 2);
+        Color expectedHeaderColor = PopupButtonColorMath.Blend(
+            control.BackColor,
+            Application.SystemVisualSettings.AccentColor,
+            0.12f);
+
         Assert.Equal(
-            Application.SystemVisualSettings.AccentColor.ToArgb(),
+            expectedHeaderColor.ToArgb(),
             actual.GetPixel(
                 actual.Width / 2,
-                Math.Min(
-                    actual.Height - 1,
-                    control.ModernBorderThickness + 2)).ToArgb());
+                headerInteriorY).ToArgb());
     }
 
     [WinFormsFact]
@@ -523,7 +522,7 @@ public class GroupBoxTests
     [WinFormsTheory]
     [InlineData(RightToLeft.No)]
     [InlineData(RightToLeft.Yes)]
-    public void GroupBox_ModernPopup_CaptionBoundsApplyStandardPaddingBeforeHeaderInset(
+    public void GroupBox_ModernPopup_CaptionBoundsStayInsideHeader(
         RightToLeft rightToLeft)
     {
         using SystemVisualSettingsTestScope settingsScope = new(
@@ -543,9 +542,6 @@ public class GroupBoxTests
         int horizontalPadding = ScaleHelper.ScaleToDpi(
             ModernControlVisualStyles.GroupBoxHeaderHorizontalPadding,
             control.DeviceDpi);
-        int verticalPadding = ScaleHelper.ScaleToDpi(
-            ModernControlVisualStyles.GroupBoxHeaderVerticalPadding,
-            control.DeviceDpi);
 
         Rectangle standardBounds = control.GetStandardCaptionBounds(
             bounds);
@@ -556,11 +552,12 @@ public class GroupBoxTests
             standardBounds.Left + horizontalPadding,
             popupBounds.Left);
         Assert.Equal(
-            standardBounds.Top + verticalPadding,
+            standardBounds.Top,
             popupBounds.Top);
         Assert.Equal(
             standardBounds.Right - horizontalPadding,
             popupBounds.Right);
+        Assert.Equal(standardBounds.Height, popupBounds.Height);
     }
 
     [WinFormsTheory]
@@ -732,7 +729,7 @@ public class GroupBoxTests
 
         control.FlatStyle = FlatStyle.Popup;
 
-        Assert.NotEqual(standardBounds, child.Bounds);
+        Assert.Equal(standardBounds, child.Bounds);
         Assert.Equal(control.DisplayRectangle, child.Bounds);
         Assert.False(control.IsHandleCreated);
     }
@@ -761,7 +758,7 @@ public class GroupBoxTests
     }
 
     [WinFormsFact]
-    public void GroupBox_ModernVisualStyles_TextScaleChangeRemeasuresParent()
+    public void GroupBox_ModernStandard_TextScaleChangeDoesNotRemeasureParent()
     {
         SystemVisualSettings previous = SystemVisualSettingsTracker.CurrentSettings;
         SystemVisualSettings initial = new(
@@ -800,8 +797,8 @@ public class GroupBoxTests
                     scaled,
                     SystemVisualSettingsCategories.TextScale));
 
-            Assert.True(control.DisplayRectangle.Top > originalTop);
-            Assert.Equal(1, layoutCallCount);
+            Assert.Equal(originalTop, control.DisplayRectangle.Top);
+            Assert.Equal(0, layoutCallCount);
             Assert.False(control.IsHandleCreated);
         }
         finally
@@ -3053,13 +3050,10 @@ public class GroupBoxTests
         public Rectangle GetPopupCaptionBounds(Rectangle bounds)
             => (Rectangle)this.TestAccessor.Dynamic.GetPopupCaptionBounds(
                 bounds,
-                ModernCaptionFont.Height,
                 ScaleHelper.ScaleToDpi(
                     ModernControlVisualStyles.GroupBoxHeaderHorizontalPadding,
                     DeviceDpi),
-                ScaleHelper.ScaleToDpi(
-                    ModernControlVisualStyles.GroupBoxHeaderVerticalPadding,
-                    DeviceDpi));
+                Math.Max(Font.Height, ModernCaptionFont.Height));
 
         public Rectangle GetFlatCaptionBounds(Rectangle bounds)
             => (Rectangle)this.TestAccessor.Dynamic.GetFlatCaptionBounds(
@@ -3101,7 +3095,7 @@ public class GroupBoxTests
 
         public void RaiseSystemVisualSettingsChanged(
             SystemVisualSettingsChangedEventArgs e)
-            => base.OnSystemVisualSettingsChanged(e);
+            => OnSystemVisualSettingsChanged(e);
 
         internal override bool IsHighContrast => false;
     }


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14832

## Root Cause

`GroupBox` used larger NET11 caption/header metrics for `DisplayRectangle` in `FlatStyle.Standard` and `FlatStyle.Popup`.

After switching from Classic to NET11, the content rectangle moved, but existing child controls kept their positions. This made controls near the top overlap the GroupBox header/border.

## Proposed changes

Update modern GroupBox rendering and layout so that:

- Preserve Classic layout metrics for Standard and Popup GroupBoxes in NET11 mode.
- Preserve caption font settings while respecting system text scaling.
- Keep the modern Popup appearance with an accent-colored header and border.
- Leave Flat GroupBox behavior unchanged.
- Add regression tests and update documentation.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Apps can enable or switch to NET11 visual styles with less layout disruption. Existing GroupBox child layouts remain stable for Standard and Popup styles.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Switching Classic → NET11 could change the GroupBox content area and cause top child controls to overlap the header/border.

<img width="618" height="428" alt="Image" src="https://github.com/user-attachments/assets/fa016150-1154-4ecb-8943-c28c9102c2ec" />


### After

Standard and Popup GroupBoxes keep the same content area after switching to NET11, so child controls stay in place and no longer overlap.

<img width="1367" height="303" alt="image" src="https://github.com/user-attachments/assets/495d094f-675a-4bb7-952a-ed8ebbe6c428" />


## Test methodology <!-- How did you ensure quality? -->

- Unit test and manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-rc.1.26411.119


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14891)