### PR TITLE
Fix issue 14778: Controls inside GroupBox no longer reflect inherited ForeColor/BackColor updates in VisualStylesMode.Net11

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/CheckBoxModernAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/CheckBoxModernAdapter.cs
@@ -112,7 +112,7 @@ internal sealed class CheckBoxModernAdapter : CheckBoxBaseAdapter
 
         PaintImage(e, layout);
 
-        Color preferredTextColor = Control.ForeColor != Forms.Control.DefaultForeColor
+        Color preferredTextColor = Control.ShouldSerializeForeColor() || Control.ForeColor != Forms.Control.DefaultForeColor
             ? Control.ForeColor
             : Application.IsDarkModeEnabled
                 ? Color.FromArgb(0xF0, 0xF0, 0xF0)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/CheckBoxModernAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/CheckBoxModernAdapter.cs
@@ -127,7 +127,7 @@ internal sealed class CheckBoxModernAdapter : CheckBoxBaseAdapter
         Color preferredTextColor = Control.ShouldSerializeForeColor() || Control.ForeColor != Forms.Control.DefaultForeColor
             ? Control.ForeColor
             : Application.IsDarkModeEnabled
-                ? Color.FromArgb(0xF0, 0xF0, 0xF0)
+                ? DarkModeButtonColors.DefaultColors.AcceptButtonTextColor // Use the default accept button text color in dark mode for checkboxes.
                 : SystemColors.WindowText;
         Color disabledTextBackColor = Control.ShouldSerializeBackColor()
             && Control.BackColor.A == byte.MaxValue

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/CheckBoxModernAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/CheckBoxModernAdapter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
@@ -112,7 +112,7 @@ internal sealed class CheckBoxModernAdapter : CheckBoxBaseAdapter
 
         PaintImage(e, layout);
 
-        Color preferredTextColor = Control.ShouldSerializeForeColor()
+        Color preferredTextColor = Control.ForeColor != Forms.Control.DefaultForeColor
             ? Control.ForeColor
             : Application.IsDarkModeEnabled
                 ? Color.FromArgb(0xF0, 0xF0, 0xF0)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/ButtonDarkModeAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/ButtonDarkModeAdapter.cs
@@ -54,7 +54,9 @@ internal class ButtonDarkModeAdapter : ButtonBaseAdapter
                 backColor);
         }
 
-        bool useEffectiveForeColor = Control.ForeColor != Forms.Control.DefaultForeColor;
+        bool useEffectiveForeColor = _modern
+             ? Control.ShouldSerializeForeColor() || Control.ForeColor != Forms.Control.DefaultForeColor
+             : Control.ForeColor != Forms.Control.DefaultForeColor;
 
         if (useEffectiveForeColor)
         {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/ButtonDarkModeAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/ButtonDarkModeAdapter.cs
@@ -54,9 +54,7 @@ internal class ButtonDarkModeAdapter : ButtonBaseAdapter
                 backColor);
         }
 
