### PR TITLE
AppContext switch for restoring exception handling behavior in WPF Clipboard APIs

### DIFF
--- a/src/System.Private.Windows.Core/src/System/Private/Windows/CoreAppContextSwitches.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/CoreAppContextSwitches.cs
@@ -19,9 +19,13 @@ internal static class CoreAppContextSwitches
     internal const string DragDropDisableSyncOverAsyncSwitchName =
         "Windows.DragDrop.DisableSyncOverAsync";
 
+    internal const string ClipboardThrowExceptionsForGetAPIsSwitchName =
+        "Windows.Clipboard.ThrowExceptionsForGetAPIs";
+
     private static int s_clipboardDragDropEnableUnsafeBinaryFormatterSerialization;
     private static int s_clipboardDragDropEnableNrbfSerialization;
     private static int s_dragDropDisableSyncOverAsync;
+    private static int s_clipboardThrowExceptionsForGetAPIs;
 
     private static bool GetCachedSwitchValue(string switchName, ref int cachedSwitchValue)
     {
@@ -117,5 +121,11 @@ internal static class CoreAppContextSwitches
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => GetCachedSwitchValue(DragDropDisableSyncOverAsyncSwitchName, ref s_dragDropDisableSyncOverAsync);
+    }
+
+    public static bool ClipboardThrowExceptionsForGetAPIs
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetCachedSwitchValue(ClipboardThrowExceptionsForGetAPIsSwitchName, ref s_clipboardThrowExceptionsForGetAPIs);
     }
 }

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/Composition.NativeToManagedAdapter.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/Composition.NativeToManagedAdapter.cs
@@ -393,6 +393,18 @@ internal unsafe partial class Composition<TOleServices, TNrbfSerializer, TDataFo
             return result;
         }
 
+        // Handles a failed clipboard get operation by either throwing (when the opt-in switch is set)
+        // or reporting failure to the caller. Always returns false so callers can 'return HandleFailedHResult(hr);'.
+        private static bool HandleFailedHResult(HRESULT hr)
+        {
+            if (CoreAppContextSwitches.ClipboardThrowExceptionsForGetAPIs)
+            {
+                hr.ThrowOnFailure();
+            }
+
+            return false;
+        }
+
         private static bool TryGetHGLOBALData<T>(
             Com.IDataObject* dataObject,
             ref readonly DataRequest request,
@@ -410,12 +422,13 @@ internal unsafe partial class Composition<TOleServices, TNrbfSerializer, TDataFo
                 tymed = (uint)Com.TYMED.TYMED_HGLOBAL
             };
 
-            if (dataObject->QueryGetData(formatetc).Failed)
+            HRESULT hr = dataObject->QueryGetData(formatetc);
+            if (hr.Failed)
             {
-                return false;
+                return HandleFailedHResult(hr);
             }
 
-            HRESULT hr = dataObject->GetData(formatetc, out Com.STGMEDIUM medium);
+            hr = dataObject->GetData(formatetc, out Com.STGMEDIUM medium);
 
             // One of the ways this can happen is when we attempt to put binary formatted data onto the
             // clipboard, which will succeed as Windows ignores all errors when putting data on the clipboard.
@@ -433,19 +446,7 @@ internal unsafe partial class Composition<TOleServices, TNrbfSerializer, TDataFo
             // (This can easily happen when the clipboard content changes between QueryGetData and GetData calls.)
             if (hr.Failed)
             {
-                if (CoreAppContextSwitches.ClipboardThrowExceptionsForGetAPIs)
-                {
-                    hr.ThrowOnFailure();
-                }
-
-                return false;
-            }
-
-            // If GetData failed, don't try to read from the medium - it may contain uninitialized data.
-            // (This can easily happen when the clipboard content changes between QueryGetData and GetData calls.)
-            if (hr.Failed)
-            {
-                return false;
+                return HandleFailedHResult(hr);
             }
 
             bool result = false;
@@ -489,22 +490,16 @@ internal unsafe partial class Composition<TOleServices, TNrbfSerializer, TDataFo
                 tymed = (uint)Com.TYMED.TYMED_ISTREAM
             };
 
