### PR TITLE
Fix ToolStripManager restore issue when ToolStripPanel padding is asymmetric

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripPanel.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripPanel.cs
@@ -858,7 +858,7 @@ public partial class ToolStripPanel : ContainerControl, IArrangedElement
                 if (Orientation == Orientation.Horizontal)
                 {
                     // If it's above the first row, insert at the front.
-                    index = (clientLocation.Y <= Padding.Left) ? 0 : index;
+                    index = (clientLocation.Y <= Padding.Top) ? 0 : index;
                 }
                 else
                 {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelRow.HorizontalRowManager.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelRow.HorizontalRowManager.cs
@@ -445,8 +445,7 @@ public partial class ToolStripPanelRow
                         int requiredSpace = controlToDragWidth;
                         if (index == 0)
                         {
-                            // make sure we account for the left side
-                            requiredSpace += locationToDrag.X;
+                            requiredSpace += Math.Max(0, locationToDrag.X - Row.Margin.Left - ToolStripPanel.Padding.Left);
                         }
 
                         int freedSpace = 0;
@@ -540,7 +539,7 @@ public partial class ToolStripPanelRow
                             if (cell is not null)
                             {
                                 Padding cellMargin = cell.Margin;
-                                cellMargin.Left = Math.Max(0, locationToDrag.X - Row.Margin.Left);
+                                cellMargin.Left = Math.Max(0, locationToDrag.X - Row.Margin.Left - ToolStripPanel.Padding.Left);
                                 cell.Margin = cellMargin;
                             }
                         }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelRow.VerticalRowManager.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelRow.VerticalRowManager.cs
@@ -452,8 +452,7 @@ public partial class ToolStripPanelRow
 
                         if (index == 0)
                         {
-                            // make sure we account for the left side
-                            requiredSpace += locationToDrag.Y;
+                            requiredSpace += Math.Max(0, locationToDrag.Y - Row.Margin.Top - ToolStripPanel.Padding.Top);
                         }
 
                         int freedSpace = 0;
@@ -544,7 +543,7 @@ public partial class ToolStripPanelRow
                             if (cell is not null)
                             {
                                 Padding cellMargin = cell.Margin;
-                                cellMargin.Top = Math.Max(0, locationToDrag.Y - Row.Margin.Top);
+                                cellMargin.Top = Math.Max(0, locationToDrag.Y - Row.Margin.Top - ToolStripPanel.Padding.Top);
                                 cell.Margin = cellMargin;
                             }
                         }

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripPanelTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripPanelTests.cs
@@ -354,6 +354,228 @@ public class ToolStripPanelTests
         Assert.Null(exception);
     }
 
