### PR TITLE
Restoring autoConvert behavior in Clipboard APIs

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/OLE/Clipboard.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/OLE/Clipboard.cs
@@ -124,7 +124,7 @@ public static class Clipboard
         // would call back through the format enumerator which defaults to true.
         //
         // We now unwrap original objects when we can, so we need to emulate the old behavior.
-        return ContainsData(ConvertToDataFormats(format), autoConvert: true);
+        return ContainsData(ClipboardUtilities.ConvertToDataFormats(format), autoConvert: true);
     }
 
     /// <summary>
@@ -349,7 +349,7 @@ public static class Clipboard
             return false;
         }
 
-        return dataObject.TryGetData(format, out data);
+        return dataObject.TryGetData(format, autoConvert: false, out data);
     }
 
     /// <inheritdoc cref="TryGetData{T}(string, out T)"/>
@@ -392,20 +392,22 @@ public static class Clipboard
     {
         SourceGenerated.EnumValidator.Validate(format, nameof(format));
 
-        return GetTypedDataIfAvailable<string>(ConvertToDataFormats(format)) is string text ? text : string.Empty;
+        return GetTypedDataIfAvailable<string>(ClipboardUtilities.ConvertToDataFormats(format)) is string text ? text : string.Empty;
     }
 
     private static T? GetTypedDataIfAvailable<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string format)
     {
         IDataObject? data = GetDataObject();
+        bool autoConvert = IsDataFormatAutoConvert(format);
+
         if (data is ITypedDataObject typed)
         {
-            return typed.TryGetData(format, autoConvert: true, out T? value) ? value : default;
+            return typed.TryGetData(format, autoConvert, out T? value) ? value : default;
         }
 
         if (data is IDataObject dataObject)
         {
-            return dataObject.GetData(format, autoConvert: true) is T value ? value : default;
+            return dataObject.GetData(format, autoConvert) is T value ? value : default;
         }
 
         return default;
@@ -475,16 +477,12 @@ public static class Clipboard
     {
         text.ThrowIfNullOrEmpty();
         SourceGenerated.EnumValidator.Validate(format, nameof(format));
-        SetDataObject(new DataObject(ConvertToDataFormats(format), text), copy: true);
+        SetDataObject(new DataObject(ClipboardUtilities.ConvertToDataFormats(format), text), copy: true);
     }
 
-    private static string ConvertToDataFormats(TextDataFormat format) => format switch
-    {
-        TextDataFormat.Text => DataFormats.Text,
-        TextDataFormat.UnicodeText => DataFormats.UnicodeText,
-        TextDataFormat.Rtf => DataFormats.Rtf,
-        TextDataFormat.Html => DataFormats.Html,
-        TextDataFormat.CommaSeparatedValue => DataFormats.CommaSeparatedValue,
-        _ => DataFormats.UnicodeText,
-    };
+    /// <summary>
+    ///  Check the auto convert for the specified data format.
+    /// </summary>
+    private static bool IsDataFormatAutoConvert(string format) =>
+        format == DataFormats.FileDrop || format == DataFormats.Bitmap;
 }

--- a/src/System.Windows.Forms/System/Windows/Forms/OLE/ClipboardUtilities.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/OLE/ClipboardUtilities.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms;
+
+internal static class ClipboardUtilities
+{
+    internal static string ConvertToDataFormats(TextDataFormat format) => format switch
+    {
+        TextDataFormat.Text => DataFormats.Text,
+        TextDataFormat.UnicodeText => DataFormats.UnicodeText,
+        TextDataFormat.Rtf => DataFormats.Rtf,
+        TextDataFormat.Html => DataFormats.Html,
+        TextDataFormat.CommaSeparatedValue => DataFormats.CommaSeparatedValue,
+        _ => DataFormats.UnicodeText,
+    };
+}

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ClipboardTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ClipboardTests.cs
@@ -64,6 +64,26 @@ public class ClipboardTests
         action.Should().Throw<InvalidEnumArgumentException>().WithParameterName("format");
     }
 
