### PR TITLE
Fix ListView Details view cell retrieval and full-row accessibility

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.ListViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.ListViewAccessibleObject.cs
@@ -179,6 +179,22 @@ public partial class ListView
             return columnHeaders;
         }
 
+        internal override IRawElementProviderSimple.Interface? GetItem(int row, int column)
+        {
+            if (!this.TryGetOwnerAs(out ListView? owningListView)
+                || owningListView.View != View.Details
+                || row < 0
+                || row >= owningListView.Items.Count
+                || column < 0
+                || column >= owningListView.Columns.Count
+                || owningListView.Items[row].AccessibilityObject is not ListViewItem.ListViewItemDetailsAccessibleObject itemAccessibleObject)
+            {
+                return null;
+            }
+
+            return itemAccessibleObject.GetChild(column + itemAccessibleObject.FirstSubItemIndex);
+        }
+
         internal override IRawElementProviderFragment.Interface? GetFocus()
             => !this.IsOwnerHandleCreated(out ListView? owningListView)
                 ? null

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListViewItem.ListViewItemDetailsAccessibleObject.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListViewItem.ListViewItemDetailsAccessibleObject.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
+using System.Text;
 using Windows.Win32.UI.Accessibility;
 
 namespace System.Windows.Forms;
@@ -22,10 +23,37 @@ public partial class ListViewItem
 
         private int LastChildIndex => HasImage ? _owningListView.Columns.Count : _owningListView.Columns.Count - 1;
 
-        public override string? Name => !_owningListView.FullRowSelect
-            ? base.Name
-            : string.Join(", ", Enumerable.Range(0, _owningListView.Columns.Count)
-                .Select(column => GetChild(column + FirstSubItemIndex)?.Name));
+        public override string? Name
+        {
+            get
+            {
+                if (!_owningListView.FullRowSelect
+                    || !_owningListView.SupportsListViewSubItems
+                    || _owningListView.Columns.Count == 0)
+                {
+                    return base.Name;
+                }
+
+                StringBuilder name = new();
+                for (int columnIndex = 0; columnIndex < _owningListView.Columns.Count; columnIndex++)
+                {
+                    int subItemIndex = _owningListView.Columns[columnIndex]._correspondingListViewSubItemIndex;
+                    if (subItemIndex < 0 || subItemIndex >= _owningItem.SubItems.Count)
+                    {
+                        continue;
+                    }
+
+                    if (name.Length > 0)
+                    {
+                        name.Append(", ");
+                    }
+
+                    name.Append(_owningItem.SubItems[subItemIndex].AccessibilityObject?.Name);
+                }
+
+                return name.Length > 0 ? name.ToString() : base.Name;
+            }
+        }
 
         protected override View View => View.Details;
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListViewItem.ListViewItemDetailsAccessibleObject.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListViewItem.ListViewItemDetailsAccessibleObject.cs
@@ -22,6 +22,11 @@ public partial class ListViewItem
 
         private int LastChildIndex => HasImage ? _owningListView.Columns.Count : _owningListView.Columns.Count - 1;
 
+        public override string? Name => !_owningListView.FullRowSelect
+            ? base.Name
+            : string.Join(", ", Enumerable.Range(0, _owningListView.Columns.Count)
+                .Select(column => GetChild(column + FirstSubItemIndex)?.Name));
+
         protected override View View => View.Details;
 
         /// <summary>

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/ListVIew.ListViewAccessibleObjectTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/ListVIew.ListViewAccessibleObjectTests.cs
@@ -202,6 +202,38 @@ public class ListView_ListViewAccessibleObjectTests
         Assert.False(listView.IsHandleCreated);
     }
 
