### PR TITLE
Fix ToggleSwitch focus border rendering for CheckBox and RadioButton

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
@@ -78,7 +78,7 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
 
         ToggleSwitchMetrics metrics = ToggleSwitchMetrics.Create(Control);
         Size textSize = TextRenderer.MeasureText(Control.Text, Control.Font);
-        Rectangle contentBounds = ToggleSwitchMetrics.GetContentBounds(Control);
+        Rectangle contentBounds = ToggleSwitchMetrics.GetContentBounds(Control, metrics);
         int totalHeight = Math.Max(textSize.Height, metrics.SwitchHeight);
         int contentTop = contentBounds.Top + Math.Max(0, (contentBounds.Height - totalHeight) / 2);
         int textY = contentTop + ((totalHeight - textSize.Height) / 2);
@@ -109,12 +109,36 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
 
         if (Control.Focused && ShowFocusCues)
         {
-            Rectangle focusBounds = Rectangle.Inflate(Control.ClientRectangle, -1, -1);
-            ControlPaint.DrawFocusRectangle(
-                graphics,
-                focusBounds,
-                Control.ForeColor,
-                Control.BackColor);
+            RenderFocusBorder(graphics, metrics);
+        }
+    }
+
+    private void RenderFocusBorder(Graphics graphics, ToggleSwitchMetrics metrics)
+    {
+        Rectangle focusBounds = ToggleSwitchMetrics.GetFocusBounds(Control.ClientRectangle, metrics);
+        if (focusBounds.Width <= 0 || focusBounds.Height <= 0)
+        {
+            return;
+        }
+
+        Color focusColor = TextBoxBase.GetVisualStylesFocusColor(
+            Application.SystemVisualSettings.HighContrastEnabled);
+        using var focusPen = focusColor.GetCachedPenScope(metrics.FocusBorderThickness);
+        using GraphicsPath focusPath = new();
+
+        focusPath.AddRoundedRectangle(
+            focusBounds,
+            new Size(focusBounds.Height, focusBounds.Height));
+
+        SmoothingMode previousSmoothingMode = graphics.SmoothingMode;
+        try
+        {
+            graphics.SmoothingMode = SmoothingMode.AntiAlias;
+            graphics.DrawPath(focusPen, focusPath);
+        }
+        finally
+        {
+            graphics.SmoothingMode = previousSmoothingMode;
         }
     }
 
@@ -161,7 +185,7 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
         ToggleSwitchMetrics metrics,
         Size textSize)
     {
-        Rectangle contentBounds = ToggleSwitchMetrics.GetContentBounds(control);
+        Rectangle contentBounds = ToggleSwitchMetrics.GetContentBounds(control, metrics);
         int totalHeight = Math.Max(textSize.Height, metrics.SwitchHeight);
         int contentTop = contentBounds.Top + Math.Max(0, (contentBounds.Height - totalHeight) / 2);
         int switchY = contentTop + ((totalHeight - metrics.SwitchHeight) / 2);
@@ -394,7 +418,9 @@ internal readonly struct ToggleSwitchMetrics
         int thumbDiameter,
         int hoverThumbDiameter,
         int borderThickness,
-        int textGap)
+        int textGap,
+        int focusBorderThickness,
+        int focusMargin)
     {
         SwitchWidth = switchWidth;
         SwitchHeight = switchHeight;
@@ -402,6 +428,8 @@ internal readonly struct ToggleSwitchMetrics
         HoverThumbDiameter = hoverThumbDiameter;
         BorderThickness = borderThickness;
         TextGap = textGap;
+        FocusBorderThickness = focusBorderThickness;
+        FocusMargin = focusMargin;
     }
 
     internal int SwitchWidth { get; }
@@ -416,6 +444,10 @@ internal readonly struct ToggleSwitchMetrics
 
     internal int TextGap { get; }
 
+    internal int FocusBorderThickness { get; }
+
+    internal int FocusMargin { get; }
+
     internal static ToggleSwitchMetrics Create(Control control)
     {
         int switchHeight = Math.Max(
@@ -423,6 +455,8 @@ internal readonly struct ToggleSwitchMetrics
             (int)(control.Font.Height * 0.9f));
         int minimumMetric = Math.Max(1, control.LogicalToDeviceUnits(1));
         int borderThickness = Math.Max(minimumMetric, switchHeight / 12);
+        int focusBorderThickness = Math.Max(minimumMetric, control.LogicalToDeviceUnits(2));
+        int focusMargin = focusBorderThickness + Math.Max(minimumMetric, control.LogicalToDeviceUnits(2));
         int maximumThumbDiameter = Math.Max(1, switchHeight - (2 * borderThickness));
         int thumbDiameter = Math.Max(
             1,
@@ -440,24 +474,38 @@ internal readonly struct ToggleSwitchMetrics
             thumbDiameter: thumbDiameter,
             hoverThumbDiameter: hoverThumbDiameter,
             borderThickness: borderThickness,
-            textGap: textGap);
+            textGap: textGap,
+            focusBorderThickness: focusBorderThickness,
+            focusMargin: focusMargin);
     }
 
     internal static Rectangle GetContentBounds(Control control)
