### PR TITLE
Fix TextBox UI Automation fragment root

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/TextBox/TextBoxBase.TextBoxBaseAccessibleObject.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/TextBox/TextBoxBase.TextBoxBaseAccessibleObject.cs
@@ -45,6 +45,9 @@ public abstract partial class TextBoxBase
 
         internal override bool IsIAccessibleExSupported() => true;
 
+        internal override IRawElementProviderFragmentRoot.Interface? FragmentRoot
+            => this;
+
         internal override bool IsPatternSupported(UIA_PATTERN_ID patternId)
             => patternId switch
             {

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/TextBoxBaseAccessibleObjectTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/TextBoxBaseAccessibleObjectTests.cs
@@ -24,6 +24,28 @@ public class TextBoxBaseAccessibleObjectTests
     }
 
     [WinFormsTheory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public unsafe void TextBoxBaseAccessibleObject_FragmentRoot_ReturnsOwnObject(bool createControl)
+    {
+        using TextBoxBase textBoxBase = new SubTextBoxBase();
+
+        if (createControl)
+        {
+            textBoxBase.CreateControl();
+        }
+
+        AccessibleObject accessibleObject = textBoxBase.AccessibilityObject;
+
+        using ComScope<IRawElementProviderFragmentRoot> actual = new(null);
+        Assert.True(((IRawElementProviderFragment.Interface)accessibleObject).get_FragmentRoot(actual).Succeeded);
+
+        Assert.Equal(accessibleObject, ComHelpers.GetObjectForIUnknown(actual));
+        Assert.Same(accessibleObject, accessibleObject.FragmentRoot);
+        Assert.Equal(createControl, textBoxBase.IsHandleCreated);
+    }
+
+    [WinFormsTheory]
     [InlineData((int)UIA_PROPERTY_ID.UIA_IsTextPatternAvailablePropertyId)]
     [InlineData((int)UIA_PROPERTY_ID.UIA_IsTextPattern2AvailablePropertyId)]
     [InlineData((int)UIA_PROPERTY_ID.UIA_IsValuePatternAvailablePropertyId)]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/ToolStripControlHost.ToolStripHostedControlAccessibleObjectTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/ToolStripControlHost.ToolStripHostedControlAccessibleObjectTests.cs
@@ -65,7 +65,7 @@ public class ToolStripControlHost_ToolStripHostedControlAccessibleObjectTests : 
             new(_textBox, null);
         IRawElementProviderFragmentRoot.Interface fragmentRoot = accessibleObject.FragmentRoot;
 
-        fragmentRoot.Should().BeNull();
+        fragmentRoot.Should().Be(_textBox.AccessibilityObject.FragmentRoot);
     }
 
     [WinFormsFact]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/ToolStripControlHost.ToolStripHostedControlAccessibleObjectTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/AccessibleObjects/ToolStripControlHost.ToolStripHostedControlAccessibleObjectTests.cs
@@ -65,7 +65,7 @@ public class ToolStripControlHost_ToolStripHostedControlAccessibleObjectTests : 
             new(_textBox, null);
         IRawElementProviderFragmentRoot.Interface fragmentRoot = accessibleObject.FragmentRoot;
 
-        fragmentRoot.Should().Be(_textBox.AccessibilityObject.FragmentRoot);
+        fragmentRoot.Should().BeNull();
     }
 
     [WinFormsFact]


### PR DESCRIPTION
Fixes #15043


## Proposed changes

- Return the TextBoxBaseAccessibleObject as its own UI Automation fragment root.
- Prevent IRawElementProviderFragment.get_FragmentRoot from returning S_OK with a null provider for text controls.
- Add COM-level regression coverage before and after control handle creation.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Prevents UI Automation clients from receiving an invalid null fragment root from TextBox, MaskedTextBox, and UpDown edit controls.
- Prevents the application hangs reported when JAWS invokes TextPattern.RangeFromPoint.

## Regression? 

- No

## Risk

- Low

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

- Added a COM-level test verifying that get_FragmentRoot returns S_OK with a valid provider.
- Verified the fragment root before and after control handle creation.
- Ran all TextBoxBaseAccessibleObjectTests: 83 passed.
- Ran the related ToolStrip fragment-root tests: 53 passed.

## Test environment(s) 

- .NET SDK 11.0.100-preview.6.26359.118

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/15058)