### PR TITLE
Fix Issue 14167: [HDPI] Cursor editor some items are not displayed in propertyGrid with special DPI settings

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/CursorEditor.CursorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/CursorEditor.CursorUI.cs
@@ -41,7 +41,7 @@ public partial class CursorEditor
                 }
             }
 
-            _cursorWidth = GetCursorWidthForDpi(Cursors.Default, DeviceDpi);
+            RecalculateCursorWidth(DeviceDpi);
         }
 
         public object? Value { get; private set; }
@@ -50,7 +50,17 @@ public partial class CursorEditor
         {
             _editorService = null;
             Value = null;
-            _cursorWidthCache.Clear();
+            ClearCursorCaches();
+        }
+
+        protected override void OnVisibleChanged(EventArgs e)
+        {
+            base.OnVisibleChanged(e);
+
+            if (Visible && IsHandleCreated)
+            {
+                BeginInvoke((MethodInvoker)ForceRedrawVisibleItems);
+            }
         }
 
         protected override void OnClick(EventArgs e)
@@ -75,7 +85,17 @@ public partial class CursorEditor
                 e.Graphics.FillRectangle(SystemBrushes.Control, new Rectangle(e.Bounds.X + 2, e.Bounds.Y + 2, _cursorWidth, e.Bounds.Height - 4));
                 e.Graphics.DrawRectangle(SystemPens.WindowText, new Rectangle(e.Bounds.X + 2, e.Bounds.Y + 2, _cursorWidth - 1, e.Bounds.Height - 4 - 1));
 
-                cursor.DrawStretched(e.Graphics, new Rectangle(e.Bounds.X + 2, e.Bounds.Y + 2, _cursorWidth, e.Bounds.Height - 4));
+                using (DeviceContextHdcScope dc = new(e.Graphics, applyGraphicsState: false))
+                {
+                    PInvokeCore.DrawIconEx(
+                        (HDC)dc,
+                        e.Bounds.X + 2,
+                        e.Bounds.Y + 2,
+                        cursor,
+                        _cursorWidth,
+                        e.Bounds.Height - 4);
+                }
+
                 e.Graphics.DrawString(text, font, brushText, e.Bounds.X + _cursorWidth + 4, e.Bounds.Y + (e.Bounds.Height - font.Height) / 2);
             }
         }
@@ -113,6 +133,9 @@ public partial class CursorEditor
             _editorService = editorService;
             Value = value;
 
+            // Rebuild width/cache for every drop-down session so owner-draw rows are ready on first paint.
+            RecalculateCursorWidth(DeviceDpi);
+
             // Select the current cursor
             if (value is not null)
             {
@@ -125,14 +148,46 @@ public partial class CursorEditor
                     }
                 }
             }
+
+            Invalidate();
+            Update();
+        }
+
+        private void ForceRedrawVisibleItems()
+        {
+            if (!IsDisposed && IsHandleCreated && Visible)
+            {
+                Invalidate();
+                Update();
+            }
+        }
+
+        private void ClearCursorCaches()
+        {
+            _cursorWidthCache.Clear();
+        }
+
+        private void RecalculateCursorWidth(int dpi)
+        {
+            int cursorWidth = GetCursorWidthForDpi(Cursors.Default, dpi);
+
+            foreach (object item in Items)
+            {
+                if (item is Cursor cursor)
+                {
+                    cursorWidth = Math.Max(cursorWidth, GetCursorWidthForDpi(cursor, dpi));
+                }
+            }
+
+            _cursorWidth = cursorWidth;
         }
 
         protected override void RescaleConstantsForDpi(int deviceDpiOld, int deviceDpiNew)
         {
             base.RescaleConstantsForDpi(deviceDpiOld, deviceDpiNew);
 
-            // Recalculate the representative width using the new DPI; all rows continue to share it to avoid the layout issues seen in #14167.
-            _cursorWidth = GetCursorWidthForDpi(Cursors.Default, deviceDpiNew);
+            // Recalculate the shared column width using the new DPI and the widest standard cursor.
+            RecalculateCursorWidth(deviceDpiNew);
             Invalidate();
         }
     }

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/CursorEditor.CursorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/CursorEditor.CursorUI.cs
@@ -85,7 +85,7 @@ public partial class CursorEditor
                 e.Graphics.FillRectangle(SystemBrushes.Control, new Rectangle(e.Bounds.X + 2, e.Bounds.Y + 2, _cursorWidth, e.Bounds.Height - 4));
                 e.Graphics.DrawRectangle(SystemPens.WindowText, new Rectangle(e.Bounds.X + 2, e.Bounds.Y + 2, _cursorWidth - 1, e.Bounds.Height - 4 - 1));
 