+    [WinFormsFact]
+    public void ToolStripPanel_Join_Horizontal_NewRowBoundary_UsesPaddingTop_NotPaddingLeft()
+    {
+        using Form form = new()
+        {
+            ClientSize = new Size(600, 200)
+        };
+        using ToolStripPanel panel = new()
+        {
+            Dock = DockStyle.Top,
+            Padding = new Padding(left: 300, top: 5, right: 300, bottom: 0)
+        };
+        using ToolStrip toolStrip1 = new();
+        using ToolStrip toolStrip2 = new();
+        toolStrip1.Items.Add(new ToolStripButton("Btn1"));
+        toolStrip2.Items.Add(new ToolStripButton("Btn2"));
+
+        form.Controls.Add(panel);
+        form.Show();
+
+        Assert.Equal(Orientation.Horizontal, panel.Orientation);
+
+        panel.Join(toolStrip1, new Point(0, 0));
+        panel.PerformLayout();
+        Application.DoEvents();
+
+        int secondRowY = toolStrip1.Bottom + 5;
+        Assert.InRange(secondRowY, panel.Padding.Top + 1, panel.Padding.Left - 1);
+
+        panel.Join(toolStrip2, new Point(0, secondRowY));
+        panel.PerformLayout();
+        Application.DoEvents();
+
+        Assert.True(toolStrip2.Top >= toolStrip1.Bottom);
+    }
+
+    [WinFormsFact]
+    public void ToolStripPanel_Join_Horizontal_RightToLeft_NewRowBoundary_UsesPaddingTop_NotPaddingLeft()
+    {
+        using Form form = new()
+        {
+            ClientSize = new Size(600, 200),
+            RightToLeft = RightToLeft.Yes
+        };
+        using ToolStripPanel panel = new()
+        {
+            Dock = DockStyle.Top,
+            RightToLeft = RightToLeft.Yes,
+            Padding = new Padding(left: 300, top: 5, right: 300, bottom: 0)
+        };
+        using ToolStrip toolStrip1 = new();
+        using ToolStrip toolStrip2 = new();
+        toolStrip1.Items.Add(new ToolStripButton("Btn1"));
+        toolStrip2.Items.Add(new ToolStripButton("Btn2"));
+
+        form.Controls.Add(panel);
+        form.Show();
+
+        panel.Join(toolStrip1, new Point(0, 0));
+        panel.PerformLayout();
+        Application.DoEvents();
+
+        int secondRowY = toolStrip1.Bottom + 5;
+        Assert.InRange(secondRowY, panel.Padding.Top + 1, panel.Padding.Left - 1);
+
+        panel.Join(toolStrip2, new Point(0, secondRowY));
+        panel.PerformLayout();
+        Application.DoEvents();
+
+        Assert.True(toolStrip2.Top >= toolStrip1.Bottom);
+    }
+
+    [WinFormsFact]
+    public void ToolStripPanel_Join_Vertical_NewRowBoundary_UsesPaddingLeft_NotPaddingTop()
+    {
+        using Form form = new()
+        {
+            ClientSize = new Size(200, 600)
+        };
+        using ToolStripPanel panel = new()
+        {
+            Dock = DockStyle.Left,
+            Padding = new Padding(left: 5, top: 300, right: 0, bottom: 300)
+        };
+        using ToolStrip toolStrip1 = new();
+        using ToolStrip toolStrip2 = new();
+        toolStrip1.Items.Add(new ToolStripButton("Btn1"));
+        toolStrip2.Items.Add(new ToolStripButton("Btn2"));
+
+        form.Controls.Add(panel);
+        form.Show();
+
+        Assert.Equal(Orientation.Vertical, panel.Orientation);
+
+        panel.Join(toolStrip1, new Point(0, 0));
+        panel.PerformLayout();
+        Application.DoEvents();
+
+        int secondColumnX = toolStrip1.Right + 5;
+        Assert.InRange(secondColumnX, panel.Padding.Left + 1, panel.Padding.Top - 1);
+
+        panel.Join(toolStrip2, new Point(secondColumnX, 0));
+        panel.PerformLayout();
+        Application.DoEvents();
+
+        Assert.True(toolStrip2.Left >= toolStrip1.Right);
+    }
+
+    [WinFormsFact]
+    public void ToolStripPanel_Join_Horizontal_InsertBeforeExistingControlInRow_UsesRequestedLocation_NotShiftedByPaddingLeft()
+    {
+        using Form form = new() { ClientSize = new Size(600, 200) };
+        using ToolStripPanel panel = new()
+        {
+            Dock = DockStyle.Top,
+            Padding = new Padding(left: 4, top: 0, right: 4, bottom: 0)
+        };
+        using ToolStrip toolStrip1 = new() { Size = new Size(50, 25) };
+        using ToolStrip toolStrip2 = new() { Size = new Size(50, 25) };
+        toolStrip1.Items.Add(new ToolStripButton("Btn1"));
+        toolStrip2.Items.Add(new ToolStripButton("Btn2"));
+
+        form.Controls.Add(panel);
+        form.Show();
+
+        panel.Join(toolStrip2, new Point(20, 0));
+        panel.PerformLayout();
+        Application.DoEvents();
+
+        Point requestedLocation = new(10, 0);
+        panel.Join(toolStrip1, requestedLocation);
+        panel.PerformLayout();
+        Application.DoEvents();
+
+        Assert.Single(panel.RowsInternal);
+        Assert.Equal(requestedLocation, toolStrip1.Location);
+        Assert.True(toolStrip2.Left >= toolStrip1.Right);
+    }
+
+    [WinFormsFact]
+    public void ToolStripPanel_Join_Vertical_InsertBeforeExistingControlInColumn_UsesRequestedLocation_NotShiftedByPaddingTop()
+    {
+        using Form form = new() { ClientSize = new Size(200, 600) };
+        using ToolStripPanel panel = new()
+        {
+            Dock = DockStyle.Left,
+            Padding = new Padding(left: 0, top: 4, right: 0, bottom: 4)
+        };
+        using ToolStrip toolStrip1 = new() { Size = new Size(25, 50) };
+        using ToolStrip toolStrip2 = new() { Size = new Size(25, 50) };
+        toolStrip1.Items.Add(new ToolStripButton("Btn1"));
+        toolStrip2.Items.Add(new ToolStripButton("Btn2"));
+
+        form.Controls.Add(panel);
+        form.Show();
+
+        panel.Join(toolStrip2, new Point(0, 20));
+        panel.PerformLayout();
+        Application.DoEvents();
+
+        Point requestedLocation = new(0, 10);
+        panel.Join(toolStrip1, requestedLocation);
+        panel.PerformLayout();
+        Application.DoEvents();
+
+        Assert.Single(panel.RowsInternal);
+        Assert.Equal(requestedLocation, toolStrip1.Location);
+        Assert.True(toolStrip2.Top >= toolStrip1.Bottom);
+    }
+
+    [WinFormsFact]
+    public void ToolStripPanel_Join_Horizontal_FirstControlInRow_UsesRequestedLocation_NotShiftedByPaddingLeft()
+    {
+        using Form form = new()
+        {
+            ClientSize = new Size(600, 200)
+        };
+        using ToolStripPanel panel = new()
+        {
+            Dock = DockStyle.Top,
+            Padding = new Padding(left: 4, top: 0, right: 4, bottom: 0)
+        };
+        using ToolStrip toolStrip = new();
+        toolStrip.Items.Add(new ToolStripButton("Btn1"));
+
+        form.Controls.Add(panel);
+        form.Show();
+
+        Point requestedLocation = new(7, 0);
+        panel.Join(toolStrip, requestedLocation);
+        panel.PerformLayout();
+        Application.DoEvents();
+
+        Assert.Equal(requestedLocation, toolStrip.Location);
+    }
+
+    [WinFormsFact]
+    public void ToolStripPanel_Join_Vertical_FirstControlInRow_UsesRequestedLocation_NotShiftedByPaddingTop()
+    {
+        using Form form = new()
+        {
+            ClientSize = new Size(200, 600)
+        };
+        using ToolStripPanel panel = new()
+        {
+            Dock = DockStyle.Left,
+            Padding = new Padding(left: 0, top: 4, right: 0, bottom: 4)
+        };
+        using ToolStrip toolStrip = new();
+        toolStrip.Items.Add(new ToolStripButton("Btn1"));
+
+        form.Controls.Add(panel);
+        form.Show();
+
+        Point requestedLocation = new(0, 7);
+        panel.Join(toolStrip, requestedLocation);
+        panel.PerformLayout();
+        Application.DoEvents();
+
+        Assert.Equal(requestedLocation, toolStrip.Location);
+    }
+
     private class SubToolStripPanel : ToolStripPanel
     {
         public new SizeF AutoScaleFactor => base.AutoScaleFactor;

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripSettingsManagerTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ToolStripSettingsManagerTests.cs
@@ -30,4 +30,63 @@ public class ToolStripSettingsManagerTests : IClassFixture<UserConfigDisposableF
         Assert.Equal(new Drawing.Size(10, 10), toolStrip.Size);
         Assert.False(toolStrip.Visible);
     }
