### PR TITLE
Fix GroupBox background image rendering in .NET 11 visual styles

### DIFF
--- a/src/System.Windows.Forms/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+override System.Windows.Forms.GroupBox.OnPaintBackground(System.Windows.Forms.PaintEventArgs! pevent) -> void
 static System.Windows.Forms.Application.SystemVisualSettings.get -> System.Windows.Forms.SystemVisualSettings!
 static System.Windows.Forms.Application.SystemVisualSettingsChanged -> System.Windows.Forms.SystemVisualSettingsChangedEventHandler?
 System.Windows.Forms.PropertyGrid.VisualStylesModeChanged -> System.EventHandler?

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.ModernComboAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ComboBox/ComboBox.ModernComboAdapter.cs
@@ -408,6 +408,7 @@ public partial class ComboBox
             Color parentColor = comboBox.ParentInternal?.BackColor
                 ?? SystemColors.Control;
             ParentBackgroundRenderer.PaintRoundedBorderRegionMitigation(
+                comboBox,
                 graphics,
                 bounds,
                 new Size(radius, radius),

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/GroupBox/GroupBox.Modern.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/GroupBox/GroupBox.Modern.cs
@@ -255,7 +255,7 @@ public partial class GroupBox
             BackgroundImageLayout,
             ClientRectangle,
             ClientRectangle,
-            DisplayRectangle.Location,
+            Point.Empty,
             RightToLeft);
     }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/GroupBox/GroupBox.Modern.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/GroupBox/GroupBox.Modern.cs
@@ -77,62 +77,62 @@ public partial class GroupBox
         switch (FlatStyle)
         {
             case FlatStyle.Standard:
-                {
-                    // Card: reserve the caption band plus its visual gap to the card. No internal
-                    // horizontal or bottom inset, so a docked child with Padding = 0 fills the card.
-                    int gap = ScaleModernMetric(ModernControlVisualStyles.GroupBoxCaptionGap);
+            {
+                // Card: reserve the caption band plus its visual gap to the card. No internal
+                // horizontal or bottom inset, so a docked child with Padding = 0 fills the card.
+                int gap = ScaleModernMetric(ModernControlVisualStyles.GroupBoxCaptionGap);
 
-                    return new Padding(
-                        left: Padding.Left,
-                        top: Padding.Top + captionHeight + gap,
-                        right: Padding.Right,
-                        bottom: Padding.Bottom);
-                }
+                return new Padding(
+                    left: Padding.Left,
+                    top: Padding.Top + captionHeight + gap,
+                    right: Padding.Right,
+                    bottom: Padding.Bottom);
+            }
 
             case FlatStyle.Flat:
-                {
-                    // Outline: the top border line runs along the caption baseline, so content clears
-                    // the descenders that hang below it (descent + 1px leeway). Left/right/bottom sit
-                    // just inside the border.
-                    (int ascent, int descent) = GetModernCaptionMetrics();
-                    int leeway = ScaleModernMetric(
-                        ModernControlVisualStyles.GroupBoxFlatBaselineLeeway);
-                    int borderInset = GetModernBorderThickness() + leeway;
+            {
+                // Outline: the top border line runs along the caption baseline, so content clears
+                // the descenders that hang below it (descent + 1px leeway). Left/right/bottom sit
+                // just inside the border.
+                (int ascent, int descent) = GetModernCaptionMetrics();
+                int leeway = ScaleModernMetric(
+                    ModernControlVisualStyles.GroupBoxFlatBaselineLeeway);
+                int borderInset = GetModernBorderThickness() + leeway;
 
-                    return new Padding(
-                        left: Padding.Left + borderInset,
-                        top: Padding.Top + ascent + descent + leeway,
-                        right: Padding.Right + borderInset,
-                        bottom: Padding.Bottom + borderInset);
-                }
+                return new Padding(
+                    left: Padding.Left + borderInset,
+                    top: Padding.Top + ascent + descent + leeway,
+                    right: Padding.Right + borderInset,
+                    bottom: Padding.Bottom + borderInset);
+            }
 
             case FlatStyle.Popup:
-                {
-                    // Accent header: content is flush to the bottom of the filled header rectangle
-                    // (0 top gap) with a 2px inset on the remaining sides.
-                    int verticalPadding = ScaleModernMetric(
-                        ModernControlVisualStyles.GroupBoxHeaderVerticalPadding);
-                    int headerHeight = captionHeight + (2 * verticalPadding);
-                    int inset = ScaleModernMetric(
-                        ModernControlVisualStyles.GroupBoxPopupContentInset);
+            {
+                // Accent header: content is flush to the bottom of the filled header rectangle
+                // (0 top gap) with a 2px inset on the remaining sides.
+                int verticalPadding = ScaleModernMetric(
+                    ModernControlVisualStyles.GroupBoxHeaderVerticalPadding);
+                int headerHeight = captionHeight + (2 * verticalPadding);
+                int inset = ScaleModernMetric(
+                    ModernControlVisualStyles.GroupBoxPopupContentInset);
 
-                    return new Padding(
-                        left: Padding.Left + inset,
-                        top: Padding.Top + headerHeight,
-                        right: Padding.Right + inset,
-                        bottom: Padding.Bottom + inset);
-                }
+                return new Padding(
+                    left: Padding.Left + inset,
+                    top: Padding.Top + headerHeight,
+                    right: Padding.Right + inset,
+                    bottom: Padding.Bottom + inset);
+            }
 
             default:
-                {
-                    int gap = ScaleModernMetric(ModernControlVisualStyles.GroupBoxCaptionGap);
+            {
+                int gap = ScaleModernMetric(ModernControlVisualStyles.GroupBoxCaptionGap);
 
-                    return new Padding(
-                        left: Padding.Left,
-                        top: Padding.Top + captionHeight + gap,
-                        right: Padding.Right,
-                        bottom: Padding.Bottom);
-                }
+                return new Padding(
+                    left: Padding.Left,
+                    top: Padding.Top + captionHeight + gap,
+                    right: Padding.Right,
+                    bottom: Padding.Bottom);
+            }
         }
     }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/GroupBox/GroupBox.Modern.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/GroupBox/GroupBox.Modern.cs
