### PR TITLE
Fix modern RadioButton glyph clipping in RTL layouts

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/RadioButtonModernAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/RadioButtonModernAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/RadioButtonModernAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/RadioButtonModernAdapter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
@@ -61,6 +61,7 @@ internal sealed class RadioButtonModernAdapter : RadioButtonBaseAdapter
     protected override LayoutOptions Layout(PaintEventArgs e)
     {
         LayoutOptions layout = CommonLayout();
+        layout.CheckPaddingSize = Control.LogicalToDeviceUnits(2);
         layout.CheckSize = Math.Max(
             Control.LogicalToDeviceUnits(13),
             (int)(Control.Font.Height * 0.9f));

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/RadioButtonTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/RadioButtonTests.cs
@@ -238,6 +238,35 @@ public class RadioButtonTests : AbstractButtonBaseTests
     }
 
     [WinFormsFact]
+    public void RadioButton_ModernGlyph_RightToLeftHovered_DoesNotClipAtRightEdge()
+    {
+        using Panel parent = new() { BackColor = Color.White };
+        using RadioButton control = new()
+        {
+            BackColor = Color.White,
+            RightToLeft = RightToLeft.Yes,
+            Size = new Size(40, 24),
+            VisualStylesMode = VisualStylesMode.Net11
+        };
+        control.FlatAppearance.BorderColor = Color.Black;
+        parent.Controls.Add(control);
+
+        control.RadioGlyphRenderer.SetInteractionState(hovered: true, focused: false);
+        control.RadioGlyphRenderer.EndAnimation();
+
+        using Bitmap bitmap = new(control.Width, control.Height);
+        using Graphics graphics = Graphics.FromImage(bitmap);
+        PaintEventArgs e = new(graphics, control.ClientRectangle);
+
+        control.CreateStandardAdapter().PaintOver(e, CheckState.Unchecked);
+
+        for (int y = 0; y < bitmap.Height; y++)
+        {
+            Assert.Equal(0, bitmap.GetPixel(bitmap.Width - 1, y).A);
+        }
+    }
+
+    [WinFormsFact]
     public void RadioButton_ModernGlyph_DefaultCheckedColorUsesWindowsAccent()
     {
         if (SystemInformation.HighContrast)

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/RadioButtonTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/RadioButtonTests.cs
@@ -251,9 +251,9 @@ public class RadioButtonTests : AbstractButtonBaseTests
         control.FlatAppearance.BorderColor = Color.Black;
         parent.Controls.Add(control);
 
+        control.TestAccessor.Dynamic.OnMouseEnter(EventArgs.Empty);
         control.RadioGlyphRenderer.SetInteractionState(hovered: true, focused: false);
         control.RadioGlyphRenderer.EndAnimation();
-
         using Bitmap bitmap = new(control.Width, control.Height);
         using Graphics graphics = Graphics.FromImage(bitmap);
         PaintEventArgs e = new(graphics, control.ClientRectangle);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14898


## Proposed changes

- Added DPI-aware glyph padding in `RadioButtonModernAdapter`, preventing RTL hover clipping
- Added regression coverage in `RadioButtonTests`

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- RadioButton glyphs now render correctly without clipping when using `RightToLeft.Yes` with .NET 11 visual styles, including during mouse hover. The change also respects DPI scaling.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

In .NET 11 visual styles, a `RadioButton` with `RightToLeft.Yes` displayed a clipped glyph when hovered with the mouse.

<img width="449" height="302" alt="image" src="https://github.com/user-attachments/assets/2eeea8fe-ed12-48f9-b4c5-24550a8fb82d" />


### After

The RadioButton glyph has DPI-aware padding and renders fully without clipping in RTL layouts during mouse hover.

https://github.com/user-attachments/assets/543b654a-0b6a-4f01-933c-80fdbdb53b2c


## Test methodology <!-- How did you ensure quality? -->

- Manually and unit test

## Test environment(s) <!-- Remove any that don't apply -->

- .net11.0.0-rc.1.26411.119


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14904)