+
+    [WinFormsFact]
+    public void ToolStripSettingsManager_SaveLoad_AsymmetricPanelPadding_NoDriftAcrossMultipleCycles()
+    {
+        string settingsKey = nameof(ToolStripSettingsManager_SaveLoad_AsymmetricPanelPadding_NoDriftAcrossMultipleCycles);
+
+        Drawing.Point? expectedLocation1 = null;
+        Drawing.Point? expectedLocation2 = null;
+
+        for (int cycle = 0; cycle < 3; cycle++)
+        {
+            using Form form = new() { Name = settingsKey, ClientSize = new Drawing.Size(600, 200) };
+            using ToolStripContainer container = new() { Dock = DockStyle.Fill, Name = "Container" };
+            using ToolStrip toolStrip1 = new() { Name = "ToolStripMain" };
+            using ToolStrip toolStrip2 = new() { Name = "ToolStripFilters" };
+
+            container.TopToolStripPanel.Padding = new Padding(4, 0, 4, 0);
+            toolStrip1.Items.Add(new ToolStripButton("Btn1"));
+            toolStrip2.Items.Add(new ToolStripButton("Btn2"));
+
+            form.Controls.Add(container);
+            form.Show();
+
+            ToolStripPanel topPanel = container.TopToolStripPanel;
+
+            if (cycle == 0)
+            {
+                topPanel.Join(toolStrip1, new Drawing.Point(7, 0));
+                topPanel.Join(toolStrip2, new Drawing.Point(7, toolStrip1.Bottom + 5));
+                topPanel.PerformLayout();
+                Application.DoEvents();
+
+                Assert.True(toolStrip2.Location.Y > toolStrip1.Location.Y);
+            }
+            else
+            {
+                topPanel.Join(toolStrip1, Drawing.Point.Empty);
+                topPanel.Join(toolStrip2, new Drawing.Point(0, 500));
+                topPanel.PerformLayout();
+                Application.DoEvents();
+            }
+
+            ToolStripManager.SaveSettings(form, settingsKey);
+            ToolStripManager.LoadSettings(form, settingsKey);
+            topPanel.PerformLayout();
+            Application.DoEvents();
+
+            if (expectedLocation1 is null)
+            {
+                expectedLocation1 = toolStrip1.Location;
+                expectedLocation2 = toolStrip2.Location;
+            }
+            else
+            {
+                Assert.Equal(expectedLocation1.Value, toolStrip1.Location);
+                Assert.Equal(expectedLocation2.Value, toolStrip2.Location);
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4449


## Proposed changes
- Corrected comparison in ToolStripPanel.MoveInsideContainer for horizontal orientation to use Padding.Top instead of Padding.Left.

- Ensures row insertion logic respects asymmetric padding values consistently.

- Added unit tests to validate behavior.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Toolbars restored via ToolStripManager.LoadSettings now appear in the correct location when ToolStripPanel.Padding is asymmetric.

- Prevents unexpected row shifts and incorrect toolbar placement, improving layout persistence reliability.

## Regression? 

- No

## Risk

- Low

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
on load:
<img width="762" height="145" alt="Screenshot 2026-09-09 175436" src="https://github.com/user-attachments/assets/b523fe19-e499-4ecc-a2bd-f406b486f1aa" />

on save:
<img width="775" height="142" alt="Screenshot 2026-09-09 180526" src="https://github.com/user-attachments/assets/07016774-d076-4484-b7e3-4376b500ae6d" />


### After
on load:
<img width="846" height="102" alt="Screenshot 2026-09-09 175625" src="https://github.com/user-attachments/assets/3540ad35-1dc0-4280-b397-f1ed361c6a0a" />

on save:
<img width="792" height="143" alt="Screenshot 2026-09-09 180556" src="https://github.com/user-attachments/assets/eb4762f3-4b16-4793-a23b-a377a6c03344" />



## Test methodology <!-- How did you ensure quality? -->

- Manual test and unit test


## Test environment(s) <!-- Remove any that don't apply -->

- .NET SDK 11.0.100-preview.6.26359.118


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/15070)