### PR TITLE
Fix Image dimension DefaultValue metadata

### DIFF
--- a/src/System.Drawing.Common/src/CompatibilitySuppressions.xml
+++ b/src/System.Drawing.Common/src/CompatibilitySuppressions.xml
@@ -27,6 +27,32 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0015</DiagnosticId>
+    <Target>P:System.Drawing.Image.Height:[T:System.ComponentModel.DefaultValueAttribute]</Target>
+    <Left>lib/net10.0/System.Drawing.Common.dll</Left>
+    <Right>lib/net10.0/System.Drawing.Common.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0015</DiagnosticId>
+    <Target>P:System.Drawing.Image.Width:[T:System.ComponentModel.DefaultValueAttribute]</Target>
+    <Left>lib/net10.0/System.Drawing.Common.dll</Left>
+    <Right>lib/net10.0/System.Drawing.Common.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0015</DiagnosticId>
+    <Target>P:System.Drawing.Image.Height:[T:System.ComponentModel.DefaultValueAttribute]</Target>
+    <Left>lib/netstandard2.0/System.Drawing.Common.dll</Left>
+    <Right>lib/net10.0/System.Drawing.Common.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0015</DiagnosticId>
+    <Target>P:System.Drawing.Image.Width:[T:System.ComponentModel.DefaultValueAttribute]</Target>
+    <Left>lib/netstandard2.0/System.Drawing.Common.dll</Left>
+    <Right>lib/net10.0/System.Drawing.Common.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0015</DiagnosticId>
     <Target>P:System.Drawing.Font.Name:[T:System.ComponentModel.EditorAttribute]</Target>
     <Left>lib/netstandard2.0/System.Drawing.Common.dll</Left>
     <Right>lib/net462/System.Drawing.Common.dll</Right>

--- a/src/System.Drawing.Common/src/System/Drawing/Image.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Image.cs
@@ -423,7 +423,7 @@ public abstract unsafe class Image : MarshalByRefObject, IImage, IDisposable, IC
     /// <summary>
     ///  Gets the width of this <see cref='Image'/>.
     /// </summary>
-    [DefaultValue(false)]
+    [DefaultValue(0)]
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public int Width
@@ -440,7 +440,7 @@ public abstract unsafe class Image : MarshalByRefObject, IImage, IDisposable, IC
     /// <summary>
     ///  Gets the height of this <see cref='Image'/>.
     /// </summary>
-    [DefaultValue(false)]
+    [DefaultValue(0)]
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public int Height

--- a/src/System.Drawing.Common/tests/System/Drawing/ImageTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/ImageTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel;
 using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -18,6 +19,19 @@ public class ImageTests
     private const int PropertyTagExifUserComment = 0x9286;
     private const int PropertyTagTypeASCII = 2;
     private const int PropertyTagTypeShort = 3;
+
+    [Theory]
+    [InlineData(nameof(Image.Width))]
+    [InlineData(nameof(Image.Height))]
+    public void ImageDimensionProperty_DefaultValueIsZero(string propertyName)
+    {
+        PropertyDescriptor? property = TypeDescriptor.GetProperties(typeof(Image))[propertyName];
+        Assert.NotNull(property);
+
+        DefaultValueAttribute defaultValue = Assert.IsType<DefaultValueAttribute>(
+            property.Attributes[typeof(DefaultValueAttribute)]);
+        Assert.Equal(0, defaultValue.Value);
+    }
 
     [Fact]
     public void PropertyIdList_GetBitmapJpg_Success()


### PR DESCRIPTION
Fixes dotnet/runtime#126265

## Proposed changes

- Change the `DefaultValue` metadata for `Image.Width` and `Image.Height` from `false` to integer `0`.
- Add a parameterized `TypeDescriptor` regression test for both properties.

## Customer Impact

- Metadata consumers no longer receive a Boolean default for integer properties.
- Prevents invalid-cast failures in consumers such as OpenAPI schema generation.

## Regression?

- No. This corrects invalid design-time metadata; the property values and API surface are unchanged.

## Risk

- Low. The production change is limited to two `DefaultValue` attributes and is covered by a focused regression test.

## Test methodology

- Built `System.Drawing.Common` and `System.Drawing.Common.Tests` with the repository-pinned .NET 11 toolchain.
- Ran `System.Drawing.Tests.ImageTests.ImageDimensionProperty_DefaultValueIsZero`: 2 passed, 0 failed.

## Test environment(s)

- Windows x64
- .NET SDK `11.0.100-preview.6.26359.118`
- Test runtime `11.0.0-rc.1.26411.119`

AI assistance: Codex was used to prepare this change; the patch was reviewed by the submitter.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14895)