+        => GetContentBounds(control, Create(control));
+
+    internal static Rectangle GetContentBounds(Control control, ToggleSwitchMetrics metrics)
     {
         Padding padding = control.Padding;
+        int horizontalInset = padding.Horizontal + (2 * metrics.FocusMargin);
+        int verticalInset = padding.Vertical + (2 * metrics.FocusMargin);
+
         return new Rectangle(
-            padding.Left,
-            padding.Top,
-            Math.Max(0, control.ClientSize.Width - padding.Horizontal),
-            Math.Max(0, control.ClientSize.Height - padding.Vertical));
+            padding.Left + metrics.FocusMargin,
+            padding.Top + metrics.FocusMargin,
+            Math.Max(0, control.ClientSize.Width - horizontalInset),
+            Math.Max(0, control.ClientSize.Height - verticalInset));
+    }
+
+    internal static Rectangle GetFocusBounds(Rectangle clientRectangle, ToggleSwitchMetrics metrics)
+    {
+        int inset = metrics.FocusBorderThickness;
+        return Rectangle.Inflate(clientRectangle, -inset, -inset);
     }
 
     internal Size GetPreferredSize(Control control)
     {
         Size textSize = TextRenderer.MeasureText(control.Text, control.Font);
         return new Size(
-            SwitchWidth + TextGap + textSize.Width + control.Padding.Horizontal,
-            Math.Max(SwitchHeight, textSize.Height) + control.Padding.Vertical);
+            SwitchWidth + TextGap + textSize.Width + control.Padding.Horizontal + (2 * FocusMargin),
+            Math.Max(SwitchHeight, textSize.Height) + control.Padding.Vertical + (2 * FocusMargin));
     }
 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
@@ -125,10 +125,11 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
             Application.SystemVisualSettings.HighContrastEnabled);
         using var focusPen = focusColor.GetCachedPenScope(metrics.FocusBorderThickness);
         using GraphicsPath focusPath = new();
+        int cornerSize = Math.Max(1, Math.Min(focusBounds.Width, focusBounds.Height));
 
         focusPath.AddRoundedRectangle(
             focusBounds,
-            new Size(focusBounds.Height, focusBounds.Height));
+            new Size(cornerSize, cornerSize));
 
         SmoothingMode previousSmoothingMode = graphics.SmoothingMode;
         try

--- a/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Rendering/CheckBox/AnimatedToggleSwitchRenderer.cs
@@ -90,6 +90,11 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
 
         PaintControlBackground(graphics);
 
+        if (Control.Focused && ShowFocusCues)
+        {
+            RenderFocusBorder(graphics, metrics);
+        }
+
         if (contentBounds.Width <= 0 || contentBounds.Height <= 0)
         {
             return;
@@ -105,11 +110,6 @@ internal sealed class AnimatedToggleSwitchRenderer : AnimatedControlRenderer
         {
             RenderSwitch(graphics, switchBounds, metrics);
             RenderText(graphics, new Point(contentBounds.Left + metrics.SwitchWidth + metrics.TextGap, textY));
-        }
-
-        if (Control.Focused && ShowFocusCues)
-        {
-            RenderFocusBorder(graphics, metrics);
         }
     }
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/CheckBoxTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/CheckBoxTests.cs
@@ -927,6 +927,50 @@ public class CheckBoxTests : AbstractButtonBaseTests
     }
 
     [WinFormsFact]
