### PR TITLE
Make GDI+ and encoder init thread-safe; add concurrency tests

### DIFF
--- a/src/System.Drawing.Common/tests/System/Drawing/ImageConcurrencyTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/ImageConcurrencyTests.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Drawing.Imaging;
+using Microsoft.DotNet.RemoteExecutor;
+using Windows.Win32.Graphics.GdiPlus;
+
+namespace System.Drawing.Tests;
+
+/// <summary>
+///  Tests concurrent first use of GDI+ image operations.
+/// </summary>
+public class ImageConcurrencyTests
+{
+    private const int WorkerCount = 16;
+
+    public static bool IsRemoteExecutorSupported => RemoteExecutor.IsSupported;
+
+    [Fact(Skip = "Condition not met", SkipUnless = nameof(IsRemoteExecutorSupported))]
+    public void GdiPlusInitialization_ConcurrentFirstUse_Succeeds()
+    {
+        RemoteExecutor.Invoke(() =>
+        {
+            using ManualResetEventSlim start = new(initialState: false);
+            Task<bool>[] tasks = new Task<bool>[WorkerCount];
+
+            for (int i = 0; i < tasks.Length; i++)
+            {
+                tasks[i] = Task.Run(() =>
+                {
+                    start.Wait();
+                    return GdiPlusInitialization.EnsureInitialized();
+                });
+            }
+
+            start.Set();
+
+            Assert.All(tasks, task => Assert.True(task.GetAwaiter().GetResult()));
+            Assert.True(GdiPlusInitialization.IsInitialized);
+        }).Dispose();
+    }
+
+    [Fact(Skip = "Condition not met", SkipUnless = nameof(IsRemoteExecutorSupported))]
+    public void Save_ConcurrentFirstUseOfEncoderCache_Succeeds()
+    {
+        RemoteExecutor.Invoke(() =>
+        {
+            using ManualResetEventSlim start = new(initialState: false);
+            Task<long>[] tasks = new Task<long>[WorkerCount];
+
+            for (int i = 0; i < tasks.Length; i++)
+            {
+                tasks[i] = Task.Run(() =>
+                {
+                    using Bitmap bitmap = new(100, 100);
+                    using MemoryStream stream = new();
+
+                    start.Wait();
+                    bitmap.Save(stream, ImageFormat.Png);
+
+                    return stream.Length;
+                });
+            }
+
+            start.Set();
+
+            Assert.All(tasks, task => Assert.True(task.GetAwaiter().GetResult() > 0));
+        }).Dispose();
+    }
+}

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/GdiPlusInitialization.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/GdiPlusInitialization.cs
@@ -8,11 +8,18 @@ namespace Windows.Win32.Graphics.GdiPlus;
 /// </summary>
 internal static partial class GdiPlusInitialization
 {
+#if NET
+    private static readonly Lock s_initializationLock = new();
+#else
+    private static readonly object s_initializationLock = new();
+#endif
     private static nuint s_initToken;
 
     private static unsafe nuint Init()
     {
-        Debug.Assert(s_initToken == 0, "GdiplusInitialization: Initialize should not be called more than once!");
+        Debug.Assert(
+            Volatile.Read(ref s_initToken) == UIntPtr.Zero,
+            "GdiplusInitialization: Initialize should not be called more than once!");
 
         // GDI+ ref counts multiple calls to Startup in the same process, so calls from multiple
         // domains are ok, just make sure to pair each w/GdiplusShutdown
@@ -38,16 +45,26 @@ internal static partial class GdiPlusInitialization
     /// </remarks>
     internal static bool EnsureInitialized()
     {
-        if (s_initToken == 0)
+        nuint token = Volatile.Read(ref s_initToken);
+        if (token == UIntPtr.Zero)
         {
-            s_initToken = Init();
+            lock (s_initializationLock)
+            {
+                token = s_initToken;
+                if (token == UIntPtr.Zero)
+                {
+                    token = Init();
+                    Volatile.Write(ref s_initToken, token);
+                }
+            }
         }
 
-        return IsInitialized;
+        return token != UIntPtr.Zero;
     }
 
     /// <summary>
     ///  Returns <see langword="true"/> if GDI+ has been started.
     /// </summary>
-    internal static bool IsInitialized => s_initToken != 0;
+    internal static bool IsInitialized
+        => Volatile.Read(ref s_initToken) != UIntPtr.Zero;
 }

--- a/src/System.Private.Windows.GdiPlus/System/Drawing/ImageCodecInfoHelper.cs
+++ b/src/System.Private.Windows.GdiPlus/System/Drawing/ImageCodecInfoHelper.cs
@@ -12,6 +12,7 @@ internal static class ImageCodecInfoHelper
     // encoder CLSIDs. There are only 5 encoders: PNG, JPEG, GIF, BMP, and TIFF. We'll just build the small cache
     // here to avoid all of the overhead. (We could probably just hard-code the values, but on the very small chance
     // that the list of encoders changes, we'll keep it dynamic.)
+    private static readonly Lock s_encoderLock = new();
     private static (Guid Format, Guid Encoder)[]? s_encoders;
 
     /// <summary>
@@ -34,31 +35,47 @@ internal static class ImageCodecInfoHelper
     {
         get
         {
-            if (s_encoders is null)
+            (Guid Format, Guid Encoder)[]? encoders = Volatile.Read(ref s_encoders);
+            if (encoders is null)
             {
-                GdiPlusInitialization.EnsureInitialized();
-
-                uint numEncoders;
-                uint size;
-
-                PInvokeGdiPlus.GdipGetImageEncodersSize(&numEncoders, &size).ThrowIfFailed();
-
-                using BufferScope<byte> buffer = new((int)size);
-
-                fixed (byte* b = buffer)
+                lock (s_encoderLock)
                 {
-                    PInvokeGdiPlus.GdipGetImageEncoders(numEncoders, size, (ImageCodecInfo*)b).ThrowIfFailed();
-                    ReadOnlySpan<ImageCodecInfo> codecInfo = new((ImageCodecInfo*)b, (int)numEncoders);
-                    s_encoders = new (Guid Format, Guid Encoder)[codecInfo.Length];
-
-                    for (int i = 0; i < codecInfo.Length; i++)
+                    encoders = s_encoders;
+                    if (encoders is null)
                     {
-                        s_encoders[i] = (codecInfo[i].FormatID, codecInfo[i].Clsid);
+                        encoders = CreateEncoders();
+                        Volatile.Write(ref s_encoders, encoders);
                     }
                 }
             }
 
-            return s_encoders;
+            return encoders;
+        }
+    }
+
+    private static unsafe (Guid Format, Guid Encoder)[] CreateEncoders()
+    {
+        GdiPlusInitialization.EnsureInitialized();
+
+        uint numEncoders;
+        uint size;
+
+        PInvokeGdiPlus.GdipGetImageEncodersSize(&numEncoders, &size).ThrowIfFailed();
+
+        using BufferScope<byte> buffer = new((int)size);
+
+        fixed (byte* b = buffer)
+        {
+            PInvokeGdiPlus.GdipGetImageEncoders(numEncoders, size, (ImageCodecInfo*)b).ThrowIfFailed();
+            ReadOnlySpan<ImageCodecInfo> codecInfo = new((ImageCodecInfo*)b, (int)numEncoders);
+            (Guid Format, Guid Encoder)[] encoders = new (Guid Format, Guid Encoder)[codecInfo.Length];
+
+            for (int i = 0; i < codecInfo.Length; i++)
+            {
+                encoders[i] = (codecInfo[i].FormatID, codecInfo[i].Clsid);
+            }
+
+            return encoders;
         }
     }
 }