+    [WinFormsTheory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ListViewAccessibleObject_GetItem_DetailsView_ReturnsSubItem(bool hasImage)
+    {
+        using ImageList imageList = new();
+        imageList.Images.Add(Form.DefaultIcon);
+        using ListView listView = new()
+        {
+            SmallImageList = imageList,
+            View = View.Details
+        };
+
+        listView.Columns.AddRange((ColumnHeader[])[new("Title"), new("Position")]);
+        ListViewItem item = new(["Item 1", "Position 1"], hasImage ? 0 : -1);
+        listView.Items.Add(item);
+        listView.CreateControl();
+
+        AccessibleObject actual = (AccessibleObject)listView.AccessibilityObject.GetItem(0, 1);
+
+        Assert.Same(item.SubItems[1].AccessibilityObject, actual);
+        Assert.Equal("Position 1", actual.Name);
+        Assert.Equal(
+            UIA_CONTROLTYPE_ID.UIA_TextControlTypeId,
+            (UIA_CONTROLTYPE_ID)(int)actual.GetPropertyValue(UIA_PROPERTY_ID.UIA_ControlTypePropertyId));
+        Assert.Null(listView.AccessibilityObject.GetItem(-1, 0));
+        Assert.Null(listView.AccessibilityObject.GetItem(0, -1));
+        Assert.Null(listView.AccessibilityObject.GetItem(1, 0));
+        Assert.Null(listView.AccessibilityObject.GetItem(0, 2));
+        Assert.True(listView.IsHandleCreated);
+    }
+
     [WinFormsFact]
     public void ListViewAccessibleObject_GetPropertyValue_returns_correct_values()
     {

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/ListViewItem.ListViewItemDetailsAccessibleObjectTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/ListViewItem.ListViewItemDetailsAccessibleObjectTests.cs
@@ -18,6 +18,42 @@ public class ListViewItem_ListViewItemDetailsAccessibleObjectTests
     }
 
     [WinFormsFact]
+    public void ListViewItemDetailsAccessibleObject_Name_FullRowSelect_ReturnsAllColumnValues()
+    {
+        using ListView control = new()
+        {
+            FullRowSelect = true,
+            View = View.Details
+        };
+
+        control.Columns.AddRange((ColumnHeader[])[new(), new(), new()]);
+        ListViewItem item = new(["Item", "Value 1", "Value 2"]);
+        control.Items.Add(item);
+
+        AccessibleObject accessibleObject = item.AccessibilityObject;
+
+        Assert.Equal("Item, Value 1, Value 2", accessibleObject.Name);
+        Assert.Empty(accessibleObject.TestAccessor.Dynamic._listViewSubItemAccessibleObjects);
+        Assert.False(control.IsHandleCreated);
+    }
+
+    [WinFormsFact]
+    public void ListViewItemDetailsAccessibleObject_Name_FullRowSelectWithoutColumns_ReturnsItemText()
+    {
+        using ListView control = new()
+        {
+            FullRowSelect = true,
+            View = View.Details
+        };
+
+        ListViewItem item = new("Item");
+        control.Items.Add(item);
+
+        Assert.Equal("Item", item.AccessibilityObject.Name);
+        Assert.False(control.IsHandleCreated);
+    }
+
+    [WinFormsFact]
     public void ListViewItemDetailsAccessibleObject_FragmentNavigate_FirstChild_ReturnsExpected()
     {
         using ListView control = new() { View = View.Details };


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #15044

## Root Cause

ListView in Details view advertises UIA Grid and Table patterns but did not override `GridPattern.GetItem(row, column)`. The base implementation returned null, even though the corresponding cell existed in the UIA tree.

Additionally, full-row mouse hit testing returned individual cells while selection events targeted the row, resulting in incomplete announcements.

## Proposed changes

- Implement `GridPattern.GetItem(row, column)` for `ListView` in Details view so it returns the correct cell accessible object. 
- For full-row selection, expose all column values through the row accessible name.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- JAWS, NVDA, Narrator, and other UIA clients can correctly read and navigate every column in Details-mode ListViews. 

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
`GridPattern.GetItem()` returned an empty provider. Screen readers generally announced only the first column.

**Accessibility Insights:**

https://github.com/user-attachments/assets/4fef8769-203c-4244-9224-606af59f1a7f

**NVDA：**
<img width="1082" height="620" alt="NVDA_beforeChange" src="https://github.com/user-attachments/assets/7e7bc21e-2763-439b-a7ce-2e6f2d90ac5c" />

**Narrator：**
<img width="1582" height="485" alt="Narrator_beforeChanges" src="https://github.com/user-attachments/assets/3ccdc2c6-ab4a-47a0-a795-672fd2961d00" />


### After
`GridPattern.GetItem(row, column)` returns the correct cell accessible object. Screen readers can read all columns in a Details-view ListView. 

**Accessibility Insights:**

https://github.com/user-attachments/assets/3d9094b9-5e23-492c-84d1-021c58de3dc4

**NVDA：**
<img width="1480" height="629" alt="NVDA_AfterChange" src="https://github.com/user-attachments/assets/1568a334-3724-4822-b2d0-43ea58a35787" />

**Narrator：**
<img width="2296" height="915" alt="Narrator_AfterChang" src="https://github.com/user-attachments/assets/1a50d29d-6943-4c76-8924-4f21adb1fab0" />

## Test methodology <!-- How did you ensure quality? -->

- Unit test and manual test

## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-beta.26453.118


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/15056)