+    public void CheckBox_ToggleSwitch_FocusedPaintsRoundedSolidFocusBorderAndReservesMargin()
+    {
+        using SystemVisualSettingsTestScope settingsScope = new(
+            clientAreaAnimationEnabled: false,
+            highContrastEnabled: false,
+            accentColor: Color.Red);
+        using CheckBox box = new()
+        {
+            Appearance = Appearance.ToggleSwitch,
+            BackColor = Color.White,
+            ForeColor = Color.Black,
+            Size = new Size(140, 36),
+            Text = "Toggle",
+            VisualStylesMode = VisualStylesMode.Net11
+        };
+
+        Rendering.CheckBox.ToggleSwitchMetrics metrics = Rendering.CheckBox.ToggleSwitchMetrics.Create(box);
+        Rectangle contentBounds = Rendering.CheckBox.ToggleSwitchMetrics.GetContentBounds(box, metrics);
+        Rectangle focusBounds = Rendering.CheckBox.ToggleSwitchMetrics.GetFocusBounds(box.ClientRectangle, metrics);
+        Size textSize = TextRenderer.MeasureText(box.Text, box.Font);
+        Size preferredSizeWithoutFocusMargin = new(
+            metrics.SwitchWidth + metrics.TextGap + textSize.Width + box.Padding.Horizontal,
+            Math.Max(metrics.SwitchHeight, textSize.Height) + box.Padding.Vertical);
+
+        Assert.Equal(box.Padding.Left + metrics.FocusMargin, contentBounds.Left);
+        Assert.Equal(box.Padding.Top + metrics.FocusMargin, contentBounds.Top);
+        Assert.Equal(
+            preferredSizeWithoutFocusMargin + new Size(2 * metrics.FocusMargin, 2 * metrics.FocusMargin),
+            box.GetPreferredSize(Size.Empty));
+
+        Rendering.CheckBox.AnimatedToggleSwitchRenderer renderer =
+            box.TestAccessor.Dynamic.ToggleSwitchRenderer;
+        renderer.SynchronizeState();
+        using Bitmap bitmap = new(box.Width, box.Height);
+        using Graphics graphics = Graphics.FromImage(bitmap);
+
+        renderer.TestAccessor.Dynamic.RenderFocusBorder(graphics, metrics);
+
+        Assert.True(CountPixels(bitmap, Color.Red) > 0);
+        Assert.NotEqual(Color.Red.ToArgb(), bitmap.GetPixel(focusBounds.Left, focusBounds.Top).ToArgb());
+        Assert.Equal(0, CountPixelsInColumn(bitmap, box.ClientRectangle.Right - 1, Color.Red));
+    }
+
+    [WinFormsFact]
     public void CheckBox_ToggleSwitch_SynchronizeState_SettlesInteractionChannels()
     {
         using SystemVisualSettingsTestScope settingsScope = new(clientAreaAnimationEnabled: true);
@@ -1028,6 +1072,22 @@ public class CheckBoxTests : AbstractButtonBaseTests
                 {
                     count++;
                 }
+            }
+        }
+
+        return count;
+    }
+
+    private static int CountPixelsInColumn(Bitmap bitmap, int column, Color color)
+    {
+        int argb = color.ToArgb();
+        int count = 0;
+
+        for (int y = 0; y < bitmap.Height; y++)
+        {
+            if (bitmap.GetPixel(column, y).ToArgb() == argb)
+            {
+                count++;
             }
         }
 
@@ -1442,10 +1502,10 @@ public class CheckBoxTests : AbstractButtonBaseTests
     }
 
     [WinFormsTheory]
-    [InlineData(Appearance.Button, FlatStyle.Standard,  "Test", 12, 8, 100, 20)]
-    [InlineData(Appearance.Normal, FlatStyle.System,    "Test", 12, 8, 100, 20)]
-    [InlineData(Appearance.Normal, FlatStyle.Flat,      "Test", 12, 8, 100, 20)]
-    [InlineData(Appearance.Normal, FlatStyle.Standard,  "Test", 12, 8, 100, 20)]
+    [InlineData(Appearance.Button, FlatStyle.Standard, "Test", 12, 8, 100, 20)]
+    [InlineData(Appearance.Normal, FlatStyle.System, "Test", 12, 8, 100, 20)]
+    [InlineData(Appearance.Normal, FlatStyle.Flat, "Test", 12, 8, 100, 20)]
+    [InlineData(Appearance.Normal, FlatStyle.Standard, "Test", 12, 8, 100, 20)]
     public void CheckBox_GetPreferredSizeCore_VariousStyles_ReturnsExpected(
         Appearance appearance, FlatStyle flatStyle, string text, int fontSize, int padding, int width, int height)
     {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14886

## Root Cause

When `CheckBox `or `RadioButton `used `Appearance.ToggleSwitch` with `VisualStylesMode.Net11`, the toggle switch renderer reused `ControlPaint.DrawFocusRectangle` against the full `ClientRectangle`. That produced the legacy dotted focus rectangle across the entire control .

The renderer also did not reserve layout space for the focus indicator, so adding focus chrome at paint time could visually crowd or clip the control edges.

## Proposed changes

The change updates `AnimatedToggleSwitchRenderer.cs` to:

- Add focus border thickness and focus margin to `ToggleSwitchMetrics`.
- Reserve the focus margin in ToggleSwitch content bounds and preferred-size calculations.
- Draw a rounded solid focus border using the modern visual styles focus color.
- Inset the focus border enough to avoid clipping at the control edges.
- Reuse the same metrics snapshot for layout and painting.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Users get a cleaner and more consistent focus style for ToggleSwitch CheckBox and RadioButton. Keyboard focus is easier to see, and the UI no longer shows the old dotted full-control outline.

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
When a ToggleSwitch CheckBox or RadioButton got focus, a dotted line appeared around the entire control.

<img width="1386" height="250" alt="Image" src="https://github.com/user-attachments/assets/51925643-634d-41e8-b203-572a224ad935" />

### After
 When focused, ToggleSwitch now shows a rounded solid focus border. The border follows the system accent color, has enough reserved space.

<img width="304" height="153" alt="image" src="https://github.com/user-attachments/assets/b6eea04d-7c88-4e6f-b06f-01e756dc72d7" />


## Test methodology <!-- How did you ensure quality? -->

- Manually and unit test

## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-rc.1.26411.119

<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14990)