### PR DESCRIPTION
This pull request improves thread safety and concurrency handling in GDI+ initialization and image encoder caching. It introduces proper locking and volatile access patterns to prevent race conditions when these resources are accessed concurrently, and adds new tests to verify correct concurrent behavior.

Fixes #14884.

**Thread safety and concurrency improvements:**

* Added locking and volatile access to `GdiPlusInitialization.EnsureInitialized` and `IsInitialized`, ensuring GDI+ is initialized safely under concurrent access. [[1]](diffhunk://#diff-2da4b43277ed78be59755bdabb8c052130b54f52d87441c2f93d38766e239209R11-R22) [[2]](diffhunk://#diff-2da4b43277ed78be59755bdabb8c052130b54f52d87441c2f93d38766e239209L41-R69)
* Introduced locking and volatile access to the encoder cache in `ImageCodecInfoHelper`, preventing race conditions when building or accessing the encoder list. [[1]](diffhunk://#diff-fcd9739fb5eabca45c9661d7a1b9f335a36a638661a51cab1aabd3870762c201R15) [[2]](diffhunk://#diff-fcd9739fb5eabca45c9661d7a1b9f335a36a638661a51cab1aabd3870762c201L37-R56) [[3]](diffhunk://#diff-fcd9739fb5eabca45c9661d7a1b9f335a36a638661a51cab1aabd3870762c201L52-R78)

**Testing enhancements:**

* Added `ImageConcurrencyTests.cs` to verify that concurrent first use of GDI+ initialization and encoder cache works correctly without failures or race conditions.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14896)