-            // We are not throwing exception from QueryGetData when CoreAppContextSwitches.ClipboardThrowExceptionsForGetAPIs is true
-            // so as to retain the .NET 9 behavior.
-            if (dataObject->QueryGetData(formatEtc).Failed)
-            {
-                return false;
-            }
-
-            HRESULT hr = dataObject->GetData(formatEtc, out Com.STGMEDIUM medium);
+            HRESULT hr = dataObject->QueryGetData(formatEtc);
             if (hr.Failed)
             {
-                if (CoreAppContextSwitches.ClipboardThrowExceptionsForGetAPIs)
-                {
-                    hr.ThrowOnFailure();
-                }
+                return HandleFailedHResult(hr);
+            }
 
-                return false;
+            hr = dataObject->GetData(formatEtc, out Com.STGMEDIUM medium);
+            if (hr.Failed)
+            {
+                return HandleFailedHResult(hr);
             }
 
             HGLOBAL hglobal = default;

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/Composition.NativeToManagedAdapter.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/Composition.NativeToManagedAdapter.cs
@@ -382,10 +382,11 @@ internal unsafe partial class Composition<TOleServices, TNrbfSerializer, TDataFo
                     result = TryGetIStreamData(dataObject, in request, out data);
                 }
             }
-            catch (Exception e) when (!e.IsCriticalException())
+            catch (Exception e)
+            when (!CoreAppContextSwitches.ClipboardThrowExceptionsForGetAPIs && !e.IsCriticalException())
             {
-                // NotSupported is the typical expected exception. We don't want to throw any exceptions outside
-                // of critical exceptions, to align with legacy behavior and the "Try" semantics of new APIs.
+                // NotSupported is the typical expected exception. Legacy behavior swallows non-critical exceptions,
+                // including failures from IDataObject::GetData.
                 Debug.Assert(e is NotSupportedException, e.Message);
             }
 
@@ -426,6 +427,19 @@ internal unsafe partial class Composition<TOleServices, TNrbfSerializer, TDataFo
             Debug.WriteLineIf(hr == HRESULT.E_UNEXPECTED, "E_UNEXPECTED returned when trying to get clipboard data.");
             Debug.WriteLineIf(hr == HRESULT.COR_E_SERIALIZATION,
                 "COR_E_SERIALIZATION returned when trying to get clipboard data, for example, BinaryFormatter threw SerializationException.");
+            Debug.WriteLineIf(hr == HRESULT.CLIPBRD_E_CANT_OPEN, "CLIPBRD_E_CANT_OPEN returned when trying to get clipboard data. It can happen when clipboard is in locked state by another process.");
+
+            // If GetData failed, don't try to read from the medium - it may contain uninitialized data.
+            // (This can easily happen when the clipboard content changes between QueryGetData and GetData calls.)
+            if (hr.Failed)
+            {
+                if (CoreAppContextSwitches.ClipboardThrowExceptionsForGetAPIs)
+                {
+                    hr.ThrowOnFailure();
+                }
+
+                return false;
+            }
 
             // If GetData failed, don't try to read from the medium - it may contain uninitialized data.
             // (This can easily happen when the clipboard content changes between QueryGetData and GetData calls.)
@@ -448,7 +462,8 @@ internal unsafe partial class Composition<TOleServices, TNrbfSerializer, TDataFo
                 data = default;
                 doNotContinue = true;
             }
-            catch (Exception ex) when (!request.TypedRequest || ex is not NotSupportedException)
+            catch (Exception ex)
+            when (!CoreAppContextSwitches.ClipboardThrowExceptionsForGetAPIs && (!request.TypedRequest || ex is not NotSupportedException))
             {
                 Debug.WriteLine(ex.ToString());
             }
@@ -474,10 +489,19 @@ internal unsafe partial class Composition<TOleServices, TNrbfSerializer, TDataFo
                 tymed = (uint)Com.TYMED.TYMED_ISTREAM
             };
 
-            // Limit the # of exceptions we may throw below.
-            if (dataObject->QueryGetData(formatEtc).Failed
-                || dataObject->GetData(formatEtc, out Com.STGMEDIUM medium).Failed)
+            if (dataObject->QueryGetData(formatEtc).Failed)
             {
+                return false;
+            }
+
+            HRESULT hr = dataObject->GetData(formatEtc, out Com.STGMEDIUM medium);
+            if (hr.Failed)
+            {
+                if (CoreAppContextSwitches.ClipboardThrowExceptionsForGetAPIs)
+                {
+                    hr.ThrowOnFailure();
+                }
+
                 return false;
             }
 

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/Composition.NativeToManagedAdapter.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/Composition.NativeToManagedAdapter.cs
@@ -489,6 +489,8 @@ internal unsafe partial class Composition<TOleServices, TNrbfSerializer, TDataFo
                 tymed = (uint)Com.TYMED.TYMED_ISTREAM
             };
 