-        bool useEffectiveForeColor = _modern
-            ? Control.ShouldSerializeForeColor()
-            : Control.ForeColor != Forms.Control.DefaultForeColor;
+        bool useEffectiveForeColor = Control.ForeColor != Forms.Control.DefaultForeColor;
 
         if (useEffectiveForeColor)
         {
@@ -85,7 +83,11 @@ internal class ButtonDarkModeAdapter : ButtonBaseAdapter
     {
         Color backColor;
 
-        if (Control.BackColor != Forms.Control.DefaultBackColor)
+        bool hasCustomBackColor = _modern
+            ? Control.ShouldSerializeBackColor()
+            : Control.BackColor != Forms.Control.DefaultBackColor;
+
+        if (hasCustomBackColor)
         {
             backColor = ButtonDarkModeRenderer.GetBackgroundColor(
                 state,

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/ButtonDarkModeAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/DarkMode/ButtonDarkModeAdapter.cs
@@ -55,8 +55,8 @@ internal class ButtonDarkModeAdapter : ButtonBaseAdapter
         }
 
         bool useEffectiveForeColor = _modern
-             ? Control.ShouldSerializeForeColor() || Control.ForeColor != Forms.Control.DefaultForeColor
-             : Control.ForeColor != Forms.Control.DefaultForeColor;
+            ? Control.ShouldSerializeForeColor() || Control.ForeColor != Forms.Control.DefaultForeColor
+            : Control.ForeColor != Forms.Control.DefaultForeColor;
 
         if (useEffectiveForeColor)
         {
@@ -95,11 +95,11 @@ internal class ButtonDarkModeAdapter : ButtonBaseAdapter
         }
         else
         {
-            bool hasExplicitBackColor = Control.ShouldSerializeBackColor();
-            bool hasUsableAmbientBackColor = !Control.BackColor.HasTransparency()
-                && Control.BackColor != Forms.Control.DefaultBackColor;
+            bool hasCustomBackColor = _modern
+                ? Control.ShouldSerializeBackColor()
+                : Control.BackColor != Forms.Control.DefaultBackColor;
 
-            if (hasExplicitBackColor || hasUsableAmbientBackColor)
+            if (hasCustomBackColor)
             {
                 backColor = ButtonDarkModeRenderer.GetBackgroundColor(
                     state,

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/RadioButtonModernAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/RadioButtonModernAdapter.cs
@@ -127,7 +127,7 @@ internal sealed class RadioButtonModernAdapter : RadioButtonBaseAdapter
         Color preferredTextColor = Control.ShouldSerializeForeColor() || Control.ForeColor != Forms.Control.DefaultForeColor
             ? Control.ForeColor
             : Application.IsDarkModeEnabled
-                ? Color.FromArgb(0xF0, 0xF0, 0xF0)
+                ? DarkModeButtonColors.DefaultColors.AcceptButtonTextColor // Use the default accept button text color in dark mode for radio buttons.
                 : SystemColors.WindowText;
         Color disabledTextBackColor = Control.ShouldSerializeBackColor()
             && Control.BackColor.A == byte.MaxValue

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/RadioButtonModernAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/RadioButtonModernAdapter.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
@@ -111,7 +111,7 @@ internal sealed class RadioButtonModernAdapter : RadioButtonBaseAdapter
 
         PaintImage(e, layout);
 
-        Color preferredTextColor = Control.ShouldSerializeForeColor()
+        Color preferredTextColor = Control.ForeColor != Forms.Control.DefaultForeColor
             ? Control.ForeColor
             : Application.IsDarkModeEnabled
                 ? Color.FromArgb(0xF0, 0xF0, 0xF0)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/RadioButtonModernAdapter.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/Buttons/ButtonInternal/RadioButtonModernAdapter.cs
@@ -111,7 +111,7 @@ internal sealed class RadioButtonModernAdapter : RadioButtonBaseAdapter
 
         PaintImage(e, layout);
 
-        Color preferredTextColor = Control.ForeColor != Forms.Control.DefaultForeColor
+        Color preferredTextColor = Control.ShouldSerializeForeColor() || Control.ForeColor != Forms.Control.DefaultForeColor
             ? Control.ForeColor
             : Application.IsDarkModeEnabled
                 ? Color.FromArgb(0xF0, 0xF0, 0xF0)

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/Button/AnimatedPopupButtonRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/Button/AnimatedPopupButtonRenderer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
@@ -138,7 +138,8 @@ internal sealed class AnimatedPopupButtonRenderer : AnimatedControlRenderer
 
             faceColor = PopupButtonColorMath.Blend(baseColor, hoverColor, _hoverCurrent);
             faceColor = PopupButtonColorMath.Blend(faceColor, pressedColor, _pressCurrent);
-            bool useAutomaticForeColor = button.ForeColor == Forms.Control.DefaultForeColor;
+            bool useAutomaticForeColor = button.ForeColor == Forms.Control.DefaultForeColor
+                 && !button.ShouldSerializeForeColor();
             foreColor = !useAutomaticForeColor
                 ? button.ForeColor
                 : _baseColorRenderer.GetTextColor(state, button.IsDefault, faceColor);

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/Button/AnimatedPopupButtonRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/Button/AnimatedPopupButtonRenderer.cs
@@ -138,9 +138,7 @@ internal sealed class AnimatedPopupButtonRenderer : AnimatedControlRenderer
 
             faceColor = PopupButtonColorMath.Blend(baseColor, hoverColor, _hoverCurrent);
             faceColor = PopupButtonColorMath.Blend(faceColor, pressedColor, _pressCurrent);
-            bool useAutomaticForeColor = button.EffectiveVisualStylesModeInternal >= VisualStylesMode.Net11
-                ? !button.ShouldSerializeForeColor()
-                : button.ForeColor == Forms.Control.DefaultForeColor;
+            bool useAutomaticForeColor = button.ForeColor == Forms.Control.DefaultForeColor;
             foreColor = !useAutomaticForeColor
                 ? button.ForeColor
                 : _baseColorRenderer.GetTextColor(state, button.IsDefault, faceColor);
@@ -157,9 +155,7 @@ internal sealed class AnimatedPopupButtonRenderer : AnimatedControlRenderer
             BackColor = faceColor,
             ForeColor = foreColor,
             SurfaceColor = button.Parent?.BackColor ?? button.BackColor,
-            UseAutomaticForeColor = button.EffectiveVisualStylesModeInternal >= VisualStylesMode.Net11
-                ? !button.ShouldSerializeForeColor()
-                : button.ForeColor == Forms.Control.DefaultForeColor,
+            UseAutomaticForeColor = button.ForeColor == Forms.Control.DefaultForeColor,
             BorderColor = borderColor,
             BorderWidth = flatAppearance.BorderSize,
             Enabled = button.Enabled,
@@ -238,7 +234,9 @@ internal sealed class AnimatedPopupButtonRenderer : AnimatedControlRenderer
         _baseColorRenderer.DeviceDpi = button.DeviceDpi;
         _baseColorRenderer.FlatAppearance = flatAppearance;
 
-        bool hasCustomBackColor = button.BackColor != Forms.Control.DefaultBackColor;
+        bool hasCustomBackColor = button.EffectiveVisualStylesModeInternal >= VisualStylesMode.Net11
+            ? button.ShouldSerializeBackColor()
+            : button.BackColor != Forms.Control.DefaultBackColor;
         Color baseColor = hasCustomBackColor
             ? button.BackColor
             : _baseColorRenderer.GetBackgroundColor(PushButtonState.Normal, isDefault: false);

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/Button/AnimatedPopupButtonRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/Button/AnimatedPopupButtonRenderer.cs
@@ -9,7 +9,7 @@ using PushButtonState = System.Windows.Forms.VisualStyles.PushButtonState;
 namespace System.Windows.Forms.Rendering.Button;
 
 /// <summary>
-///  Drives and renders a <see cref="Forms.ButtonBase"/> whose <see cref="Forms.ButtonBase.FlatStyle"/> is
+///  Drives and renders a <see cref="ButtonBase"/> whose <see cref="ButtonBase.FlatStyle"/> is
 ///  <see cref="FlatStyle.Popup"/> when modern visual styles or dark mode are active, using the concave key-cap
 ///  look of <see cref="PopupButtonKeyCapRenderer"/>.
 /// </summary>
@@ -119,6 +119,7 @@ internal sealed class AnimatedPopupButtonRenderer : AnimatedControlRenderer
         Color faceColor;
         Color foreColor;
         Color borderColor;
+        bool useAutomaticForeColor = false;
 
         if (highContrast)
         {
@@ -138,8 +139,8 @@ internal sealed class AnimatedPopupButtonRenderer : AnimatedControlRenderer
 
             faceColor = PopupButtonColorMath.Blend(baseColor, hoverColor, _hoverCurrent);
             faceColor = PopupButtonColorMath.Blend(faceColor, pressedColor, _pressCurrent);
-            bool useAutomaticForeColor = button.ForeColor == Forms.Control.DefaultForeColor
-                 && !button.ShouldSerializeForeColor();
+            useAutomaticForeColor = button.ForeColor == Control.DefaultForeColor
+                && !button.ShouldSerializeForeColor();
             foreColor = !useAutomaticForeColor
                 ? button.ForeColor
                 : _baseColorRenderer.GetTextColor(state, button.IsDefault, faceColor);
@@ -156,7 +157,7 @@ internal sealed class AnimatedPopupButtonRenderer : AnimatedControlRenderer
             BackColor = faceColor,
             ForeColor = foreColor,
             SurfaceColor = button.Parent?.BackColor ?? button.BackColor,
-            UseAutomaticForeColor = button.ForeColor == Forms.Control.DefaultForeColor,
+            UseAutomaticForeColor = useAutomaticForeColor,
             BorderColor = borderColor,
             BorderWidth = flatAppearance.BorderSize,
             Enabled = button.Enabled,
@@ -230,14 +231,14 @@ internal sealed class AnimatedPopupButtonRenderer : AnimatedControlRenderer
 
     internal (Color BaseColor, Color HoverColor, Color PressedColor) GetStateColors()
     {
-        Forms.ButtonBase button = Button;
+        ButtonBase button = Button;
         FlatButtonAppearance flatAppearance = button.FlatAppearance;
         _baseColorRenderer.DeviceDpi = button.DeviceDpi;
         _baseColorRenderer.FlatAppearance = flatAppearance;
 
         bool hasCustomBackColor = button.EffectiveVisualStylesModeInternal >= VisualStylesMode.Net11
             ? button.ShouldSerializeBackColor()
-            : button.BackColor != Forms.Control.DefaultBackColor;
+            : button.BackColor != Control.DefaultBackColor;
         Color baseColor = hasCustomBackColor
             ? button.BackColor
             : _baseColorRenderer.GetBackgroundColor(PushButtonState.Normal, isDefault: false);

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ButtonVisualStylesTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ButtonVisualStylesTests.cs
@@ -658,6 +658,32 @@ public class ButtonVisualStylesTests
         Assert.True(animator.IsRunning);
     }
 
+    [WinFormsFact]
+    public void ButtonDarkModeAdapter_InheritedBackColor_UsesThemeStateColorInNet11()
+    {
+        using Panel parent = new() { BackColor = Color.Red };
+        using Button button = new()
+        {
+            FlatStyle = FlatStyle.Standard,
+            VisualStylesMode = VisualStylesMode.Net11
+        };
+        parent.Controls.Add(button);
+        ButtonInternal.ButtonDarkModeAdapter adapter = new(button);
+        dynamic accessor = adapter.TestAccessor.Dynamic;
+        ModernButtonDarkModeRenderer neutralRenderer = new()
+        {
+            DeviceDpi = button.DeviceDpi,
+            FlatAppearance = button.FlatAppearance
+        };
+
+        Color actual = (Color)accessor.GetButtonBackColor(VisualStyles.PushButtonState.Normal);
+
+        Assert.Equal(
+            neutralRenderer.GetBackgroundColor(VisualStyles.PushButtonState.Normal, isDefault: false),
+            actual);
+        Assert.False(button.ShouldSerializeBackColor());
+    }
+
     public static TheoryData<Type, FlatStyle, ContentAlignment, TextImageRelation> ModernImageLayoutData
     {
         get
@@ -1120,7 +1146,7 @@ public class ButtonVisualStylesTests
     }
 
     [WinFormsFact]
-    public void ButtonDarkModeAdapter_InheritedForeColor_UsesAutomaticContrast()
+    public void ButtonDarkModeAdapter_InheritedForeColor_IsPreservedInNet11()
     {
         using Panel parent = new() { ForeColor = Color.Red };
         using Button button = new()
@@ -1139,7 +1165,7 @@ public class ButtonVisualStylesTests
             VisualStyles.PushButtonState.Normal,
             Color.White);
 
-        Assert.Equal(Color.Black, actual);
+        Assert.Equal(Color.Red, actual);
         Assert.False(button.ShouldSerializeForeColor());
     }
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/PopupButtonVisualStylesTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/PopupButtonVisualStylesTests.cs
@@ -204,6 +204,37 @@ public class PopupButtonVisualStylesTests
     }
 
     [WinFormsFact]
+    public void AnimatedPopupButtonRenderer_InheritedBackColor_UsesThemeStateColorsInNet11()
+    {
+        using Panel parent = new() { BackColor = Color.Red };
+        using Button button = new()
+        {
+            FlatStyle = FlatStyle.Popup,
+            VisualStylesMode = VisualStylesMode.Net11
+        };
+        parent.Controls.Add(button);
+        using AnimatedPopupButtonRenderer renderer = new(button);
+        ModernButtonDarkModeRenderer neutralRenderer = new()
+        {
+            DeviceDpi = button.DeviceDpi,
+            FlatAppearance = button.FlatAppearance
+        };
+
+        (Color baseColor, Color hoverColor, Color pressedColor) = renderer.GetStateColors();
+
+        Assert.Equal(
+            neutralRenderer.GetBackgroundColor(VisualStyles.PushButtonState.Normal, isDefault: false),
+            baseColor);
+        Assert.Equal(
+            neutralRenderer.GetBackgroundColor(VisualStyles.PushButtonState.Hot, isDefault: false),
+            hoverColor);
+        Assert.Equal(
+            neutralRenderer.GetBackgroundColor(VisualStyles.PushButtonState.Pressed, isDefault: false),
+            pressedColor);
+        Assert.False(button.ShouldSerializeBackColor());
+    }
+
+    [WinFormsFact]
     public void PopupButtonKeyCapRenderer_FocusedDefault_RendersWithoutThrow()
     {
         PopupButtonRenderContext context = CreateContext(


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14778 

## Root Cause

In the VisualStylesMode.Net11 modern rendering path, button-family controls (Button, CheckBox, RadioButton) relied too heavily on ShouldSerializeForeColor/BackColor to decide whether to use automatic colors.
This caused inherited colors from parent containers to be misclassified as either “not set” (fallback to automatic theme colors) or “custom colors,” which led to:

- ForeColor inheritance being overridden unexpectedly (child controls not following GroupBox foreground updates)

- BackColor inheritance being treated as explicit customization (child controls unexpectedly following GroupBox background updates)

## Proposed changes

1. Fix ForeColor decision logic. in Net11 rendering paths, determine automatic text color usage based on whether the effective ForeColor is still default, instead of relying only on ShouldSerializeForeColor(). This preserves inherited non-default foreground colors.
2. Fix BackColor customization detection. in Net11 rendering paths, treat BackColor as custom only when it is explicitly set (ShouldSerializeBackColor() semantics), so inherited background colors are no longer treated as explicit overrides.
3. Align logic across relevant renderers/adapters. Applied consistently in ButtonDarkModeAdapter, AnimatedPopupButtonRenderer, CheckBoxModernAdapter, and RadioButtonModernAdapter to avoid behavior drift across control paths.
4. Add/update regression tests. Added and updated Net11 tests for inherited foreground/background behavior to lock expected behavior and prevent regressions.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- More consistent behavior: Color inheritance for controls inside GroupBox under Net11 now better matches user expectations and Classic behavior.
- Lower migration risk: Apps moving to Net11 modern styles are less likely to see visual regressions like “text color not following container” or “background unexpectedly following container.”
- No API-breaking change: The fix is internal to rendering decision logic and tests; public API and usage remain unchanged.

## Regression? 

- No

## Risk

- Mini

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

**Issue#1:** 
When a GroupBox ForeColor is changed at design time, child controls such as Button and CheckBox do not update their text color accordingly with VisualStylesMode.Net11 mode.
<img width="322" height="237" alt="Image" src="https://github.com/user-attachments/assets/627743db-dfd9-42b1-8797-f151efbb10c7" />
Behavior differs from VisualStylesMode.Classic.

<img width="317" height="193" alt="Image" src="https://github.com/user-attachments/assets/9e107fbe-8fbd-410d-a100-c15e62a2134e" />

**Issue#2:**
When a GroupBox BackColor is changed, a Button contained within the GroupBox unexpectedly reflects inherited BackColor updates with VisualStylesMode.Net11 mode.
<img width="304" height="198" alt="Image" src="https://github.com/user-attachments/assets/2656e827-8a09-4ad1-95a8-9bbb01b00201" />
Behavior differs from VisualStylesMode.Classic.

<img width="294" height="160" alt="Image" src="https://github.com/user-attachments/assets/7a3a0c92-33ec-49b2-9015-c6243954db2e" />

### After


https://github.com/user-attachments/assets/1fde8b3e-8af0-4e97-a1a7-4951b48e7ce1




## Test methodology <!-- How did you ensure quality? -->

- Manual
- Automation Test

## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.0-preview.7.26381.103


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14929)