-                using (DeviceContextHdcScope dc = new(e.Graphics, applyGraphicsState: false))
+                using (DeviceContextHdcScope dc = new(e, applyGraphicsState: false))
                 {
                     PInvokeCore.DrawIconEx(
                         (HDC)dc,

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/CursorEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/CursorEditorTests.cs
@@ -112,14 +112,14 @@ public class CursorEditorTests
         MethodInfo startMethod = type.GetMethod("Start", BindingFlags.Public | BindingFlags.Instance)!;
 
         IDictionary cache = (IDictionary)cursorWidthCacheField.GetValue(cursorUI)!;
-        Assert.NotEqual(0, cache.Count);
+        Assert.NotEmpty(cache);
 
         endMethod.Invoke(cursorUI, null);
-        Assert.Equal(0, cache.Count);
+        Assert.Empty(cache);
 
         Mock<IWindowsFormsEditorService> mockEditorService = new(MockBehavior.Strict);
         startMethod.Invoke(cursorUI, [mockEditorService.Object, Cursors.Default]);
-        Assert.NotEqual(0, cache.Count);
+        Assert.NotEmpty(cache);
     }
 
     [WinFormsFact]

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/CursorEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/CursorEditorTests.cs
@@ -4,6 +4,8 @@
 #nullable disable
 
 using System.ComponentModel;
+using System.Collections;
+using System.Reflection;
 using System.Windows.Forms.Design;
 using System.Windows.Forms.TestUtilities;
 using Moq;
@@ -73,5 +75,76 @@ public class CursorEditorTests
     {
         CursorEditor editor = new();
         Assert.False(editor.GetPaintValueSupported(context));
+    }
+
+    [WinFormsFact]
+    public void CursorEditor_CursorUI_CursorWidth_UsesWidestStandardCursor()
+    {
+        Type type = typeof(CursorEditor).GetNestedType("CursorUI", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        using ListBox cursorUI = (ListBox)Activator.CreateInstance(type)!;
+        int dpi = cursorUI.DeviceDpi;
+
+        MethodInfo getCursorWidthForDpiMethod = type.GetMethod("GetCursorWidthForDpi", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        FieldInfo cursorWidthField = type.GetField("_cursorWidth", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        int expectedWidth = 0;
+        foreach (object item in cursorUI.Items)
+        {
+            if (item is Cursor cursor)
+            {
+                int width = (int)getCursorWidthForDpiMethod.Invoke(cursorUI, [cursor, dpi])!;
+                expectedWidth = Math.Max(expectedWidth, width);
+            }
+        }
+
+        Assert.NotEqual(0, expectedWidth);
+        Assert.Equal(expectedWidth, (int)cursorWidthField.GetValue(cursorUI)!);
+    }
+
+    [WinFormsFact]
+    public void CursorEditor_CursorUI_Start_RebuildsCursorWidthCache()
+    {
+        Type type = typeof(CursorEditor).GetNestedType("CursorUI", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        using ListBox cursorUI = (ListBox)Activator.CreateInstance(type)!;
+
+        FieldInfo cursorWidthCacheField = type.GetField("_cursorWidthCache", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        MethodInfo endMethod = type.GetMethod("End", BindingFlags.Public | BindingFlags.Instance)!;
+        MethodInfo startMethod = type.GetMethod("Start", BindingFlags.Public | BindingFlags.Instance)!;
+
+        IDictionary cache = (IDictionary)cursorWidthCacheField.GetValue(cursorUI)!;
+        Assert.NotEqual(0, cache.Count);
+
+        endMethod.Invoke(cursorUI, null);
+        Assert.Equal(0, cache.Count);
+
+        Mock<IWindowsFormsEditorService> mockEditorService = new(MockBehavior.Strict);
+        startMethod.Invoke(cursorUI, [mockEditorService.Object, Cursors.Default]);
+        Assert.NotEqual(0, cache.Count);
+    }
+
+    [WinFormsFact]
+    public void CursorEditor_CursorUI_OnDrawItem_RestoresGraphicsClip()
+    {
+        Type type = typeof(CursorEditor).GetNestedType("CursorUI", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        using ListBox cursorUI = (ListBox)Activator.CreateInstance(type)!;
+        MethodInfo onDrawItemMethod = type.GetMethod("OnDrawItem", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        using Bitmap image = new(600, 400);
+        using Graphics graphics = Graphics.FromImage(image);
+        graphics.SetClip(new Rectangle(10, 10, 580, 380));
+        Rectangle initialClipBounds = Rectangle.Round(graphics.ClipBounds);
+
+        using DrawItemEventArgs args = new(
+            graphics,
+            SystemFonts.DefaultFont,
+            new Rectangle(0, 0, 500, cursorUI.ItemHeight),
+            index: 0,
+            DrawItemState.Default,
+            SystemColors.WindowText,
+            SystemColors.Window);
+
+        onDrawItemMethod.Invoke(cursorUI, [args]);
+
+        Assert.Equal(initialClipBounds, Rectangle.Round(graphics.ClipBounds));
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #14167

## Root Cause
The issue with the CurSor icon offset was introduced by #14575. CursorEditor.CursorUI uses a "uniform icon column width" when drawing Cursor dropdowns, but this width is only calculated based on Cursors.Default.

At high DPI or with certain cursors (such as NoMove2D / NoMoveHoriz / NoMoveVert / HSplit / VSplit), the actual drawn width may be greater than this column width, causing icons to go out of bounds, overlap with text areas, or appear truncated.


## Proposed changes
The calculation logic for shared icon column width has been changed from "only Cursors.Default" to "the maximum width of all standard Cursors at the current DPI":
- During initialization and DPI changes, the standard Cursor set is traversed and the maximum scaling width is calculated.
- This maximum value is used as the unified `_cursorWidth` to draw each row, maintaining consistent column alignment.
- The existing caching mechanism is retained to avoid the drawing overhead caused by repeated scaling calculations.
- Regression tests are added to verify that `_cursorWidth` equals the maximum width in the standard Cursor set.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Fixed the issue of out-of-bounds/overlapping Cursor drop-down list icons under high DPI.
- All Cursor items maintain consistent icon column width and text alignment when first displayed.
- Improved PropertyGrid design-time experience to reduce visual anomalies and misjudgments as resource loading failures.

## Regression? 

- Yes

## Risk

- Mini

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<img width="390" height="640" alt="image" src="https://github.com/user-attachments/assets/310a3be2-b9f3-4340-8eef-197436fda419" />

### After

**125%**

https://github.com/user-attachments/assets/acf46bd0-b2eb-427d-b15c-9f8aba51d0bf

**150%**

https://github.com/user-attachments/assets/e6d3fd64-e104-4596-ba18-46557503abdf


**175%**

https://github.com/user-attachments/assets/ad1ed6ac-ebbb-4a74-a332-d7d806f8c86f


**225%**

https://github.com/user-attachments/assets/12dabaef-e5b1-4502-8e5b-9f0c253fddbe

**350%**

https://github.com/user-attachments/assets/96070e29-4be4-4e3b-a752-196de77a1ecc


## Test methodology <!-- How did you ensure quality? -->

- Manual
- Automation Test 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- 11.0.0-preview.7.26381.103


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/15049)