+            // We are not throwing exception from QueryGetData when CoreAppContextSwitches.ClipboardThrowExceptionsForGetAPIs is true
+            // so as to retain the .NET 9 behavior.
             if (dataObject->QueryGetData(formatEtc).Failed)
             {
                 return false;

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Private/Windows/Ole/FailingGetDataNativeDataObject.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Private/Windows/Ole/FailingGetDataNativeDataObject.cs
@@ -13,13 +13,18 @@ namespace System.Private.Windows.Ole;
 internal unsafe class FailingGetDataNativeDataObject : NativeDataObjectMock
 {
     private readonly ushort _format;
-    private readonly TYMED _tymed;
     private readonly HRESULT _failureHResult;
 
-    public FailingGetDataNativeDataObject(ushort format, TYMED tymed, HRESULT failureHResult = default)
+    /// <summary>
+    ///  Initializes the mock for the specified clipboard format and failure result.
+    /// </summary>
+    /// <param name="format">The clipboard format for which <see cref="QueryGetData"/> reports success.</param>
+    /// <param name="failureHResult">
+    ///  The failure returned by <see cref="GetData"/>. The default represents clipboard contention.
+    /// </param>
+    public FailingGetDataNativeDataObject(ushort format, HRESULT failureHResult = default)
     {
         _format = format;
-        _tymed = tymed;
 
         // Default to CLIPBRD_E_CANT_OPEN which can happen during clipboard contention.
         _failureHResult = failureHResult == default ? HRESULT.CLIPBRD_E_CANT_OPEN : failureHResult;

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Private/Windows/Ole/FailingGetDataNativeDataObject.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Private/Windows/Ole/FailingGetDataNativeDataObject.cs
@@ -13,11 +13,13 @@ namespace System.Private.Windows.Ole;
 internal unsafe class FailingGetDataNativeDataObject : NativeDataObjectMock
 {
     private readonly ushort _format;
+    private readonly TYMED _tymed;
     private readonly HRESULT _failureHResult;
 
-    public FailingGetDataNativeDataObject(ushort format, HRESULT failureHResult = default)
+    public FailingGetDataNativeDataObject(ushort format, TYMED tymed, HRESULT failureHResult = default)
     {
         _format = format;
+        _tymed = tymed;
 
         // Default to CLIPBRD_E_CANT_OPEN which can happen during clipboard contention.
         _failureHResult = failureHResult == default ? HRESULT.CLIPBRD_E_CANT_OPEN : failureHResult;
@@ -25,12 +27,10 @@ internal unsafe class FailingGetDataNativeDataObject : NativeDataObjectMock
 
     public override HRESULT QueryGetData(FORMATETC* pformatetc)
     {
-        if (pformatetc is null)
-        {
-            return HRESULT.DV_E_FORMATETC;
-        }
-
-        if (pformatetc->cfFormat != _format)
+        if (pformatetc is null
+            || pformatetc->cfFormat != _format
+            || pformatetc->dwAspect != (uint)DVASPECT.DVASPECT_CONTENT
+            || pformatetc->lindex != -1)
         {
             return HRESULT.DV_E_FORMATETC;
         }

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Private/Windows/Ole/NativeToManagedAdapterTests.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Private/Windows/Ole/NativeToManagedAdapterTests.cs
@@ -385,7 +385,7 @@ public unsafe class NativeToManagedAdapterTests
         // This can happen in practice when there's clipboard contention - QueryGetData succeeds
         // but GetData fails because another application modified the clipboard in between.
 
-        using FailingGetDataNativeDataObject dataObject = new((ushort)_format.Id, TYMED.TYMED_HGLOBAL);
+        using FailingGetDataNativeDataObject dataObject = new((ushort)_format.Id);
 
         var composition = Composition.Create(ComHelpers.GetComPointer<IDataObject>(dataObject));
 
@@ -398,39 +398,32 @@ public unsafe class NativeToManagedAdapterTests
     }
 
     [Theory]
-    [InlineData((uint)TYMED.TYMED_HGLOBAL)]
-    [InlineData((uint)TYMED.TYMED_ISTREAM)]
-    public void GetData_WhenGetDataFailsAndSwitchDisabled_ReturnsNull(uint tymed)
+    [InlineData(false)]
+    [InlineData(true)]
+    public void GetData_WhenGetDataFails_ReturnsExpected(bool enableSwitch)
     {
         using AppContextSwitchScope scope = new(
             CoreAppContextSwitches.ClipboardThrowExceptionsForGetAPIsSwitchName,
             getDefaultValue: () => false,
-            enable: false);
-        using FailingGetDataNativeDataObject dataObject = new((ushort)_format.Id, (TYMED)tymed);
+            enable: enableSwitch);
+
+        using FailingGetDataNativeDataObject dataObject = new(
+            (ushort)_format.Id,
+            HRESULT.CLIPBRD_E_CANT_OPEN);
 
         var composition = Composition.Create(ComHelpers.GetComPointer<IDataObject>(dataObject));
-        object? data = composition.GetData(nameof(NativeToManagedAdapterTests));
 
-        data.Should().BeNull();
-    }
-
-    [Theory]
-    [InlineData((uint)TYMED.TYMED_HGLOBAL)]
-    [InlineData((uint)TYMED.TYMED_ISTREAM)]
-    public void GetData_WhenGetDataFailsAndSwitchEnabled_Throws(uint tymed)
-    {
-        using AppContextSwitchScope scope = new(
-            CoreAppContextSwitches.ClipboardThrowExceptionsForGetAPIsSwitchName,
-            getDefaultValue: () => false,
-            enable: true);
-        using FailingGetDataNativeDataObject dataObject = new((ushort)_format.Id, (TYMED)tymed, HRESULT.CLIPBRD_E_CANT_OPEN);
-
-        var composition = Composition.Create(ComHelpers.GetComPointer<IDataObject>(dataObject));
-        Action action = () => composition.GetData(nameof(NativeToManagedAdapterTests));
-
-        action.Should()
-            .Throw<COMException>()
-            .And.HResult.Should()
-            .Be((int)HRESULT.CLIPBRD_E_CANT_OPEN);
+        if (enableSwitch)
+        {
+            Action action = () => composition.GetData(nameof(NativeToManagedAdapterTests));
+            action.Should()
+                .Throw<COMException>()
+                .And.HResult.Should()
+                .Be((int)HRESULT.CLIPBRD_E_CANT_OPEN);
+        }
+        else
+        {
+            composition.GetData(nameof(NativeToManagedAdapterTests)).Should().BeNull();
+        }
     }
 }

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Private/Windows/Ole/NativeToManagedAdapterTests.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Private/Windows/Ole/NativeToManagedAdapterTests.cs
@@ -4,7 +4,7 @@
 using System.ComponentModel;
 using System.Formats.Nrbf;
 using System.Private.Windows.BinaryFormat;
-
+using System.Runtime.InteropServices;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.System.Com;
@@ -385,7 +385,7 @@ public unsafe class NativeToManagedAdapterTests
         // This can happen in practice when there's clipboard contention - QueryGetData succeeds
         // but GetData fails because another application modified the clipboard in between.
 
-        using FailingGetDataNativeDataObject dataObject = new((ushort)_format.Id);
+        using FailingGetDataNativeDataObject dataObject = new((ushort)_format.Id, TYMED.TYMED_HGLOBAL);
 
         var composition = Composition.Create(ComHelpers.GetComPointer<IDataObject>(dataObject));
 
@@ -395,5 +395,42 @@ public unsafe class NativeToManagedAdapterTests
 
         // Should return null, not corrupted data
         data.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData((uint)TYMED.TYMED_HGLOBAL)]
+    [InlineData((uint)TYMED.TYMED_ISTREAM)]
+    public void GetData_WhenGetDataFailsAndSwitchDisabled_ReturnsNull(uint tymed)
+    {
+        using AppContextSwitchScope scope = new(
+            CoreAppContextSwitches.ClipboardThrowExceptionsForGetAPIsSwitchName,
+            getDefaultValue: () => false,
+            enable: false);
+        using FailingGetDataNativeDataObject dataObject = new((ushort)_format.Id, (TYMED)tymed);
+
+        var composition = Composition.Create(ComHelpers.GetComPointer<IDataObject>(dataObject));
+        object? data = composition.GetData(nameof(NativeToManagedAdapterTests));
+
+        data.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData((uint)TYMED.TYMED_HGLOBAL)]
+    [InlineData((uint)TYMED.TYMED_ISTREAM)]
+    public void GetData_WhenGetDataFailsAndSwitchEnabled_Throws(uint tymed)
+    {
+        using AppContextSwitchScope scope = new(
+            CoreAppContextSwitches.ClipboardThrowExceptionsForGetAPIsSwitchName,
+            getDefaultValue: () => false,
+            enable: true);
+        using FailingGetDataNativeDataObject dataObject = new((ushort)_format.Id, (TYMED)tymed, HRESULT.CLIPBRD_E_CANT_OPEN);
+
+        var composition = Composition.Create(ComHelpers.GetComPointer<IDataObject>(dataObject));
+        Action action = () => composition.GetData(nameof(NativeToManagedAdapterTests));
+
+        action.Should()
+            .Throw<COMException>()
+            .And.HResult.Should()
+            .Be((int)HRESULT.CLIPBRD_E_CANT_OPEN);
     }
 }

--- a/src/System.Windows.Forms/System/Windows/Forms/OLE/WinFormsOleServices.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/OLE/WinFormsOleServices.cs
@@ -99,6 +99,11 @@ internal sealed class WinFormsOleServices : IOleServices
             // get the data out.
             Debug.WriteLineIf(result == HRESULT.CLIPBRD_E_BAD_DATA, "CLIPBRD_E_BAD_DATA returned when trying to get clipboard data.");
 
+            if (result.Failed && CoreAppContextSwitches.ClipboardThrowExceptionsForGetAPIs)
+            {
+                result.ThrowOnFailure();
+            }
+
             try
             {
                 // GDI+ doesn't own this HBITMAP, but we can't delete it while the object is still around. So we

--- a/src/System.Windows.Forms/System/Windows/Forms/OLE/WinFormsOleServices.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/OLE/WinFormsOleServices.cs
@@ -86,9 +86,10 @@ internal sealed class WinFormsOleServices : IOleServices
             };
 
             HRESULT result = dataObject->QueryGetData(formatEtc);
+
             if (result.Failed)
             {
-                return false;
+                return HandleFailedHResult(result);
             }
 
             result = dataObject->GetData(formatEtc, out STGMEDIUM medium);
@@ -99,17 +100,17 @@ internal sealed class WinFormsOleServices : IOleServices
             // get the data out.
             Debug.WriteLineIf(result == HRESULT.CLIPBRD_E_BAD_DATA, "CLIPBRD_E_BAD_DATA returned when trying to get clipboard data.");
 
-            if (result.Failed && CoreAppContextSwitches.ClipboardThrowExceptionsForGetAPIs)
+            // If GetData failed, don't try to read from the medium - it may contain uninitialized data.
+            if (result.Failed)
             {
-                result.ThrowOnFailure();
+                return HandleFailedHResult(result);
             }
 
             try
             {
                 // GDI+ doesn't own this HBITMAP, but we can't delete it while the object is still around. So we
                 // have to do the really expensive thing of cloning the image so we can release the HBITMAP.
-                if (result.Succeeded
-                    && (uint)medium.tymed == (uint)TYMED.TYMED_GDI
+                if ((uint)medium.tymed == (uint)TYMED.TYMED_GDI
                     && !medium.hGlobal.IsNull
                     && Image.FromHbitmap(medium.hGlobal) is Bitmap clipboardBitmap)
                 {
@@ -125,6 +126,18 @@ internal sealed class WinFormsOleServices : IOleServices
 
             return false;
         }
+    }
+
+    // Handles a failed clipboard get operation by either throwing (when the opt-in switch is set)
+    // or reporting failure to the caller. Always returns false so callers can 'return HandleFailedHResult(hr);'.
+    private static bool HandleFailedHResult(HRESULT hr)
+    {
+        if (CoreAppContextSwitches.ClipboardThrowExceptionsForGetAPIs)
+        {
+            hr.ThrowOnFailure();
+        }
+
+        return false;
     }
 
     static bool IOleServices.AllowTypeWithoutResolver<T>() =>

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ClipboardTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ClipboardTests.cs
@@ -638,6 +638,73 @@ public class ClipboardTests
     }
 
     [WinFormsFact]
+    public void ThrowExceptionsForClipboardGetAPIs_AppContextSwitch()
+    {
+        string switchName = CoreAppContextSwitches.ClipboardThrowExceptionsForGetAPIsSwitchName;
+
+        CoreAppContextSwitches.ClipboardThrowExceptionsForGetAPIs.Should().BeFalse();
+
+        using (AppContextSwitchScope scope = new(switchName, getDefaultValue: () => false, enable: true))
+        {
+            CoreAppContextSwitches.ClipboardThrowExceptionsForGetAPIs.Should().BeTrue();
+        }
+
+        using (AppContextSwitchScope scope = new(switchName, getDefaultValue: () => false, enable: false))
+        {
+            CoreAppContextSwitches.ClipboardThrowExceptionsForGetAPIs.Should().BeFalse();
+        }
+    }
+
+    [WinFormsTheory]
+    [InlineData(nameof(Clipboard.GetText), DataFormatNames.UnicodeText)]
+    [InlineData(nameof(Clipboard.GetAudioStream), DataFormatNames.WaveAudio)]
+    [InlineData(nameof(Clipboard.GetImage), DataFormatNames.Bitmap)]
+    [InlineData(nameof(Clipboard.GetFileDropList), DataFormatNames.FileDrop)]
+    [InlineData(nameof(Clipboard.GetData), "Custom")]
+    public void GetApi_GetDataFailsAndSwitchEnabled_Throws(string api, string format)
+    {
+        try
+        {
+            DataObject dataObject = new();
+            dataObject.SetData(format, data: null);
+            Clipboard.SetDataObject(dataObject, copy: true);
+
+            Action action = api switch
+            {
+                nameof(Clipboard.GetText) => () => Clipboard.GetText(),
+                nameof(Clipboard.GetAudioStream) => () => Clipboard.GetAudioStream(),
+                nameof(Clipboard.GetImage) => () => Clipboard.GetImage(),
+                nameof(Clipboard.GetFileDropList) => () => Clipboard.GetFileDropList(),
+                nameof(Clipboard.GetData) => () => Clipboard.GetData(format),
+                _ => throw new InvalidOperationException()
+            };
+
+            using (AppContextSwitchScope scope = new(
+                CoreAppContextSwitches.ClipboardThrowExceptionsForGetAPIsSwitchName,
+                getDefaultValue: () => false,
+                enable: false))
+            {
+                action.Should().NotThrow();
+            }
+
+            using (AppContextSwitchScope scope = new(
+                CoreAppContextSwitches.ClipboardThrowExceptionsForGetAPIsSwitchName,
+                getDefaultValue: () => false,
+                enable: true))
+            {
+                action.Should()
+                    .Throw<COMException>()
+                    .And.HResult.Should()
+                    .Be((int)HRESULT.CLIPBRD_E_BAD_DATA);
+            }
+        }
+        finally
+        {
+            Clipboard.Clear();
+        }
+    }
+
+    [WinFormsFact]
     public void TryGetInt_ReturnsExpected()
     {
         int expected = 101;


### PR DESCRIPTION
Fixes empty string scenario in bug https://github.com/dotnet/winforms/issues/14322

## Description 
Until .NET 9.0, the WPF Clipboard Get* APIs threw exceptions when an operation failed. This differed from the WinForms Clipboard APIs, which swallow exceptions and return an empty string.

In .NET 10, we unified the clipboard implementation in `System.Private.Windows.Core`. The unified implementation follows the existing WinForms behavior, but this introduces a behavior change for WPF: its Clipboard APIs now also swallow exceptions and return an empty string instead of propagating the exception.

## Customer Impact
This behavior change is causing issues for some existing WPF applications that rely on exceptions being thrown to detect clipboard operation failures. More details are available in the bug.

## Regression
Yes - In WPF from .NET 9.0


## Fix
Added a new AppContext switch: "Windows.Clipboard.ThrowExceptionsForGetAPIs" When set, the Clipboard Get* APIs will throw exception during a Clipboard failure. This switch is off by default. In off state the APIs will continue to swallow exceptions and return an empty string.

Added unit tests.

## Testing
Created a WinForms app to write unicode data on the clipboard and another app to read it. Before the changes, the reader app returned empty string very frequently. After fix and with the new AppContext switch turned on, the app did not return empty string for Get* APIs at all. Note that it still returns empty string if QueryGet* API fails which have same behavior as in .NET 9.

## Risk
This should be a very low risk change as this behavior was working fine in 9.0 and previous versions.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/15022)