@@ -77,62 +77,62 @@ public partial class GroupBox
         switch (FlatStyle)
         {
             case FlatStyle.Standard:
-            {
-                // Card: reserve the caption band plus its visual gap to the card. No internal
-                // horizontal or bottom inset, so a docked child with Padding = 0 fills the card.
-                int gap = ScaleModernMetric(ModernControlVisualStyles.GroupBoxCaptionGap);
+                {
+                    // Card: reserve the caption band plus its visual gap to the card. No internal
+                    // horizontal or bottom inset, so a docked child with Padding = 0 fills the card.
+                    int gap = ScaleModernMetric(ModernControlVisualStyles.GroupBoxCaptionGap);
 
-                return new Padding(
-                    left: Padding.Left,
-                    top: Padding.Top + captionHeight + gap,
-                    right: Padding.Right,
-                    bottom: Padding.Bottom);
-            }
+                    return new Padding(
+                        left: Padding.Left,
+                        top: Padding.Top + captionHeight + gap,
+                        right: Padding.Right,
+                        bottom: Padding.Bottom);
+                }
 
             case FlatStyle.Flat:
-            {
-                // Outline: the top border line runs along the caption baseline, so content clears
-                // the descenders that hang below it (descent + 1px leeway). Left/right/bottom sit
-                // just inside the border.
-                (int ascent, int descent) = GetModernCaptionMetrics();
-                int leeway = ScaleModernMetric(
-                    ModernControlVisualStyles.GroupBoxFlatBaselineLeeway);
-                int borderInset = GetModernBorderThickness() + leeway;
+                {
+                    // Outline: the top border line runs along the caption baseline, so content clears
+                    // the descenders that hang below it (descent + 1px leeway). Left/right/bottom sit
+                    // just inside the border.
+                    (int ascent, int descent) = GetModernCaptionMetrics();
+                    int leeway = ScaleModernMetric(
+                        ModernControlVisualStyles.GroupBoxFlatBaselineLeeway);
+                    int borderInset = GetModernBorderThickness() + leeway;
 
-                return new Padding(
-                    left: Padding.Left + borderInset,
-                    top: Padding.Top + ascent + descent + leeway,
-                    right: Padding.Right + borderInset,
-                    bottom: Padding.Bottom + borderInset);
-            }
+                    return new Padding(
+                        left: Padding.Left + borderInset,
+                        top: Padding.Top + ascent + descent + leeway,
+                        right: Padding.Right + borderInset,
+                        bottom: Padding.Bottom + borderInset);
+                }
 
             case FlatStyle.Popup:
-            {
-                // Accent header: content is flush to the bottom of the filled header rectangle
-                // (0 top gap) with a 2px inset on the remaining sides.
-                int verticalPadding = ScaleModernMetric(
-                    ModernControlVisualStyles.GroupBoxHeaderVerticalPadding);
-                int headerHeight = captionHeight + (2 * verticalPadding);
-                int inset = ScaleModernMetric(
-                    ModernControlVisualStyles.GroupBoxPopupContentInset);
+                {
+                    // Accent header: content is flush to the bottom of the filled header rectangle
+                    // (0 top gap) with a 2px inset on the remaining sides.
+                    int verticalPadding = ScaleModernMetric(
+                        ModernControlVisualStyles.GroupBoxHeaderVerticalPadding);
+                    int headerHeight = captionHeight + (2 * verticalPadding);
+                    int inset = ScaleModernMetric(
+                        ModernControlVisualStyles.GroupBoxPopupContentInset);
 
-                return new Padding(
-                    left: Padding.Left + inset,
-                    top: Padding.Top + headerHeight,
-                    right: Padding.Right + inset,
-                    bottom: Padding.Bottom + inset);
-            }
+                    return new Padding(
+                        left: Padding.Left + inset,
+                        top: Padding.Top + headerHeight,
+                        right: Padding.Right + inset,
+                        bottom: Padding.Bottom + inset);
+                }
 
             default:
-            {
-                int gap = ScaleModernMetric(ModernControlVisualStyles.GroupBoxCaptionGap);
+                {
+                    int gap = ScaleModernMetric(ModernControlVisualStyles.GroupBoxCaptionGap);
 
-                return new Padding(
-                    left: Padding.Left,
-                    top: Padding.Top + captionHeight + gap,
-                    right: Padding.Right,
-                    bottom: Padding.Bottom);
-            }
+                    return new Padding(
+                        left: Padding.Left,
+                        top: Padding.Top + captionHeight + gap,
+                        right: Padding.Right,
+                        bottom: Padding.Bottom);
+                }
         }
     }
 
