### PR TITLE
Fix setting VisualStylesMode to Classic in the Properties window

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Control.cs
@@ -7456,15 +7456,7 @@ public unsafe partial class Control :
 
         if (Properties.ContainsKey(s_visualStylesModeProperty))
         {
-            if (Properties.GetValueOrDefault<VisualStylesMode>(s_visualStylesModeProperty)
-                == ParentInternal?.ResolvedVisualStylesMode)
-            {
-                // Same as the parent value, make it ambient again by removing it.
-                Properties.RemoveValue(s_visualStylesModeProperty);
-            }
-
-            // A local value isolates this subtree from parent changes. If the local value matched the
-            // parent's new value, removing it preserves the effective value while making it ambient again.
+            // A local value isolates this subtree from parent changes.
             return;
         }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Control.cs
@@ -899,18 +899,7 @@ public unsafe partial class Control :
 
             VisualStylesMode oldEffectiveValue = EffectiveVisualStylesMode;
 
-            bool hadLocalOverride = Properties.TryGetValue(
-                s_visualStylesModeProperty,
-                out VisualStylesMode existingRawValue)
-                && existingRawValue != VisualStylesMode.Inherit;
-
-            // Inherit always clears the local override. Setting to the ambient (parent) value clears only when
-            // transitioning an existing local override back to ambient.
-            if (value == VisualStylesMode.Inherit
-                || (hadLocalOverride
-                    && existingRawValue != value
-                    && ParentInternal is { } parent
-                    && parent.ResolvedVisualStylesMode == value))
+            if (value == VisualStylesMode.Inherit)
             {
                 Properties.RemoveValue(s_visualStylesModeProperty);
             }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ControlTests.VisualStylesMode.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ControlTests.VisualStylesMode.cs
@@ -283,6 +283,23 @@ public partial class ControlTests
     }
 
     [WinFormsFact]
+    public void Control_VisualStylesMode_SetValueMatchingParent_PreservesLocalOverride()
+    {
+        using SubControlWithVisualStyles parent = new()
+        {
+            VisualStylesMode = VisualStylesMode.Classic
+        };
+        using SubControlWithVisualStyles child = new();
+        parent.Controls.Add(child);
+        PropertyDescriptor property = TypeDescriptor.GetProperties(child)[nameof(Control.VisualStylesMode)];
+
+        property.SetValue(child, VisualStylesMode.Classic);
+
+        Assert.Equal(VisualStylesMode.Classic, child.VisualStylesMode);
+        Assert.True(property.ShouldSerializeValue(child));
+    }
+
+    [WinFormsFact]
     public void Control_VisualStylesMode_ParentChangeWithLocalValue_DoesNotRaiseChanged()
     {
         using SubControlWithVisualStyles parent = new()

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ControlTests.VisualStylesMode.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ControlTests.VisualStylesMode.cs
@@ -181,14 +181,18 @@ public partial class ControlTests
         Assert.Equal(VisualStylesMode.Disabled, child.VisualStylesMode);
         Assert.Equal(VisualStylesMode.Net11, parent.VisualStylesMode);
 
-        // Setting the child back to the parent's value makes it ambient again, so a later
-        // change on the parent flows through to the child once more.
+        // Setting the child to the parent's value preserves the explicit override.
         child.VisualStylesMode = VisualStylesMode.Net11;
-        Assert.Equal(VisualStylesMode.Inherit, child.VisualStylesMode);
+        Assert.Equal(VisualStylesMode.Net11, child.VisualStylesMode);
         Assert.Equal(VisualStylesMode.Net11, child.EffectiveVisualStylesModeAccessor);
 
         parent.VisualStylesMode = VisualStylesMode.Classic;
         Assert.Equal(VisualStylesMode.Classic, parent.VisualStylesMode);
+        Assert.Equal(VisualStylesMode.Net11, child.VisualStylesMode);
+        Assert.Equal(VisualStylesMode.Net11, child.EffectiveVisualStylesModeAccessor);
+
+        // Explicitly setting Inherit makes the child ambient again.
+        child.VisualStylesMode = VisualStylesMode.Inherit;
         Assert.Equal(VisualStylesMode.Inherit, child.VisualStylesMode);
         Assert.Equal(VisualStylesMode.Classic, child.EffectiveVisualStylesModeAccessor);
     }
@@ -318,6 +322,33 @@ public partial class ControlTests
 
         Assert.Equal(VisualStylesMode.Disabled, child.VisualStylesMode);
         Assert.Equal(0, callCount);
+    }
+
+    [WinFormsFact]
+    public void Control_VisualStylesMode_ParentChangeMatchingLocalValue_PreservesLocalOverride()
+    {
+        using SubControlWithVisualStyles parent = new()
+        {
+            VisualStylesMode = VisualStylesMode.Classic
+        };
+
+        using SubControlWithVisualStyles child = new()
+        {
+            VisualStylesMode = VisualStylesMode.Disabled
+        };
+
+        parent.Controls.Add(child);
+        PropertyDescriptor property = TypeDescriptor.GetProperties(child)[nameof(Control.VisualStylesMode)];
+
+        parent.VisualStylesMode = VisualStylesMode.Disabled;
+
+        Assert.Equal(VisualStylesMode.Disabled, child.VisualStylesMode);
+        Assert.True(property.ShouldSerializeValue(child));
+
+        parent.VisualStylesMode = VisualStylesMode.Net11;
+
+        Assert.Equal(VisualStylesMode.Disabled, child.VisualStylesMode);
+        Assert.Equal(VisualStylesMode.Disabled, child.EffectiveVisualStylesModeAccessor);
     }
 
     [WinFormsFact]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/RadioButtonTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/RadioButtonTests.cs
@@ -309,10 +309,9 @@ public class RadioButtonTests : AbstractButtonBaseTests
     [WinFormsFact]
     public void RadioButton_ModernGlyph_RightToLeftHovered_DoesNotClipAtRightEdge()
     {
-        using Panel parent = new() { BackColor = Color.White };
+        using Panel parent = new();
         using RadioButton control = new()
         {
-            BackColor = Color.White,
             RightToLeft = RightToLeft.Yes,
             Size = new Size(40, 24),
             VisualStylesMode = VisualStylesMode.Net11


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #15012

## Root Cause

The `VisualStylesMode` setter removed the local value when it matched the parent’s resolved mode. In the designer, setting `Classic` matched the ambient parent value, so the override was removed and the property reverted to Inherit.

## Proposed changes

- Only remove the local override when `VisualStylesMode.Inherit` is explicitly assigned. Preserve explicitly assigned values even when they currently match the parent. 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Customers can configure `VisualStylesMode` as `Classic` through the Visual Studio Properties window. Explicit values also remain stable if the parent’s visual styles mode later changes.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Selecting Classic for `Form.VisualStylesMode` in the Properties window immediately reverted the property to Inherit and did not serialize the selection.

https://github.com/user-attachments/assets/331312f3-9782-41c5-aaee-0acb83a36f81

### After
Selecting `Classic` preserves and serializes the explicit value. Selecting `Inherit` continues to remove the local override as expected.

https://github.com/user-attachments/assets/6d2ecf40-6dcd-405e-a65f-a52d778e9a54


## Test methodology <!-- How did you ensure quality? -->

- Unit test and manual test
 

## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-rc.1.26424.125


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/15019)