### PR TITLE
Handle disposed AsyncWaitHandle during BeginInvoke completion

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Control.ThreadMethodEntry.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Control.ThreadMethodEntry.cs
@@ -76,7 +76,14 @@ public partial class Control
             lock (_invokeSyncObject)
             {
                 IsCompleted = true;
-                _resetEvent?.Set();
+                try
+                {
+                    _resetEvent?.Set();
+                }
+                catch (ObjectDisposedException)
+                {
+                    // AsyncWaitHandle exposes the event and allows callers to dispose it before completion.
+                }
             }
         }
     }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ControlTests.Methods.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ControlTests.Methods.cs
@@ -4277,6 +4277,21 @@ public partial class ControlTests
     }
 
     [WinFormsFact]
+    public void Control_BeginInvoke_DisposedAsyncWaitHandle_CompletesCallback()
+    {
+        using Control control = new();
+        Assert.NotEqual(IntPtr.Zero, control.Handle);
+        bool callbackInvoked = false;
+        IAsyncResult asyncResult = control.BeginInvoke(() => callbackInvoked = true);
+        asyncResult.AsyncWaitHandle.Dispose();
+
+        control.TestAccessor.Dynamic.InvokeMarshaledCallbacks();
+
+        Assert.True(callbackInvoked);
+        Assert.True(asyncResult.IsCompleted);
+    }
+
+    [WinFormsFact]
     public void Control_Invoke_Action_calls_correct_method()
     {
         using Control control = new();


### PR DESCRIPTION
## Summary

- tolerate `ObjectDisposedException` when `ThreadMethodEntry.Complete` signals an `AsyncWaitHandle` disposed by its consumer
- add a regression test that verifies the callback runs and the async result completes

Fixes #14996

## Testing

- `dotnet test src/test/unit/System.Windows.Forms/System.Windows.Forms.Tests.csproj --no-restore -- --filter-method System.Windows.Forms.Tests.ControlTests.Control_BeginInvoke_DisposedAsyncWaitHandle_CompletesCallback` (1 passed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/14998)