@@ -230,6 +230,15 @@ public partial class GroupBox
         // so it remains visible (issue #14779).
         PaintModernBackgroundImage(e, frameBounds);
 
+        if (BackgroundImage is not null)
+        {
+            Color bodyShadeColor = Color.FromArgb(
+                ModernControlVisualStyles.GroupBoxCardBodyShadeAlpha,
+                Color.Black);
+            using var bodyShadeBrush = bodyShadeColor.GetCachedSolidBrushScope();
+            e.Graphics.FillRectangle(bodyShadeBrush, frameBounds);
+        }
+
         DrawModernCaption(
             e.Graphics,
             captionBounds,
@@ -255,13 +264,16 @@ public partial class GroupBox
             return;
         }
 
+        using GraphicsStateScope state = new(e.Graphics);
+        e.Graphics.SetClip(clipBounds, CombineMode.Intersect);
+
         ControlPaint.DrawBackgroundImage(
             e.Graphics,
             BackgroundImage,
             Color.Transparent,
             BackgroundImageLayout,
             ClientRectangle,
-            clipBounds,
+            ClientRectangle,
             DisplayRectangle.Location,
             RightToLeft);
     }
@@ -293,6 +305,11 @@ public partial class GroupBox
             borderColor = PopupButtonColorMath.Mute(borderColor, 0.55f);
         }
 
+        if (BackgroundImage is not null)
+        {
+            PaintModernBackgroundImage(e, ClientRectangle);
+        }
+
         DrawRoundedFrame(e.Graphics, frameBounds, borderColor);
 
         Rectangle captionBackground = GetFlatCaptionBackgroundBounds(
@@ -301,7 +318,14 @@ public partial class GroupBox
             frameBounds);
         if (!captionBackground.IsEmpty)
         {
-            PaintBackground(e, captionBackground);
+            if (BackgroundImage is null)
+            {
+                PaintBackground(e, captionBackground);
+            }
+            else
+            {
+                PaintModernBackgroundImage(e, captionBackground);
+            }
         }
 
         DrawModernCaption(
@@ -343,6 +367,12 @@ public partial class GroupBox
             borderColor = PopupButtonColorMath.Mute(borderColor, 0.55f);
         }
 
