### PR TITLE
Fix issue 15031: Disable NET11 VisualStylesMode for composite controls (ToolStrip, DataGridView, etc.) until NET11 layout modernization is completed

### DIFF
--- a/docs/runtime-configuration.md
+++ b/docs/runtime-configuration.md
@@ -135,6 +135,24 @@ For example, the content of `[appname].runtimeconfig.json` generated from above 
 }
 ```
 
+#### Enabling modern rendering for composite controls
+
+`ToolStrip`, `MenuStrip`, and `DataGridView` use Classic rendering when `VisualStylesMode`
+is `Net11` or `Latest` by default. Applications can opt in to modern rendering with these
+switches:
+
+```json
+{
+  "configProperties": {
+    "System.Windows.Forms.ToolStripModernRendering": true,
+    "System.Windows.Forms.DataGridViewModernRendering": true
+  }
+}
+```
+
+`System.Windows.Forms.ToolStripModernRendering` controls both `ToolStrip` and `MenuStrip`.
+Both switches default to `false`.
+
 The target framework information added to `[appname].runtimeconfig.json` file always match with the application target framework irrespective of runtime/SDK installed on the machine or runtime used ([roll-forward scenarios](https://docs.microsoft.com/dotnet/core/versions/selection#framework-dependent-apps-roll-forward)) by the Windows Forms application.
 
 #### .NET runtime support in reading `runtimeconfig.json`

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -27,6 +27,8 @@ internal static partial class LocalAppContextSwitches
     internal const string TreeNodeCollectionAddRangeRespectsSortOrderSwitchName = "System.Windows.Forms.TreeNodeCollectionAddRangeRespectsSortOrder";
     internal const string MoveTreeViewTextLocationOnePixelSwitchName = "System.Windows.Forms.TreeView.MoveTreeViewTextLocationOnePixel";
     internal const string DataGridViewDarkModeThemingSwitchName = "System.Windows.Forms.DataGridViewDarkModeTheming";
+    internal const string ToolStripModernRenderingSwitchName = "System.Windows.Forms.ToolStripModernRendering";
+    internal const string DataGridViewModernRenderingSwitchName = "System.Windows.Forms.DataGridViewModernRendering";
 
     private static int s_scaleTopLevelFormMinMaxSizeForDpi;
     private static int s_anchorLayoutV2;
@@ -41,6 +43,8 @@ internal static partial class LocalAppContextSwitches
 
     private static int s_moveTreeViewTextLocationOnePixel;
     private static int s_dataGridViewDarkModeTheming;
+    private static int s_toolStripModernRendering;
+    private static int s_dataGridViewModernRendering;
 
     private static FrameworkName? s_targetFrameworkName;
 
@@ -253,5 +257,25 @@ internal static partial class LocalAppContextSwitches
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => GetCachedSwitchValue(DataGridViewDarkModeThemingSwitchName, ref s_dataGridViewDarkModeTheming);
+    }
+
+    /// <summary>
+    ///  Indicates whether ToolStrip controls, including MenuStrip, support modern visual styles.
+    ///  Defaults to <see langword="false"/>.
+    /// </summary>
+    public static bool ToolStripModernRendering
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetCachedSwitchValue(ToolStripModernRenderingSwitchName, ref s_toolStripModernRendering);
+    }
+
+    /// <summary>
+    ///  Indicates whether DataGridView controls support modern visual styles.
+    ///  Defaults to <see langword="false"/>.
+    /// </summary>
+    public static bool DataGridViewModernRendering
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetCachedSwitchValue(DataGridViewModernRenderingSwitchName, ref s_dataGridViewModernRendering);
     }
 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Control.cs
@@ -7458,28 +7458,46 @@ public unsafe partial class Control :
             return;
         }
 
-        if (Properties.ContainsKey(s_visualStylesModeProperty))
+        VisualStylesModeChangeEventArgs? transition = e as VisualStylesModeChangeEventArgs;
+        if (transition is not null
+            && (!transition.IsCurrent
+                || ParentInternal?.EffectiveVisualStylesMode != transition.NewEffectiveVisualStylesMode))
         {
-            if (Properties.GetValueOrDefault<VisualStylesMode>(s_visualStylesModeProperty)
-                == ParentInternal?.UncoercedVisualStylesMode)
-            {
-                // Same as the parent value, make it ambient again by removing it.
-                Properties.RemoveValue(s_visualStylesModeProperty);
-            }
-
-            // A local value isolates this subtree from parent changes. If the local value matched the
-            // parent's new value, removing it preserves the effective value while making it ambient again.
             return;
         }
 
-        if (e is VisualStylesModeChangeEventArgs transition)
+        if (Properties.ContainsKey(s_visualStylesModeProperty))
         {
-            if (!transition.IsCurrent
-                || ParentInternal?.EffectiveVisualStylesMode != transition.NewEffectiveVisualStylesMode)
+            if (Properties.GetValueOrDefault<VisualStylesMode>(s_visualStylesModeProperty)
+                != ParentInternal?.UncoercedVisualStylesMode)
+            {
+                // A local value isolates this subtree from parent changes.
+                return;
+            }
+
+            VisualStylesMode oldEffectiveVisualStylesMode = EffectiveVisualStylesMode;
+
+            // Same as the parent value, make it ambient again by removing it.
+            Properties.RemoveValue(s_visualStylesModeProperty);
+
+            VisualStylesMode newEffectiveVisualStylesMode = EffectiveVisualStylesMode;
+            if (oldEffectiveVisualStylesMode == newEffectiveVisualStylesMode)
             {
                 return;
             }
 
+            OnVisualStylesModeChanged(
+                transition?.CreateForControl(
+                    this,
+                    oldEffectiveVisualStylesMode,
+                    newEffectiveVisualStylesMode)
+                ?? e);
+
+            return;
+        }
+
+        if (transition is not null)
+        {
             VisualStylesModeChangeEventArgs transitionForControl = transition.CreateForControl(this);
             if (transitionForControl.OldEffectiveVisualStylesMode
                 != transitionForControl.NewEffectiveVisualStylesMode)
@@ -7571,14 +7589,23 @@ public unsafe partial class Control :
                     systemVisualSettingsTransition);
             }
 
-            return new(
+            return CreateForControl(
+                control,
+                control.GetSupportedVisualStylesMode(OldEffectiveVisualStylesMode),
+                control.GetSupportedVisualStylesMode(NewEffectiveVisualStylesMode));
+        }
+
+        public VisualStylesModeChangeEventArgs CreateForControl(
+            Control control,
+            VisualStylesMode oldEffectiveVisualStylesMode,
+            VisualStylesMode newEffectiveVisualStylesMode)
+            => new(
                 _state,
                 control,
                 control.Properties.GetValueOrDefault(s_visualStylesModeChangeVersionProperty, 0),
-                control.GetSupportedVisualStylesMode(OldEffectiveVisualStylesMode),
-                control.GetSupportedVisualStylesMode(NewEffectiveVisualStylesMode),
+                oldEffectiveVisualStylesMode,
+                newEffectiveVisualStylesMode,
                 systemVisualSettingsTransition: null);
-        }
 
         public void PerformLayouts()
         {

--- a/src/System.Windows.Forms/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Control.cs
@@ -899,10 +899,10 @@ public unsafe partial class Control :
 
             VisualStylesMode oldEffectiveValue = EffectiveVisualStylesMode;
 
-            // Inherit was requested explicitly, or the requested value matches the ambient (parent) value:
+            // Inherit was requested explicitly, or the requested value matches the uncoerced ambient value:
             // drop any local override so the value is inherited again.
             if (value == VisualStylesMode.Inherit
-                || (ParentInternal is { } parent && parent.ResolvedVisualStylesMode == value))
+                || (ParentInternal is { } parent && parent.UncoercedVisualStylesMode == value))
             {
                 Properties.RemoveValue(s_visualStylesModeProperty);
             }
@@ -927,17 +927,29 @@ public unsafe partial class Control :
     private void ResetVisualStylesMode()
         => VisualStylesMode = VisualStylesMode.Inherit;
 
-    private VisualStylesMode ResolvedVisualStylesMode
+    private VisualStylesMode UncoercedVisualStylesMode
     {
         get
         {
             VisualStylesMode value = VisualStylesMode;
 
             return value == VisualStylesMode.Inherit
-                ? ParentInternal?.ResolvedVisualStylesMode ?? DefaultVisualStylesMode
+                ? ParentInternal?.UncoercedVisualStylesMode ?? DefaultVisualStylesMode
                 : value;
         }
     }
+
+    private VisualStylesMode ResolvedVisualStylesMode
+        => GetSupportedVisualStylesMode(
+            VisualStylesMode == VisualStylesMode.Inherit
+                ? ParentInternal?.ResolvedVisualStylesMode ?? DefaultVisualStylesMode
+                : VisualStylesMode);
+
+    /// <summary>
+    ///  Coerces a requested visual styles mode to one supported by this control.
+    /// </summary>
+    private protected virtual VisualStylesMode GetSupportedVisualStylesMode(VisualStylesMode mode)
+        => mode;
 
     /// <summary>
     ///  Gets the renderer-authoritative <see cref="Forms.VisualStylesMode"/> that controls must honor when deciding
@@ -7449,7 +7461,7 @@ public unsafe partial class Control :
         if (Properties.ContainsKey(s_visualStylesModeProperty))
         {
             if (Properties.GetValueOrDefault<VisualStylesMode>(s_visualStylesModeProperty)
-                == ParentInternal?.ResolvedVisualStylesMode)
+                == ParentInternal?.UncoercedVisualStylesMode)
             {
                 // Same as the parent value, make it ambient again by removing it.
                 Properties.RemoveValue(s_visualStylesModeProperty);
@@ -7460,14 +7472,28 @@ public unsafe partial class Control :
             return;
         }
 
-        if (e is VisualStylesModeChangeEventArgs transition
-            && (!transition.IsCurrent
-                || ParentInternal?.EffectiveVisualStylesMode != transition.NewEffectiveVisualStylesMode))
+        if (e is VisualStylesModeChangeEventArgs transition)
         {
+            if (!transition.IsCurrent
+                || ParentInternal?.EffectiveVisualStylesMode != transition.NewEffectiveVisualStylesMode)
+            {
+                return;
+            }
+
+            VisualStylesModeChangeEventArgs transitionForControl = transition.CreateForControl(this);
+            if (transitionForControl.OldEffectiveVisualStylesMode
+                != transitionForControl.NewEffectiveVisualStylesMode)
+            {
+                OnVisualStylesModeChanged(transitionForControl);
+            }
+            else if (ChildControls is { } children)
+            {
+                CascadeVisualStylesModeChanged(children, transitionForControl, transitionForControl);
+            }
+
             return;
         }
 
-        // In every other case we're going to raise the event.
         OnVisualStylesModeChanged(e);
     }
 
@@ -7534,18 +7560,24 @@ public unsafe partial class Control :
 
         public VisualStylesModeChangeEventArgs CreateForControl(Control control)
         {
-            if (SystemVisualSettingsTransition is not { } systemVisualSettingsTransition)
+            if (SystemVisualSettingsTransition is { } systemVisualSettingsTransition)
             {
-                return this;
+                return new(
+                    _state,
+                    control,
+                    control.Properties.GetValueOrDefault(s_visualStylesModeChangeVersionProperty, 0),
+                    control.GetEffectiveVisualStylesMode(systemVisualSettingsTransition.OldSettings.HighContrastEnabled),
+                    control.GetEffectiveVisualStylesMode(systemVisualSettingsTransition.NewSettings.HighContrastEnabled),
+                    systemVisualSettingsTransition);
             }
 
             return new(
                 _state,
                 control,
                 control.Properties.GetValueOrDefault(s_visualStylesModeChangeVersionProperty, 0),
-                control.GetEffectiveVisualStylesMode(systemVisualSettingsTransition.OldSettings.HighContrastEnabled),
-                control.GetEffectiveVisualStylesMode(systemVisualSettingsTransition.NewSettings.HighContrastEnabled),
-                systemVisualSettingsTransition);
+                control.GetSupportedVisualStylesMode(OldEffectiveVisualStylesMode),
+                control.GetSupportedVisualStylesMode(NewEffectiveVisualStylesMode),
+                systemVisualSettingsTransition: null);
         }
 
         public void PerformLayouts()

--- a/src/System.Windows.Forms/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Control.cs
@@ -7465,7 +7465,33 @@ public unsafe partial class Control :
 
         if (Properties.ContainsKey(s_visualStylesModeProperty))
         {
-            // A local value isolates this subtree from parent changes.
+            if (ParentInternal is not { } parent
+                || Properties.GetValueOrDefault<VisualStylesMode>(s_visualStylesModeProperty)
+                    != parent.UncoercedVisualStylesMode
+                || parent.UncoercedVisualStylesMode == parent.EffectiveVisualStylesMode)
+            {
+                // A local value isolates this subtree from parent changes.
+                return;
+            }
+
+            VisualStylesMode oldEffectiveVisualStylesMode = EffectiveVisualStylesMode;
+
+            // Inherit the parent's coerced mode when the local value matches its uncoerced mode.
+            Properties.RemoveValue(s_visualStylesModeProperty);
+
+            VisualStylesMode newEffectiveVisualStylesMode = EffectiveVisualStylesMode;
+            if (oldEffectiveVisualStylesMode == newEffectiveVisualStylesMode)
+            {
+                return;
+            }
+
+            OnVisualStylesModeChanged(
+                transition?.CreateForControl(
+                    this,
+                    oldEffectiveVisualStylesMode,
+                    newEffectiveVisualStylesMode)
+                ?? e);
+
             return;
         }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
@@ -16,6 +16,9 @@ namespace System.Windows.Forms;
 [SRDescription(nameof(SR.DescriptionDataGridView))]
 public partial class DataGridView : Control, ISupportInitialize
 {
+    private protected override VisualStylesMode GetSupportedVisualStylesMode(VisualStylesMode mode)
+        => mode >= VisualStylesMode.Net11 ? VisualStylesMode.Classic : mode;
+
     private static readonly object s_allowUserToAddRowsChangedEvent = new();
     private static readonly object s_allowUserToDeleteRowsChangedEvent = new();
     private static readonly object s_allowUserToOrderColumnsChangedEvent = new();

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
@@ -17,7 +17,9 @@ namespace System.Windows.Forms;
 public partial class DataGridView : Control, ISupportInitialize
 {
     private protected override VisualStylesMode GetSupportedVisualStylesMode(VisualStylesMode mode)
-        => mode >= VisualStylesMode.Net11 ? VisualStylesMode.Classic : mode;
+        => mode < VisualStylesMode.Net11 || AppContextSwitches.DataGridViewModernRendering
+            ? mode
+            : VisualStylesMode.Classic;
 
     private static readonly object s_allowUserToAddRowsChangedEvent = new();
     private static readonly object s_allowUserToDeleteRowsChangedEvent = new();

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
@@ -23,6 +23,9 @@ namespace System.Windows.Forms;
 [DefaultEvent(nameof(ItemClicked))]
 public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportToolStripPanel
 {
+    private protected override VisualStylesMode GetSupportedVisualStylesMode(VisualStylesMode mode)
+        => mode >= VisualStylesMode.Net11 ? VisualStylesMode.Classic : mode;
+
     private static Size s_onePixel = new(1, 1);
     internal static Point s_invalidMouseEnter = new(int.MaxValue, int.MaxValue);
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
@@ -24,7 +24,9 @@ namespace System.Windows.Forms;
 public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportToolStripPanel
 {
     private protected override VisualStylesMode GetSupportedVisualStylesMode(VisualStylesMode mode)
-        => mode >= VisualStylesMode.Net11 ? VisualStylesMode.Classic : mode;
+        => mode < VisualStylesMode.Net11 || AppContextSwitches.ToolStripModernRendering
+            ? mode
+            : VisualStylesMode.Classic;
 
     private static Size s_onePixel = new(1, 1);
     internal static Point s_invalidMouseEnter = new(int.MaxValue, int.MaxValue);

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ControlTests.VisualStylesMode.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ControlTests.VisualStylesMode.cs
@@ -497,6 +497,33 @@ public partial class ControlTests
     }
 
     [WinFormsFact]
+    public void Control_VisualStylesMode_LocalOverrideRemovedByCoercedParent_RaisesChangedAndCascades()
+    {
+        using DataGridView parent = new() { VisualStylesMode = VisualStylesMode.Disabled };
+        using SubControlWithVisualStyles child = new()
+        {
+            HighContrast = false,
+            VisualStylesMode = VisualStylesMode.Latest
+        };
+        using SubControlWithVisualStyles grandchild = new() { HighContrast = false };
+        child.Controls.Add(grandchild);
+        parent.Controls.Add(child);
+
+        int childChangedCallCount = 0;
+        child.VisualStylesModeChanged += (sender, e) => childChangedCallCount++;
+        int grandchildChangedCallCount = 0;
+        grandchild.VisualStylesModeChanged += (sender, e) => grandchildChangedCallCount++;
+
+        parent.VisualStylesMode = VisualStylesMode.Latest;
+
+        Assert.Equal(VisualStylesMode.Inherit, child.VisualStylesMode);
+        Assert.Equal(VisualStylesMode.Classic, child.EffectiveVisualStylesModeAccessor);
+        Assert.Equal(VisualStylesMode.Classic, grandchild.EffectiveVisualStylesModeAccessor);
+        Assert.Equal(1, childChangedCallCount);
+        Assert.Equal(1, grandchildChangedCallCount);
+    }
+
+    [WinFormsFact]
     public void Appearance_ToggleSwitch_HasExpectedValue()
     {
         Assert.Equal(2, (int)Appearance.ToggleSwitch);

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewTests.cs
@@ -38,6 +38,61 @@ public partial class DataGridViewTests : IDisposable
         Assert.Same(control.RowTemplate, control.RowTemplate);
     }
 
+    [WinFormsTheory]
+    [InlineData(VisualStylesMode.Net11)]
+    [InlineData(VisualStylesMode.Latest)]
+    public void DataGridView_VisualStylesMode_ModernMode_UsesClassicEffectiveMode(VisualStylesMode value)
+    {
+        using SubDataGridView control = new() { VisualStylesMode = value };
+
+        Assert.Equal(value, control.VisualStylesMode);
+        Assert.Equal(VisualStylesMode.Classic, control.EffectiveVisualStylesModeAccessor);
+        Assert.False(control.IsHandleCreated);
+    }
+
+    [WinFormsTheory]
+    [InlineData(VisualStylesMode.Net11)]
+    [InlineData(VisualStylesMode.Latest)]
+    public void DataGridView_VisualStylesMode_InheritedModernMode_UsesClassicEffectiveMode(VisualStylesMode value)
+    {
+        using Control parent = new() { VisualStylesMode = value };
+        using SubDataGridView control = new();
+        parent.Controls.Add(control);
+
+        Assert.Equal(VisualStylesMode.Inherit, control.VisualStylesMode);
+        Assert.Equal(VisualStylesMode.Classic, control.EffectiveVisualStylesModeAccessor);
+        Assert.False(control.IsHandleCreated);
+    }
+
+    [WinFormsFact]
+    public void DataGridView_VisualStylesMode_ParentChangesToModernMode_DoesNotRaiseChanged()
+    {
+        using Control parent = new() { VisualStylesMode = VisualStylesMode.Classic };
+        using SubDataGridView control = new();
+        parent.Controls.Add(control);
+        int callCount = 0;
+        control.VisualStylesModeChanged += (sender, e) => callCount++;
+
+        parent.VisualStylesMode = VisualStylesMode.Net11;
+
+        Assert.Equal(VisualStylesMode.Classic, control.EffectiveVisualStylesModeAccessor);
+        Assert.Equal(0, callCount);
+    }
+
+    [WinFormsFact]
+    public void DataGridView_VisualStylesMode_ExplicitClassic_RemainsLocalOverride()
+    {
+        using Control parent = new() { VisualStylesMode = VisualStylesMode.Net11 };
+        using SubDataGridView control = new();
+        parent.Controls.Add(control);
+        control.VisualStylesMode = VisualStylesMode.Classic;
+
+        parent.VisualStylesMode = VisualStylesMode.Disabled;
+
+        Assert.Equal(VisualStylesMode.Classic, control.VisualStylesMode);
+        Assert.Equal(VisualStylesMode.Classic, control.EffectiveVisualStylesModeAccessor);
+    }
+
     private const int DefaultColumnHeadersHeight = 23;
 
     public static IEnumerable<object[]> ColumnHeadersHeight_Set_TestData()
@@ -2892,6 +2947,8 @@ public partial class DataGridViewTests : IDisposable
 
     private class SubDataGridView : DataGridView
     {
+        public VisualStylesMode EffectiveVisualStylesModeAccessor => base.EffectiveVisualStylesMode;
+
         public new void OnColumnHeadersHeightChanged(EventArgs e) => base.OnColumnHeadersHeightChanged(e);
 
         public new void OnColumnHeadersHeightSizeModeChanged(DataGridViewAutoSizeModeEventArgs e) => base.OnColumnHeadersHeightSizeModeChanged(e);

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewTests.cs
@@ -43,10 +43,29 @@ public partial class DataGridViewTests : IDisposable
     [InlineData(VisualStylesMode.Latest)]
     public void DataGridView_VisualStylesMode_ModernMode_UsesClassicEffectiveMode(VisualStylesMode value)
     {
+        using AppContextSwitchScope scope = new(
+            WinFormsAppContextSwitchNames.DataGridViewModernRendering,
+            enable: false);
         using SubDataGridView control = new() { VisualStylesMode = value };
 
         Assert.Equal(value, control.VisualStylesMode);
         Assert.Equal(VisualStylesMode.Classic, control.EffectiveVisualStylesModeAccessor);
+        Assert.False(control.IsHandleCreated);
+    }
+
+    [WinFormsTheory]
+    [InlineData(VisualStylesMode.Net11)]
+    [InlineData(VisualStylesMode.Latest)]
+    public void DataGridView_VisualStylesMode_ModernRenderingEnabled_UsesRequestedEffectiveMode(
+        VisualStylesMode value)
+    {
+        using AppContextSwitchScope scope = new(
+            WinFormsAppContextSwitchNames.DataGridViewModernRendering,
+            enable: true);
+        using SubDataGridView control = new() { VisualStylesMode = value };
+
+        Assert.Equal(value, control.VisualStylesMode);
+        Assert.Equal(value, control.EffectiveVisualStylesModeAccessor);
         Assert.False(control.IsHandleCreated);
     }
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripTests.cs
@@ -16,6 +16,61 @@ namespace System.Windows.Forms.Tests;
 
 public partial class ToolStripTests : IDisposable
 {
+    [WinFormsTheory]
+    [InlineData(VisualStylesMode.Net11)]
+    [InlineData(VisualStylesMode.Latest)]
+    public void ToolStrip_VisualStylesMode_ModernMode_UsesClassicEffectiveMode(VisualStylesMode value)
+    {
+        using SubToolStrip control = new() { VisualStylesMode = value };
+
+        Assert.Equal(value, control.VisualStylesMode);
+        Assert.Equal(VisualStylesMode.Classic, control.EffectiveVisualStylesModeAccessor);
+        Assert.False(control.IsHandleCreated);
+    }
+
+    [WinFormsTheory]
+    [InlineData(VisualStylesMode.Net11)]
+    [InlineData(VisualStylesMode.Latest)]
+    public void ToolStrip_VisualStylesMode_InheritedModernMode_UsesClassicEffectiveMode(VisualStylesMode value)
+    {
+        using Control parent = new() { VisualStylesMode = value };
+        using SubToolStrip control = new();
+        parent.Controls.Add(control);
+
+        Assert.Equal(VisualStylesMode.Inherit, control.VisualStylesMode);
+        Assert.Equal(VisualStylesMode.Classic, control.EffectiveVisualStylesModeAccessor);
+        Assert.False(control.IsHandleCreated);
+    }
+
+    [WinFormsFact]
+    public void ToolStrip_VisualStylesMode_ParentChangesToModernMode_DoesNotRaiseChanged()
+    {
+        using Control parent = new() { VisualStylesMode = VisualStylesMode.Classic };
+        using SubToolStrip control = new();
+        parent.Controls.Add(control);
+        int callCount = 0;
+        control.VisualStylesModeChanged += (sender, e) => callCount++;
+
+        parent.VisualStylesMode = VisualStylesMode.Net11;
+
+        Assert.Equal(VisualStylesMode.Classic, control.EffectiveVisualStylesModeAccessor);
+        Assert.Equal(0, callCount);
+    }
+
+    [WinFormsFact]
+    public void ToolStrip_VisualStylesMode_ExplicitClassic_RemainsLocalOverride()
+    {
+        using Control parent = new() { VisualStylesMode = VisualStylesMode.Net11 };
+        using SubToolStrip control = new();
+        parent.Controls.Add(control);
+        control.VisualStylesMode = VisualStylesMode.Classic;
+
+        parent.VisualStylesMode = VisualStylesMode.Disabled;
+
+        Assert.Equal(VisualStylesMode.Classic, control.VisualStylesMode);
+        Assert.Equal(VisualStylesMode.Classic, control.EffectiveVisualStylesModeAccessor);
+    }
+
     [WinFormsFact]
     public void ToolStrip_Ctor_Default()
     {
@@ -7536,6 +7591,8 @@ public partial class ToolStripTests : IDisposable
         public new bool CanEnableIme => base.CanEnableIme;
 
         public new bool CanRaiseEvents => base.CanRaiseEvents;
+
+        public VisualStylesMode EffectiveVisualStylesModeAccessor => base.EffectiveVisualStylesMode;
 
         public new CreateParams CreateParams => base.CreateParams;
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripTests.cs
@@ -21,11 +21,32 @@ public partial class ToolStripTests : IDisposable
     [InlineData(VisualStylesMode.Latest)]
     public void ToolStrip_VisualStylesMode_ModernMode_UsesClassicEffectiveMode(VisualStylesMode value)
     {
+        using AppContextSwitchScope scope = new(
+            WinFormsAppContextSwitchNames.ToolStripModernRendering,
+            enable: false);
         using SubToolStrip control = new() { VisualStylesMode = value };
 
         Assert.Equal(value, control.VisualStylesMode);
         Assert.Equal(VisualStylesMode.Classic, control.EffectiveVisualStylesModeAccessor);
         Assert.False(control.IsHandleCreated);
+    }
+
+    [WinFormsTheory]
+    [InlineData(VisualStylesMode.Net11)]
+    [InlineData(VisualStylesMode.Latest)]
+    public void ToolStrip_VisualStylesMode_ModernRenderingEnabled_UsesRequestedEffectiveMode(
+        VisualStylesMode value)
+    {
+        using AppContextSwitchScope scope = new(
+            WinFormsAppContextSwitchNames.ToolStripModernRendering,
+            enable: true);
+        using SubToolStrip toolStrip = new() { VisualStylesMode = value };
+        using SubMenuStripWithVisualStyles menuStrip = new() { VisualStylesMode = value };
+
+        Assert.Equal(value, toolStrip.EffectiveVisualStylesModeAccessor);
+        Assert.Equal(value, menuStrip.EffectiveVisualStylesModeAccessor);
+        Assert.False(toolStrip.IsHandleCreated);
+        Assert.False(menuStrip.IsHandleCreated);
     }
 
     [WinFormsTheory]
@@ -7566,6 +7587,14 @@ public partial class ToolStripTests : IDisposable
         public new ToolStripItemCollection DisplayedItems => base.DisplayedItems;
 
         public new bool ProcessDialogChar(char charCode) => base.ProcessDialogChar(charCode);
+    }
+
+    /// <summary>
+    ///  Exposes the effective visual styles mode for MenuStrip tests.
+    /// </summary>
+    private sealed class SubMenuStripWithVisualStyles : MenuStrip
+    {
+        public VisualStylesMode EffectiveVisualStylesModeAccessor => base.EffectiveVisualStylesMode;
     }
 
     private class SubToolStrip : ToolStrip

--- a/src/test/util/System.Windows.Forms/WinFormsAppContextSwitchNames.cs
+++ b/src/test/util/System.Windows.Forms/WinFormsAppContextSwitchNames.cs
@@ -50,4 +50,16 @@ public static class WinFormsAppContextSwitchNames
     /// </summary>
     public const string TreeNodeCollectionAddRangeRespectsSortOrder
         = "System.Windows.Forms.TreeNodeCollectionAddRangeRespectsSortOrder";
+
+    /// <summary>
+    ///  The switch that controls whether ToolStrip controls, including MenuStrip, use modern rendering.
+    /// </summary>
+    public const string ToolStripModernRendering
+        = "System.Windows.Forms.ToolStripModernRendering";
+
+    /// <summary>
+    ///  The switch that controls whether DataGridView controls use modern rendering.
+    /// </summary>
+    public const string DataGridViewModernRendering
+        = "System.Windows.Forms.DataGridViewModernRendering";
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #15031


## Proposed changes

- Fall back to Classic rendering for ToolStrip, MenuStrip, and DataGridView when Net11 visual styles are requested.
- Add AppContext switches to opt these controls into Net11 rendering:

>  -  System.Windows.Forms.ToolStripModernRendering
>  -  System.Windows.Forms.DataGridViewModernRendering

- Preserve visual-style inheritance and change-notification behavior for coerced modes.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- ToolStrip, MenuStrip, and DataGridView use stable Classic rendering by default until their Net11 layout modernization is complete.
- Applications can opt into Net11 rendering through the corresponding AppContext switches.
- Existing applications retain their current behavior unless explicitly opted in.

## Regression? 

- No

## Risk

- Mini

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<img width="800" height="265" alt="image" src="https://github.com/user-attachments/assets/9d0b239e-df65-4191-a6f0-436edab7170a" />

### After

https://github.com/user-attachments/assets/b37cde39-50ab-4b9d-92c9-68aff05cbc8f

https://github.com/user-attachments/assets/be5781ff-64a4-46ec-826b-1779bfedc996



## Test methodology <!-- How did you ensure quality? -->

- Manually
- Automated test cases

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.0-preview.7.26381.103


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/15033)