+    [WinFormsTheory]
+    [InlineData(TextDataFormat.Text, TextDataFormat.UnicodeText)]
+    [InlineData(TextDataFormat.UnicodeText, TextDataFormat.Text)]
+    public void GetText_AutoConvertibleFormat_DoesNotAutoConvert(
+    TextDataFormat sourceFormat,
+    TextDataFormat requestedFormat)
+    {
+        const string text = "Hello, World!";
+        string sourceDataFormat = ClipboardUtilities.ConvertToDataFormats(sourceFormat);
+        string requestedDataFormat = ClipboardUtilities.ConvertToDataFormats(requestedFormat);
+        DataObject dataObject = new();
+        dataObject.SetData(sourceDataFormat, autoConvert: true, text);
+
+        dataObject.GetData(requestedDataFormat, autoConvert: true).Should().Be(text);
+        dataObject.GetData(requestedDataFormat, autoConvert: false).Should().BeNull();
+
+        Clipboard.SetDataObject(dataObject);
+        Clipboard.GetText(requestedFormat).Should().BeEmpty();
+    }
+
     [WinFormsFact]
     public void SetAudio_InvokeByteArray_GetReturnsExpected()
     {
@@ -1153,9 +1173,9 @@ public class ClipboardTests
         formats = dataObject.GetFormats(autoConvert: false);
         formats.Should().BeEquivalentTo(["System.String", "UnicodeText", "Text"]);
 
-        Clipboard.GetText().Should().Be(expected);
-        Clipboard.GetText(TextDataFormat.Text).Should().Be(expected);
-        Clipboard.GetText(TextDataFormat.UnicodeText).Should().Be(expected);
+        Clipboard.GetText().Should().Be(string.Empty);
+        Clipboard.GetText(TextDataFormat.Text).Should().Be(string.Empty);
+        Clipboard.GetText(TextDataFormat.UnicodeText).Should().Be(string.Empty);
 
         Clipboard.GetData("System.String").Should().Be(expected);
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ClipboardTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ClipboardTests.cs
@@ -68,8 +68,8 @@ public class ClipboardTests
     [InlineData(TextDataFormat.Text, TextDataFormat.UnicodeText)]
     [InlineData(TextDataFormat.UnicodeText, TextDataFormat.Text)]
     public void GetText_AutoConvertibleFormat_DoesNotAutoConvert(
-    TextDataFormat sourceFormat,
-    TextDataFormat requestedFormat)
+        TextDataFormat sourceFormat,
+        TextDataFormat requestedFormat)
     {
         const string text = "Hello, World!";
         string sourceDataFormat = ClipboardUtilities.ConvertToDataFormats(sourceFormat);

--- a/src/test/util/System.Windows.Forms/Data/TypedAndRuntimeDataObject.cs
+++ b/src/test/util/System.Windows.Forms/Data/TypedAndRuntimeDataObject.cs
@@ -24,8 +24,17 @@ internal class TypedAndRuntimeDataObject : ManagedAndRuntimeDataObject, ITypedDa
         return false;
     }
 
-    public bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string format, bool autoConvert, [MaybeNullWhen(false), NotNullWhen(true)] out T data) =>
-        throw new NotImplementedException();
+    public bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string format, bool autoConvert, [MaybeNullWhen(false), NotNullWhen(true)] out T data)
+    {
+        data = default;
+        if (format == s_format && _data is T t)
+        {
+            data = t;
+            return true;
+        }
+
+        return false;
+    }
 
     public bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
         string format,

--- a/src/test/util/System.Windows.Forms/Data/TypedDataObject.cs
+++ b/src/test/util/System.Windows.Forms/Data/TypedDataObject.cs
@@ -24,8 +24,18 @@ internal class TypedDataObject : UntypedDataObject, ITypedDataObject
         return false;
     }
 
-    public bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string format, bool autoConvert, [MaybeNullWhen(false), NotNullWhen(true)] out T data) =>
-        throw new NotImplementedException();
+    public bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string format, bool autoConvert, [MaybeNullWhen(false), NotNullWhen(true)] out T data)
+    {
+        data = default;
+        if (format == s_format && _data is T t)
+        {
+            data = t;
+            return true;
+        }
+
+        return false;
+    }
+
     public bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
         string format,
         Func<TypeName, Type?> resolver,


### PR DESCRIPTION
Fixes mojibake character issue in https://github.com/dotnet/winforms/issues/14322

## Description

Till .NET 9.0, `autoConvert` was set to true only for `FileDrop` and `Bitmap` scenarios. However, since .NET 10, it is being set to true for `GetAudioStream`, `GetFileDropList`, `GetImage`, and `GetText` APIs inside the private method `GetTypedDataIfAvailable`. This causes issues with GetText API with mojibake characters as described in the bug.

## Customer Impact

There is no way for the app to know whether the clipboard contents were corrupted or if there is any problem with the API as it didn't get the desired data.

## Regression

Yes - from .NET 9.0

## Testing

Created a WinForms app to write unicode data on the clipboard and another app to read it. Before the changes, the reader app returned several hits for mojibake characters. After fix, there were none.

## Risk

This should be a very low risk change as this behavior was working fine in 9.0 and previous versions.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14893)