+        Color headerFillColor = BackgroundImage is null
+            ? headerColor
+            : Color.FromArgb(
+                ModernControlVisualStyles.GroupBoxPopupHeaderOverlayAlpha,
+                headerColor);
+
         using GraphicsPath path = CreateModernFramePath(bounds);
         using (var bodyBrush = bodyColor.GetCachedSolidBrushScope())
         {
@@ -361,7 +391,7 @@ public partial class GroupBox
         using (GraphicsStateScope state = new(e.Graphics))
         {
             e.Graphics.SetClip(headerBounds);
-            using var headerBrush = headerColor.GetCachedSolidBrushScope();
+            using var headerBrush = headerFillColor.GetCachedSolidBrushScope();
             e.Graphics.FillPath(headerBrush, path);
         }
 
@@ -373,6 +403,7 @@ public partial class GroupBox
         // artifacts into the parent by tracing the parent color just outside the border.
         int frameRadius = GetModernFrameCornerRadius(bounds);
         ParentBackgroundRenderer.PaintRoundedBorderRegionMitigation(
+            this,
             e.Graphics,
             bounds,
             new Size(frameRadius, frameRadius),
@@ -477,6 +508,7 @@ public partial class GroupBox
         // artifacts into the parent by tracing the parent color just outside the border.
         int frameRadius = GetModernFrameCornerRadius(bounds);
         ParentBackgroundRenderer.PaintRoundedBorderRegionMitigation(
+            this,
             graphics,
             bounds,
             new Size(frameRadius, frameRadius),

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/GroupBox/GroupBox.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/GroupBox/GroupBox.cs
@@ -482,6 +482,21 @@ public partial class GroupBox : Control
         base.OnPaint(e); // raise paint event
     }
 
+    protected override void OnPaintBackground(PaintEventArgs pevent)
+    {
+        ArgumentNullException.ThrowIfNull(pevent);
+        if (!OwnerDraw
+            && EffectiveVisualStylesMode >= VisualStylesMode.Net11
+            && BackgroundImage is not null)
+        {
+            using var brush = BackColor.GetCachedSolidBrushScope();
+            pevent.Graphics.FillRectangle(brush, ClientRectangle);
+            return;
+        }
+
+        base.OnPaintBackground(pevent);
+    }
+
     private void DrawGroupBox(PaintEventArgs e)
     {
         // Offset from the left bound.

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TextBox/TextBoxBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TextBox/TextBoxBase.cs
@@ -2751,6 +2751,7 @@ public abstract partial class TextBoxBase : Control
                     // The rounded chrome is clipped with a non-antialiased region; blend the resulting
                     // corner artifacts into the parent by tracing the parent color just outside the border.
                     ParentBackgroundRenderer.PaintRoundedBorderRegionMitigation(
+                        this,
                         offscreenGraphics,
                         deflatedBounds,
                         new Size(cornerRadius, cornerRadius),

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/UpDown/UpDownBase.cs
@@ -1131,6 +1131,7 @@ public abstract partial class UpDownBase : ContainerControl
                     // The rounded chrome is clipped with a non-antialiased region; blend the resulting
                     // corner artifacts into the parent by tracing the parent color just outside the border.
                     ParentBackgroundRenderer.PaintRoundedBorderRegionMitigation(
+                        this,
                         graphics,
                         deflatedBounds,
                         new Size(cornerRadius, cornerRadius),

--- a/src/System.Windows.Forms/System/Windows/Forms/ParentBackgroundRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/ParentBackgroundRenderer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
@@ -50,15 +50,19 @@ internal static class ParentBackgroundRenderer
     ///  </para>
     /// </remarks>
     internal static void PaintRoundedBorderRegionMitigation(
+        Control control,
         Graphics graphics,
         Rectangle borderBounds,
         Size cornerRadius,
         int borderThickness,
         Color parentBackColor)
     {
+        ArgumentNullException.ThrowIfNull(control);
         ArgumentNullException.ThrowIfNull(graphics);
 
-        if (borderBounds.Width <= 0 || borderBounds.Height <= 0)
+        if (borderBounds.Width <= 0
+            || borderBounds.Height <= 0
+            || control.ParentInternal?.BackgroundImage is not null)
         {
             return;
         }

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/ModernControlVisualStyles.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/ModernControlVisualStyles.cs
@@ -32,6 +32,9 @@ internal static class ModernControlVisualStyles
     /// <summary>Scale factor applied to the GroupBox caption font in modern mode.</summary>
     internal const float GroupBoxCaptionFontScale = 1.15f;
 
+    /// <summary>Opacity of the Standard GroupBox body shade over a background image.</summary>
+    internal const int GroupBoxCardBodyShadeAlpha = 0x20;
+
     /// <summary>Gap between the GroupBox caption text and the surrounding frame line.</summary>
     internal const int GroupBoxCaptionGap = 4;
 
@@ -55,6 +58,9 @@ internal static class ModernControlVisualStyles
 
     /// <summary>Vertical padding around the GroupBox header text.</summary>
     internal const int GroupBoxHeaderVerticalPadding = 5;
+
+    /// <summary>Opacity of the Popup GroupBox accent header over a background image.</summary>
+    internal const int GroupBoxPopupHeaderOverlayAlpha = 0x80;
 
     /// <summary>Extra content inset for the modern Popup-style GroupBox, applied on top of the header height.</summary>
     internal const int GroupBoxPopupContentInset = 2;

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/GroupBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/GroupBoxTests.cs
@@ -152,55 +152,55 @@ public class GroupBoxTests
         switch (flatStyle)
         {
             case FlatStyle.Standard:
-            {
-                // Card reserves only the caption band plus its gap at the top; no internal
-                // horizontal or bottom inset, so a docked child can fill the card.
-                int top = captionFont.Height
-                    + ScaleHelper.ScaleToDpi(
-                        ModernControlVisualStyles.GroupBoxCaptionGap,
-                        deviceDpi);
-                expectedInsets = new Padding(
-                    padding.Left,
-                    padding.Top + top,
-                    padding.Right,
-                    padding.Bottom);
-                break;
-            }
+                {
+                    // Card reserves only the caption band plus its gap at the top; no internal
+                    // horizontal or bottom inset, so a docked child can fill the card.
+                    int top = captionFont.Height
+                        + ScaleHelper.ScaleToDpi(
+                            ModernControlVisualStyles.GroupBoxCaptionGap,
+                            deviceDpi);
+                    expectedInsets = new Padding(
+                        padding.Left,
+                        padding.Top + top,
+                        padding.Right,
+                        padding.Bottom);
+                    break;
+                }
 
             case FlatStyle.Flat:
-            {
-                // Content clears the descenders below the baseline border line, and sits just
-                // inside the border on the other sides.
-                (int ascent, int descent) = control.ModernCaptionMetrics;
-                int leeway = ScaleHelper.ScaleToDpi(
-                    ModernControlVisualStyles.GroupBoxFlatBaselineLeeway,
-                    deviceDpi);
-                int borderInset = control.ModernBorderThickness + leeway;
-                expectedInsets = new Padding(
-                    padding.Left + borderInset,
-                    padding.Top + ascent + descent + leeway,
-                    padding.Right + borderInset,
-                    padding.Bottom + borderInset);
-                break;
-            }
+                {
+                    // Content clears the descenders below the baseline border line, and sits just
+                    // inside the border on the other sides.
+                    (int ascent, int descent) = control.ModernCaptionMetrics;
+                    int leeway = ScaleHelper.ScaleToDpi(
+                        ModernControlVisualStyles.GroupBoxFlatBaselineLeeway,
+                        deviceDpi);
+                    int borderInset = control.ModernBorderThickness + leeway;
+                    expectedInsets = new Padding(
+                        padding.Left + borderInset,
+                        padding.Top + ascent + descent + leeway,
+                        padding.Right + borderInset,
+                        padding.Bottom + borderInset);
+                    break;
+                }
 
             case FlatStyle.Popup:
-            {
-                // Content is flush to the header rectangle (0 top gap) with a 2px inset elsewhere.
-                int headerHeight = captionFont.Height
-                    + (2 * ScaleHelper.ScaleToDpi(
-                        ModernControlVisualStyles.GroupBoxHeaderVerticalPadding,
-                        deviceDpi));
-                int inset = ScaleHelper.ScaleToDpi(
-                    ModernControlVisualStyles.GroupBoxPopupContentInset,
-                    deviceDpi);
-                expectedInsets = new Padding(
-                    padding.Left + inset,
-                    padding.Top + headerHeight,
-                    padding.Right + inset,
-                    padding.Bottom + inset);
-                break;
-            }
+                {
+                    // Content is flush to the header rectangle (0 top gap) with a 2px inset elsewhere.
+                    int headerHeight = captionFont.Height
+                        + (2 * ScaleHelper.ScaleToDpi(
+                            ModernControlVisualStyles.GroupBoxHeaderVerticalPadding,
+                            deviceDpi));
+                    int inset = ScaleHelper.ScaleToDpi(
+                        ModernControlVisualStyles.GroupBoxPopupContentInset,
+                        deviceDpi);
+                    expectedInsets = new Padding(
+                        padding.Left + inset,
+                        padding.Top + headerHeight,
+                        padding.Right + inset,
+                        padding.Bottom + inset);
+                    break;
+                }
 
             default:
                 throw new InvalidOperationException();
@@ -491,6 +491,140 @@ public class GroupBoxTests
                 Math.Min(
                     actual.Height - 1,
                     control.ModernBorderThickness + 2)).ToArgb());
+    }
+
+    [WinFormsFact]
+    public void GroupBox_ModernPopup_WithBackgroundImageBlendsAccentHeader()
+    {
+        using SystemVisualSettingsTestScope settingsScope = new(
+            clientAreaAnimationEnabled: false,
+            highContrastEnabled: false);
+        using Bitmap backgroundImage = CreateCoordinateBackgroundImage(
+            new Size(100, 70));
+        using VisualStylesGroupBox control = new()
+        {
+            BackColor = Color.White,
+            BackgroundImage = backgroundImage,
+            BackgroundImageLayout = ImageLayout.Stretch,
+            FlatStyle = FlatStyle.Popup,
+            Size = new Size(100, 70),
+            Text = string.Empty,
+            VisualStylesMode = VisualStylesMode.Net11
+        };
+        control.CreateControl();
+        using Bitmap actual = new(control.Width, control.Height);
+
+        control.DrawToBitmap(
+            actual,
+            new Rectangle(Point.Empty, control.Size));
+
+        int x = actual.Width / 2;
+        int headerY = Math.Min(
+            actual.Height - 1,
+            control.ModernBorderThickness + 2);
+        Color expectedHeaderPixel = PopupButtonColorMath.Composite(
+            Color.FromArgb(
+                ModernControlVisualStyles.GroupBoxPopupHeaderOverlayAlpha,
+                Application.SystemVisualSettings.AccentColor),
+            backgroundImage.GetPixel(x, headerY));
+        Assert.Equal(
+            expectedHeaderPixel.ToArgb(),
+            actual.GetPixel(x, headerY).ToArgb());
+    }
+
+    [WinFormsTheory]
+    [InlineData(FlatStyle.Standard)]
+    [InlineData(FlatStyle.Flat)]
+    [InlineData(FlatStyle.Popup)]
+    public void GroupBox_ModernVisualStyles_OnPaintPaintsBackgroundImageAcrossBody(
+        FlatStyle flatStyle)
+    {
+        using SystemVisualSettingsTestScope settingsScope = new(
+            clientAreaAnimationEnabled: false,
+            highContrastEnabled: false);
+        using Bitmap backgroundImage = CreateCoordinateBackgroundImage(
+            new Size(100, 70));
+        using VisualStylesGroupBox control = new()
+        {
+            BackColor = Color.White,
+            BackgroundImage = backgroundImage,
+            BackgroundImageLayout = ImageLayout.Stretch,
+            FlatStyle = flatStyle,
+            Size = new Size(100, 70),
+            Text = "Modern group",
+            VisualStylesMode = VisualStylesMode.Net11
+        };
+        control.CreateControl();
+        using Bitmap actual = new(control.Width, control.Height);
+        using Graphics graphics = Graphics.FromImage(actual);
+        using PaintEventArgs paintEventArgs = new(graphics, control.ClientRectangle);
+
+        control.OnPaint(paintEventArgs);
+
+        Point sample = new(actual.Width / 2, actual.Height / 2);
+        Color expected = backgroundImage.GetPixel(sample.X, sample.Y);
+        if (flatStyle == FlatStyle.Standard)
+        {
+            expected = PopupButtonColorMath.Composite(
+                Color.FromArgb(
+                    ModernControlVisualStyles.GroupBoxCardBodyShadeAlpha,
+                    Color.Black),
+                expected);
+        }
+
+        Assert.Equal(
+            expected.ToArgb(),
+            actual.GetPixel(sample.X, sample.Y).ToArgb());
+    }
+
+    [WinFormsFact]
+    public void GroupBox_ModernSystem_OnPaintBackgroundDoesNotPaintBackgroundImage()
+    {
+        using SystemVisualSettingsTestScope settingsScope = new(
+            clientAreaAnimationEnabled: false,
+            highContrastEnabled: false);
+        using Bitmap backgroundImage = new(1, 1);
+        backgroundImage.SetPixel(0, 0, Color.Lime);
+        using SubGroupBox control = new()
+        {
+            BackColor = Color.White,
+            BackgroundImage = backgroundImage,
+            BackgroundImageLayout = ImageLayout.Tile,
+            FlatStyle = FlatStyle.System,
+            Size = new Size(100, 70),
+            VisualStylesMode = VisualStylesMode.Net11
+        };
+        control.CreateControl();
+        using Bitmap actual = new(control.Width, control.Height);
+        using Graphics graphics = Graphics.FromImage(actual);
+        using PaintEventArgs paintEventArgs = new(graphics, control.ClientRectangle);
+
+        control.OnPaintBackground(paintEventArgs);
+
+        Assert.Equal(
+            Color.White.ToArgb(),
+            actual.GetPixel(actual.Width / 2, actual.Height / 2).ToArgb());
+    }
+
+    private static Bitmap CreateCoordinateBackgroundImage(Size size)
+    {
+        Bitmap bitmap = new(size.Width, size.Height);
+        for (int y = 0; y < size.Height; y++)
+        {
+            for (int x = 0; x < size.Width; x++)
+            {
+                bitmap.SetPixel(
+                    x,
+                    y,
+                    Color.FromArgb(
+                        255,
+                        x * 255 / size.Width,
+                        y * 255 / size.Height,
+                        (x + y) * 255 / (size.Width + size.Height)));
+            }
+        }
+
+        return bitmap;
     }
 
     [WinFormsFact]
@@ -3101,7 +3235,7 @@ public class GroupBoxTests
 
         public void RaiseSystemVisualSettingsChanged(
             SystemVisualSettingsChangedEventArgs e)
-            => base.OnSystemVisualSettingsChanged(e);
+            => OnSystemVisualSettingsChanged(e);
 
         internal override bool IsHighContrast => false;
     }
@@ -3219,6 +3353,8 @@ public class GroupBoxTests
         public new void OnMouseUp(MouseEventArgs e) => base.OnMouseUp(e);
 
         public new void OnPaint(PaintEventArgs e) => base.OnPaint(e);
+
+        public new void OnPaintBackground(PaintEventArgs e) => base.OnPaintBackground(e);
 
         public new bool ProcessMnemonic(char charCode) => base.ProcessMnemonic(charCode);
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/GroupBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/GroupBoxTests.cs
@@ -576,6 +576,56 @@ public class GroupBoxTests
             actual.GetPixel(sample.X, sample.Y).ToArgb());
     }
 
+    [WinFormsTheory]
+    [InlineData(FlatStyle.Standard)]
+    [InlineData(FlatStyle.Flat)]
+    [InlineData(FlatStyle.Popup)]
+    public void GroupBox_ModernVisualStyles_TiledBackgroundImageUsesClientOrigin(
+       FlatStyle flatStyle)
+    {
+        using SystemVisualSettingsTestScope settingsScope = new(
+            clientAreaAnimationEnabled: false,
+            highContrastEnabled: false);
+        using Bitmap backgroundImage = new(2, 2);
+        backgroundImage.SetPixel(0, 0, Color.Red);
+        backgroundImage.SetPixel(1, 0, Color.Green);
+        backgroundImage.SetPixel(0, 1, Color.Blue);
+        backgroundImage.SetPixel(1, 1, Color.Yellow);
+        using VisualStylesGroupBox control = new()
+        {
+            BackColor = Color.White,
+            BackgroundImage = backgroundImage,
+            BackgroundImageLayout = ImageLayout.Tile,
+            FlatStyle = flatStyle,
+            Size = new Size(100, 70),
+            Text = "Modern group",
+            VisualStylesMode = VisualStylesMode.Net11
+        };
+        control.CreateControl();
+        using Bitmap actual = new(control.Width, control.Height);
+        using Graphics graphics = Graphics.FromImage(actual);
+        using PaintEventArgs paintEventArgs = new(graphics, control.ClientRectangle);
+
+        control.OnPaint(paintEventArgs);
+
+        Point sample = new(actual.Width / 2, actual.Height / 2);
+        Color expected = backgroundImage.GetPixel(
+            sample.X % backgroundImage.Width,
+            sample.Y % backgroundImage.Height);
+        if (flatStyle == FlatStyle.Standard)
+        {
+            expected = PopupButtonColorMath.Composite(
+                Color.FromArgb(
+                    ModernControlVisualStyles.GroupBoxCardBodyShadeAlpha,
+                    Color.Black),
+                expected);
+        }
+
+        Assert.Equal(
+            expected.ToArgb(),
+            actual.GetPixel(sample.X, sample.Y).ToArgb());
+    }
+
     [WinFormsFact]
     public void GroupBox_ModernSystem_OnPaintBackgroundDoesNotPaintBackgroundImage()
     {

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/GroupBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/GroupBoxTests.cs
@@ -152,55 +152,55 @@ public class GroupBoxTests
         switch (flatStyle)
         {
             case FlatStyle.Standard:
-                {
-                    // Card reserves only the caption band plus its gap at the top; no internal
-                    // horizontal or bottom inset, so a docked child can fill the card.
-                    int top = captionFont.Height
-                        + ScaleHelper.ScaleToDpi(
-                            ModernControlVisualStyles.GroupBoxCaptionGap,
-                            deviceDpi);
-                    expectedInsets = new Padding(
-                        padding.Left,
-                        padding.Top + top,
-                        padding.Right,
-                        padding.Bottom);
-                    break;
-                }
+            {
+                // Card reserves only the caption band plus its gap at the top; no internal
+                // horizontal or bottom inset, so a docked child can fill the card.
+                int top = captionFont.Height
+                    + ScaleHelper.ScaleToDpi(
+                        ModernControlVisualStyles.GroupBoxCaptionGap,
+                        deviceDpi);
+                expectedInsets = new Padding(
+                    padding.Left,
+                    padding.Top + top,
+                    padding.Right,
+                    padding.Bottom);
+                break;
+            }
 
             case FlatStyle.Flat:
-                {
-                    // Content clears the descenders below the baseline border line, and sits just
-                    // inside the border on the other sides.
-                    (int ascent, int descent) = control.ModernCaptionMetrics;
-                    int leeway = ScaleHelper.ScaleToDpi(
-                        ModernControlVisualStyles.GroupBoxFlatBaselineLeeway,
-                        deviceDpi);
-                    int borderInset = control.ModernBorderThickness + leeway;
-                    expectedInsets = new Padding(
-                        padding.Left + borderInset,
-                        padding.Top + ascent + descent + leeway,
-                        padding.Right + borderInset,
-                        padding.Bottom + borderInset);
-                    break;
-                }
+            {
+                // Content clears the descenders below the baseline border line, and sits just
+                // inside the border on the other sides.
+                (int ascent, int descent) = control.ModernCaptionMetrics;
+                int leeway = ScaleHelper.ScaleToDpi(
+                    ModernControlVisualStyles.GroupBoxFlatBaselineLeeway,
+                    deviceDpi);
+                int borderInset = control.ModernBorderThickness + leeway;
+                expectedInsets = new Padding(
+                    padding.Left + borderInset,
+                    padding.Top + ascent + descent + leeway,
+                    padding.Right + borderInset,
+                    padding.Bottom + borderInset);
+                break;
+            }
 
             case FlatStyle.Popup:
-                {
-                    // Content is flush to the header rectangle (0 top gap) with a 2px inset elsewhere.
-                    int headerHeight = captionFont.Height
-                        + (2 * ScaleHelper.ScaleToDpi(
-                            ModernControlVisualStyles.GroupBoxHeaderVerticalPadding,
-                            deviceDpi));
-                    int inset = ScaleHelper.ScaleToDpi(
-                        ModernControlVisualStyles.GroupBoxPopupContentInset,
-                        deviceDpi);
-                    expectedInsets = new Padding(
-                        padding.Left + inset,
-                        padding.Top + headerHeight,
-                        padding.Right + inset,
-                        padding.Bottom + inset);
-                    break;
-                }
+            {
+                // Content is flush to the header rectangle (0 top gap) with a 2px inset elsewhere.
+                int headerHeight = captionFont.Height
+                    + (2 * ScaleHelper.ScaleToDpi(
+                        ModernControlVisualStyles.GroupBoxHeaderVerticalPadding,
+                        deviceDpi));
+                int inset = ScaleHelper.ScaleToDpi(
+                    ModernControlVisualStyles.GroupBoxPopupContentInset,
+                    deviceDpi);
+                expectedInsets = new Padding(
+                    padding.Left + inset,
+                    padding.Top + headerHeight,
+                    padding.Right + inset,
+                    padding.Bottom + inset);
+                break;
+            }
 
             default:
                 throw new InvalidOperationException();

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ParentBackgroundRendererTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ParentBackgroundRendererTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
@@ -93,6 +93,39 @@ public class ParentBackgroundRendererTests
 
         Assert.NotEqual(Color.Lime.ToArgb(), bitmap.GetPixel(2, 2).ToArgb());
         Assert.Equal(Color.White.ToArgb(), bitmap.GetPixel(20, 15).ToArgb());
+    }
+
+    [WinFormsFact]
+    public void PaintRoundedBorderRegionMitigation_WithParentBackgroundImage_DoesNotPaintSolidColor()
+    {
+        using Bitmap backgroundImage = new(1, 1);
+        backgroundImage.SetPixel(0, 0, Color.Blue);
+        using Panel parent = new()
+        {
+            BackgroundImage = backgroundImage,
+            Size = new Size(40, 30)
+        };
+        using Control child = new() { Size = parent.Size };
+        parent.Controls.Add(child);
+        using Bitmap bitmap = new(child.Width, child.Height);
+        using Graphics graphics = Graphics.FromImage(bitmap);
+        graphics.Clear(Color.Lime);
+
+        ParentBackgroundRenderer.PaintRoundedBorderRegionMitigation(
+            child,
+            graphics,
+            new Rectangle(2, 2, 35, 25),
+            new Size(8, 8),
+            borderThickness: 1,
+            Color.Magenta);
+
+        for (int y = 0; y < bitmap.Height; y++)
+        {
+            for (int x = 0; x < bitmap.Width; x++)
+            {
+                Assert.Equal(Color.Lime.ToArgb(), bitmap.GetPixel(x, y).ToArgb());
+            }
+        }
     }
 
     private sealed class PatternControl : Control


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14779

## Root Cause

Modern GroupBox renderers painted opaque surfaces over `BackgroundImage`. Additionally:
- Clipped regions recalculated image layout, making Header and Body appear as separate images.
- Flat style only repainted the caption background.
- Popup used an opaque accent Header.
- System style exposed its background image when child controls requested the parent background.
- Rounded child controls painted a solid `Parent.BackColor` mitigation outline, causing white halos over image backgrounds.

## Proposed changes

- Render Standard, Flat, and Popup background images using one shared client-coordinate image.
- Use graphics clipping without recalculating image layout.
- Apply a subtle dark shade to the Standard Body to preserve Header/Body separation.
- Blend the Popup Header with the system accent color at 50% opacity.
- Prevent System GroupBox images from leaking into child-control backgrounds.
- Skip solid rounded-border mitigation when the parent has a background image.
- Add pixel-based regression tests for image continuity, overlays, System behavior, and rounded-control edges.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Applications using `VisualStylesMode.Net11` receive consistent GroupBox background rendering across supported FlatStyle values. Existing behavior without background images remains unchanged, while image-backed layouts gain correct continuity, styling, and child-control edge rendering.

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

- Flat and standard style headings may redisplay the background image.
- Pop-up headings completely obscure the image.
- Standard headings and body text become visually indistinguishable.
- System child controls may display GroupBox images at their edges.
- Rounded corner child controls may display a white halo.

<img width="872" height="545" alt="image" src="https://github.com/user-attachments/assets/2122b98f-7fb8-43e1-a0f6-42739e682d47" />


### After

- Standard, Flat, and Popup display one continuous background image.
- Standard retains subtle Header/Body separation.
- Popup shows the image through an accent-colored Header.
- System continues to display no background image.
- Child controls blend cleanly with image-backed GroupBoxes without white outlines

<img width="872" height="548" alt="image" src="https://github.com/user-attachments/assets/e5532175-5cce-40af-be7a-840ee4cd95f5" />


## Test methodology <!-- How did you ensure quality? -->

- Unit test and manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-rc.1.26411.119


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14910)