### PR TITLE
Fix DataGridView ComboBox and Button cell rendering in dark mode

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
@@ -16,6 +16,8 @@ namespace System.Windows.Forms;
 [SRDescription(nameof(SR.DescriptionDataGridView))]
 public partial class DataGridView : Control, ISupportInitialize
 {
+    internal VisualStylesMode EffectiveVisualStylesModeInternal => EffectiveVisualStylesMode;
+
     private protected override VisualStylesMode GetSupportedVisualStylesMode(VisualStylesMode mode)
         => mode < VisualStylesMode.Net11 || AppContextSwitches.DataGridViewModernRendering
             ? mode

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
@@ -16,8 +16,6 @@ namespace System.Windows.Forms;
 [SRDescription(nameof(SR.DescriptionDataGridView))]
 public partial class DataGridView : Control, ISupportInitialize
 {
-    internal VisualStylesMode EffectiveVisualStylesModeInternal => EffectiveVisualStylesMode;
-
     private protected override VisualStylesMode GetSupportedVisualStylesMode(VisualStylesMode mode)
         => mode < VisualStylesMode.Net11 || AppContextSwitches.DataGridViewModernRendering
             ? mode

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.DataGridViewButtonCellRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.DataGridViewButtonCellRenderer.cs
@@ -11,6 +11,12 @@ public partial class DataGridViewButtonCell
     private static class DataGridViewButtonCellRenderer
     {
         private static VisualStyleRenderer? s_visualStyleRenderer;
+        [ThreadStatic]
+        private static ButtonDarkModeRendererBase? s_flatButtonDarkModeRenderer;
+        [ThreadStatic]
+        private static ButtonDarkModeRendererBase? s_modernButtonDarkModeRenderer;
+        [ThreadStatic]
+        private static ButtonDarkModeRendererBase? s_systemButtonDarkModeRenderer;
 
         public static VisualStyleRenderer DataGridViewButtonRenderer
         {
@@ -22,10 +28,71 @@ public partial class DataGridViewButtonCell
             }
         }
 
-        public static void DrawButton(Graphics g, Rectangle bounds, int buttonState)
+        public static (Rectangle ContentBounds, Color TextColor) DrawButton(
+            Graphics g,
+            Rectangle bounds,
+            int buttonState,
+            FlatStyle flatStyle,
+            int deviceDpi,
+            bool useModernRenderer)
         {
+            if (Application.IsDarkModeEnabled
+                && AppContextSwitches.DataGridViewDarkModeTheming
+                && !SystemInformation.HighContrast)
+            {
+                ButtonDarkModeRendererBase renderer = GetDarkModeRenderer(flatStyle, useModernRenderer);
+                renderer.DeviceDpi = deviceDpi;
+                PushButtonState state = GetPushButtonState(buttonState);
+                Color backColor = renderer.GetBackgroundColor(state, isDefault: false, customBaseColor: Color.Empty);
+                Rectangle contentBounds = renderer.DrawButtonBackground(
+                    g,
+                    bounds,
+                    state,
+                    isDefault: false,
+                    focused: false,
+                    backColor);
+
+                return (contentBounds, renderer.GetTextColor(state, isDefault: false, backColor));
+            }
+
             DataGridViewButtonRenderer.SetParameters(s_buttonElement.ClassName, s_buttonElement.Part, buttonState);
             DataGridViewButtonRenderer.DrawBackground(g, bounds, Rectangle.Truncate(g.ClipBounds));
+            return (
+                DataGridViewButtonRenderer.GetBackgroundContentRectangle(g, bounds),
+                DataGridViewButtonRenderer.GetColor(ColorProperty.TextColor));
         }
+
+        public static Color GetDarkModeTextColor(
+            int buttonState,
+            FlatStyle flatStyle,
+            int deviceDpi,
+            bool useModernRenderer)
+        {
+            ButtonDarkModeRendererBase renderer = GetDarkModeRenderer(flatStyle, useModernRenderer);
+            renderer.DeviceDpi = deviceDpi;
+            PushButtonState state = GetPushButtonState(buttonState);
+            Color backColor = renderer.GetBackgroundColor(state, isDefault: false, customBaseColor: Color.Empty);
+
+            return renderer.GetTextColor(state, isDefault: false, backColor);
+        }
+
+        private static ButtonDarkModeRendererBase GetDarkModeRenderer(FlatStyle flatStyle, bool useModernRenderer)
+            => flatStyle switch
+            {
+                FlatStyle.Standard => useModernRenderer
+                    ? s_modernButtonDarkModeRenderer ??= new ModernButtonDarkModeRenderer()
+                    : s_flatButtonDarkModeRenderer ??= new FlatButtonDarkModeRenderer(),
+                FlatStyle.System => s_systemButtonDarkModeRenderer ??= new SystemButtonDarkModeRenderer(),
+                _ => throw new ArgumentOutOfRangeException(nameof(flatStyle))
+            };
+
+        private static PushButtonState GetPushButtonState(int buttonState)
+            => buttonState switch
+            {
+                (int)PushButtonState.Hot => PushButtonState.Hot,
+                (int)PushButtonState.Pressed => PushButtonState.Pressed,
+                (int)PushButtonState.Disabled => PushButtonState.Disabled,
+                _ => PushButtonState.Normal
+            };
     }
 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.DataGridViewButtonCellRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.DataGridViewButtonCellRenderer.cs
@@ -12,6 +12,12 @@ public partial class DataGridViewButtonCell
     {
         private static VisualStyleRenderer? s_visualStyleRenderer;
 
+        [ThreadStatic]
+        private static FlatButtonDarkModeRenderer? s_flatButtonDarkModeRenderer;
+
+        [ThreadStatic]
+        private static SystemButtonDarkModeRenderer? s_systemButtonDarkModeRenderer;
+
         public static VisualStyleRenderer DataGridViewButtonRenderer
         {
             get
@@ -37,19 +43,20 @@ public partial class DataGridViewButtonCell
                 ButtonDarkModeRendererBase renderer = GetDarkModeRenderer(flatStyle);
                 renderer.DeviceDpi = deviceDpi;
                 Color backColor = renderer.GetBackgroundColor(state, isDefault, customBaseColor: Color.Empty);
+                Rectangle paddedBounds = ApplyRendererPadding(renderer, bounds);
                 Rectangle contentBounds;
                 using (new GraphicsStateScope(g))
                 {
                     contentBounds = renderer.DrawButtonBackground(
                         g,
-                        bounds,
+                        paddedBounds,
                         state,
                         isDefault,
                         focused: false,
                         backColor);
                 }
 
-                return (contentBounds, renderer.GetTextColor(state, isDefault, backColor));
+                return (contentBounds, GetTextColor(renderer, state, isDefault, flatStyle, backColor));
             }
 
             PushButtonState visualStyleState = isDefault && state == PushButtonState.Normal
@@ -72,15 +79,34 @@ public partial class DataGridViewButtonCell
         {
             ButtonDarkModeRendererBase renderer = GetDarkModeRenderer(flatStyle);
             Color backColor = renderer.GetBackgroundColor(state, isDefault, customBaseColor: Color.Empty);
-            return renderer.GetTextColor(state, isDefault, backColor);
+            return GetTextColor(renderer, state, isDefault, flatStyle, backColor);
         }
 
         private static ButtonDarkModeRendererBase GetDarkModeRenderer(FlatStyle flatStyle)
             => flatStyle switch
             {
-                FlatStyle.Standard => new FlatButtonDarkModeRenderer(),
-                FlatStyle.System => new SystemButtonDarkModeRenderer(),
+                FlatStyle.Standard => s_flatButtonDarkModeRenderer ??= new FlatButtonDarkModeRenderer(),
+                FlatStyle.System => s_systemButtonDarkModeRenderer ??= new SystemButtonDarkModeRenderer(),
                 _ => throw new ArgumentOutOfRangeException(nameof(flatStyle))
             };
+
+        private static Rectangle ApplyRendererPadding(ButtonDarkModeRendererBase renderer, Rectangle bounds)
+        {
+            Padding padding = renderer.GetPreferredSizePadding();
+
+            return new Rectangle(
+                bounds.X + padding.Left,
+                bounds.Y + padding.Top,
+                bounds.Width - padding.Horizontal,
+                bounds.Height - padding.Vertical);
+        }
+
+        private static Color GetTextColor(
+            ButtonDarkModeRendererBase renderer,
+            PushButtonState state,
+            bool isDefault,
+            FlatStyle flatStyle,
+            Color backColor)
+            => renderer.GetTextColor(state, isDefault && flatStyle != FlatStyle.System, backColor);
     }
 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.DataGridViewButtonCellRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.DataGridViewButtonCellRenderer.cs
@@ -11,12 +11,6 @@ public partial class DataGridViewButtonCell
     private static class DataGridViewButtonCellRenderer
     {
         private static VisualStyleRenderer? s_visualStyleRenderer;
-        [ThreadStatic]
-        private static ButtonDarkModeRendererBase? s_flatButtonDarkModeRenderer;
-        [ThreadStatic]
-        private static ButtonDarkModeRendererBase? s_modernButtonDarkModeRenderer;
-        [ThreadStatic]
-        private static ButtonDarkModeRendererBase? s_systemButtonDarkModeRenderer;
 
         public static VisualStyleRenderer DataGridViewButtonRenderer
         {
@@ -34,14 +28,13 @@ public partial class DataGridViewButtonCell
             PushButtonState state,
             bool isDefault,
             FlatStyle flatStyle,
-            int deviceDpi,
-            bool useModernRenderer)
+            int deviceDpi)
         {
             if (Application.IsDarkModeEnabled
                 && AppContextSwitches.DataGridViewDarkModeTheming
                 && !SystemInformation.HighContrast)
             {
-                ButtonDarkModeRendererBase renderer = GetDarkModeRenderer(flatStyle, useModernRenderer);
+                ButtonDarkModeRendererBase renderer = GetDarkModeRenderer(flatStyle);
                 renderer.DeviceDpi = deviceDpi;
                 Color backColor = renderer.GetBackgroundColor(state, isDefault, customBaseColor: Color.Empty);
                 Rectangle contentBounds;
@@ -75,21 +68,18 @@ public partial class DataGridViewButtonCell
         public static Color GetDarkModeTextColor(
             PushButtonState state,
             bool isDefault,
-            FlatStyle flatStyle,
-            bool useModernRenderer)
+            FlatStyle flatStyle)
         {
-            ButtonDarkModeRendererBase renderer = GetDarkModeRenderer(flatStyle, useModernRenderer);
+            ButtonDarkModeRendererBase renderer = GetDarkModeRenderer(flatStyle);
             Color backColor = renderer.GetBackgroundColor(state, isDefault, customBaseColor: Color.Empty);
             return renderer.GetTextColor(state, isDefault, backColor);
         }
 
-        private static ButtonDarkModeRendererBase GetDarkModeRenderer(FlatStyle flatStyle, bool useModernRenderer)
+        private static ButtonDarkModeRendererBase GetDarkModeRenderer(FlatStyle flatStyle)
             => flatStyle switch
             {
-                FlatStyle.Standard => useModernRenderer
-                    ? s_modernButtonDarkModeRenderer ??= new ModernButtonDarkModeRenderer()
-                    : s_flatButtonDarkModeRenderer ??= new FlatButtonDarkModeRenderer(),
-                FlatStyle.System => s_systemButtonDarkModeRenderer ??= new SystemButtonDarkModeRenderer(),
+                FlatStyle.Standard => new FlatButtonDarkModeRenderer(),
+                FlatStyle.System => new SystemButtonDarkModeRenderer(),
                 _ => throw new ArgumentOutOfRangeException(nameof(flatStyle))
             };
     }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.DataGridViewButtonCellRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.DataGridViewButtonCellRenderer.cs
@@ -8,13 +8,33 @@ namespace System.Windows.Forms;
 
 public partial class DataGridViewButtonCell
 {
+    private static (Rectangle ContentBounds, Color TextColor) DrawButton(
+        Graphics graphics,
+        Rectangle bounds,
+        PushButtonState state,
+        bool isDefault,
+        FlatStyle flatStyle,
+        int deviceDpi)
+        => DataGridViewButtonCellRenderer.DrawButton(
+            graphics,
+            bounds,
+            state,
+            isDefault,
+            flatStyle,
+            deviceDpi);
+
+    private static Rectangle GetButtonContentBounds(
+        Graphics graphics,
+        Rectangle bounds,
+        FlatStyle flatStyle,
+        int deviceDpi)
+        => DataGridViewButtonCellRenderer.GetContentBounds(graphics, bounds, flatStyle, deviceDpi);
+
     private static class DataGridViewButtonCellRenderer
     {
         private static VisualStyleRenderer? s_visualStyleRenderer;
-
         [ThreadStatic]
         private static FlatButtonDarkModeRenderer? s_flatButtonDarkModeRenderer;
-
         [ThreadStatic]
         private static SystemButtonDarkModeRenderer? s_systemButtonDarkModeRenderer;
 
@@ -43,20 +63,20 @@ public partial class DataGridViewButtonCell
                 ButtonDarkModeRendererBase renderer = GetDarkModeRenderer(flatStyle);
                 renderer.DeviceDpi = deviceDpi;
                 Color backColor = renderer.GetBackgroundColor(state, isDefault, customBaseColor: Color.Empty);
-                Rectangle paddedBounds = ApplyRendererPadding(renderer, bounds);
-                Rectangle contentBounds;
                 using (new GraphicsStateScope(g))
                 {
-                    contentBounds = renderer.DrawButtonBackground(
+                    renderer.DrawButtonBackground(
                         g,
-                        paddedBounds,
+                        bounds,
                         state,
                         isDefault,
                         focused: false,
                         backColor);
                 }
 
-                return (contentBounds, GetTextColor(renderer, state, isDefault, flatStyle, backColor));
+                return (
+                    GetContentBounds(g, bounds, flatStyle, deviceDpi),
+                    GetTextColor(renderer, state, isDefault, flatStyle, backColor));
             }
 
             PushButtonState visualStyleState = isDefault && state == PushButtonState.Normal
@@ -68,8 +88,26 @@ public partial class DataGridViewButtonCell
                 (int)visualStyleState);
             DataGridViewButtonRenderer.DrawBackground(g, bounds, Rectangle.Truncate(g.ClipBounds));
             return (
-                DataGridViewButtonRenderer.GetBackgroundContentRectangle(g, bounds),
+                GetContentBounds(g, bounds, flatStyle, deviceDpi),
                 DataGridViewButtonRenderer.GetColor(ColorProperty.TextColor));
+        }
+
+        public static Rectangle GetContentBounds(
+            Graphics g,
+            Rectangle bounds,
+            FlatStyle flatStyle,
+            int deviceDpi)
+        {
+            if (Application.IsDarkModeEnabled
+                && AppContextSwitches.DataGridViewDarkModeTheming
+                && !SystemInformation.HighContrast)
+            {
+                ButtonDarkModeRendererBase renderer = GetDarkModeRenderer(flatStyle);
+                renderer.DeviceDpi = deviceDpi;
+                return Rectangle.Inflate(bounds, -3, -3);
+            }
+
+            return DataGridViewButtonRenderer.GetBackgroundContentRectangle(g, bounds);
         }
 
         public static Color GetDarkModeTextColor(
@@ -82,6 +120,15 @@ public partial class DataGridViewButtonCell
             return GetTextColor(renderer, state, isDefault, flatStyle, backColor);
         }
 
+        public static Color GetDarkModeBackgroundColor(
+            PushButtonState state,
+            bool isDefault,
+            FlatStyle flatStyle)
+        {
+            ButtonDarkModeRendererBase renderer = GetDarkModeRenderer(flatStyle);
+            return renderer.GetBackgroundColor(state, isDefault, customBaseColor: Color.Empty);
+        }
+
         private static ButtonDarkModeRendererBase GetDarkModeRenderer(FlatStyle flatStyle)
             => flatStyle switch
             {
@@ -89,17 +136,6 @@ public partial class DataGridViewButtonCell
                 FlatStyle.System => s_systemButtonDarkModeRenderer ??= new SystemButtonDarkModeRenderer(),
                 _ => throw new ArgumentOutOfRangeException(nameof(flatStyle))
             };
-
-        private static Rectangle ApplyRendererPadding(ButtonDarkModeRendererBase renderer, Rectangle bounds)
-        {
-            Padding padding = renderer.GetPreferredSizePadding();
-
-            return new Rectangle(
-                bounds.X + padding.Left,
-                bounds.Y + padding.Top,
-                bounds.Width - padding.Horizontal,
-                bounds.Height - padding.Vertical);
-        }
 
         private static Color GetTextColor(
             ButtonDarkModeRendererBase renderer,

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.DataGridViewButtonCellRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.DataGridViewButtonCellRenderer.cs
@@ -31,7 +31,8 @@ public partial class DataGridViewButtonCell
         public static (Rectangle ContentBounds, Color TextColor) DrawButton(
             Graphics g,
             Rectangle bounds,
-            int buttonState,
+            PushButtonState state,
+            bool isDefault,
             FlatStyle flatStyle,
             int deviceDpi,
             bool useModernRenderer)
@@ -42,20 +43,29 @@ public partial class DataGridViewButtonCell
             {
                 ButtonDarkModeRendererBase renderer = GetDarkModeRenderer(flatStyle, useModernRenderer);
                 renderer.DeviceDpi = deviceDpi;
-                PushButtonState state = GetPushButtonState(buttonState);
-                Color backColor = renderer.GetBackgroundColor(state, isDefault: false, customBaseColor: Color.Empty);
-                Rectangle contentBounds = renderer.DrawButtonBackground(
-                    g,
-                    bounds,
-                    state,
-                    isDefault: false,
-                    focused: false,
-                    backColor);
+                Color backColor = renderer.GetBackgroundColor(state, isDefault, customBaseColor: Color.Empty);
+                Rectangle contentBounds;
+                using (new GraphicsStateScope(g))
+                {
+                    contentBounds = renderer.DrawButtonBackground(
+                        g,
+                        bounds,
+                        state,
+                        isDefault,
+                        focused: false,
+                        backColor);
+                }
 
-                return (contentBounds, renderer.GetTextColor(state, isDefault: false, backColor));
+                return (contentBounds, renderer.GetTextColor(state, isDefault, backColor));
             }
 
-            DataGridViewButtonRenderer.SetParameters(s_buttonElement.ClassName, s_buttonElement.Part, buttonState);
+            PushButtonState visualStyleState = isDefault && state == PushButtonState.Normal
+                ? PushButtonState.Default
+                : state;
+            DataGridViewButtonRenderer.SetParameters(
+                s_buttonElement.ClassName,
+                s_buttonElement.Part,
+                (int)visualStyleState);
             DataGridViewButtonRenderer.DrawBackground(g, bounds, Rectangle.Truncate(g.ClipBounds));
             return (
                 DataGridViewButtonRenderer.GetBackgroundContentRectangle(g, bounds),
@@ -63,17 +73,14 @@ public partial class DataGridViewButtonCell
         }
 
         public static Color GetDarkModeTextColor(
-            int buttonState,
+            PushButtonState state,
+            bool isDefault,
             FlatStyle flatStyle,
-            int deviceDpi,
             bool useModernRenderer)
         {
             ButtonDarkModeRendererBase renderer = GetDarkModeRenderer(flatStyle, useModernRenderer);
-            renderer.DeviceDpi = deviceDpi;
-            PushButtonState state = GetPushButtonState(buttonState);
-            Color backColor = renderer.GetBackgroundColor(state, isDefault: false, customBaseColor: Color.Empty);
-
-            return renderer.GetTextColor(state, isDefault: false, backColor);
+            Color backColor = renderer.GetBackgroundColor(state, isDefault, customBaseColor: Color.Empty);
+            return renderer.GetTextColor(state, isDefault, backColor);
         }
 
         private static ButtonDarkModeRendererBase GetDarkModeRenderer(FlatStyle flatStyle, bool useModernRenderer)
@@ -84,15 +91,6 @@ public partial class DataGridViewButtonCell
                     : s_flatButtonDarkModeRenderer ??= new FlatButtonDarkModeRenderer(),
                 FlatStyle.System => s_systemButtonDarkModeRenderer ??= new SystemButtonDarkModeRenderer(),
                 _ => throw new ArgumentOutOfRangeException(nameof(flatStyle))
-            };
-
-        private static PushButtonState GetPushButtonState(int buttonState)
-            => buttonState switch
-            {
-                (int)PushButtonState.Hot => PushButtonState.Hot,
-                (int)PushButtonState.Pressed => PushButtonState.Pressed,
-                (int)PushButtonState.Disabled => PushButtonState.Disabled,
-                _ => PushButtonState.Normal
             };
     }
 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.cs
@@ -667,10 +667,10 @@ public partial class DataGridViewButtonCell : DataGridViewCell
             && !SystemInformation.HighContrast
             && DataGridView.ApplyVisualStylesToInnerCells
             && FlatStyle is FlatStyle.Standard or FlatStyle.System;
-        (Color backBrushColor, Color foreBrushColor) = GetButtonColors(
-            cellStyle,
-            cellSelected,
-            PaintSelectionBackground(paintParts));
+        Color backBrushColor = (PaintSelectionBackground(paintParts) && cellSelected)
+            ? cellStyle.SelectionBackColor
+            : cellStyle.BackColor;
+        Color foreBrushColor = cellSelected ? cellStyle.SelectionForeColor : cellStyle.ForeColor;
         Color renderedTextColor = Color.Empty;
         PushButtonState pushButtonState = PushButtonState.Normal;
         if ((ButtonState & (ButtonState.Pushed | ButtonState.Checked)) != 0)
@@ -745,8 +745,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
                                 pushButtonState,
                                 isDefault,
                                 FlatStyle,
-                                DataGridView.DeviceDpi,
-                                DataGridView.EffectiveVisualStylesModeInternal >= VisualStylesMode.Net11);
+                                DataGridView.DeviceDpi);
                             resultBounds = buttonBounds;
                         }
                         else
@@ -996,8 +995,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
                     textColor = DataGridViewButtonCellRenderer.GetDarkModeTextColor(
                         pushButtonState,
                         isDefault,
-                        FlatStyle,
-                        DataGridView.EffectiveVisualStylesModeInternal >= VisualStylesMode.Net11);
+                        FlatStyle);
                 }
                 else if (DataGridView.ApplyVisualStylesToInnerCells &&
                     (FlatStyle == FlatStyle.System || FlatStyle == FlatStyle.Standard))
@@ -1030,19 +1028,6 @@ public partial class DataGridViewButtonCell : DataGridViewCell
         }
 
         return resultBounds;
-    }
-
-    private static (Color BackColor, Color ForeColor) GetButtonColors(
-        DataGridViewCellStyle cellStyle,
-        bool cellSelected,
-        bool paintSelectionBackground)
-    {
-        Color backColor = paintSelectionBackground && cellSelected
-            ? cellStyle.SelectionBackColor
-            : cellStyle.BackColor;
-        Color foreColor = cellSelected ? cellStyle.SelectionForeColor : cellStyle.ForeColor;
-
-        return (backColor, foreColor);
     }
 
     public override string ToString() =>

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.cs
@@ -662,10 +662,16 @@ public partial class DataGridViewButtonCell : DataGridViewCell
         Rectangle resultBounds;
         string? formattedString = formattedValue as string;
 
-        Color backBrushColor = PaintSelectionBackground(paintParts) && cellSelected
-            ? cellStyle.SelectionBackColor
-            : cellStyle.BackColor;
-        Color foreBrushColor = cellSelected ? cellStyle.SelectionForeColor : cellStyle.ForeColor;
+        bool useDarkModeRenderer = Application.IsDarkModeEnabled
+            && AppContextSwitches.DataGridViewDarkModeTheming
+            && !SystemInformation.HighContrast
+            && DataGridView.ApplyVisualStylesToInnerCells
+            && FlatStyle is FlatStyle.Standard or FlatStyle.System;
+        (Color backBrushColor, Color foreBrushColor) = GetButtonColors(
+            cellStyle,
+            cellSelected,
+            PaintSelectionBackground(paintParts));
+        Color renderedTextColor = Color.Empty;
 
         if (paint && PaintBorder(paintParts))
         {
@@ -717,6 +723,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
                     {
                         if (paint && PaintContentBackground(paintParts))
                         {
+                            Rectangle buttonBounds = valBounds;
                             PushButtonState pbState = PushButtonState.Normal;
                             if ((ButtonState & (ButtonState.Pushed | ButtonState.Checked)) != 0)
                             {
@@ -733,11 +740,20 @@ public partial class DataGridViewButtonCell : DataGridViewCell
                                 pbState |= PushButtonState.Default;
                             }
 
-                            DataGridViewButtonCellRenderer.DrawButton(g, valBounds, (int)pbState);
+                            (valBounds, renderedTextColor) = DataGridViewButtonCellRenderer.DrawButton(
+                                g,
+                                valBounds,
+                                (int)pbState,
+                                FlatStyle,
+                                DataGridView.DeviceDpi,
+                                DataGridView.EffectiveVisualStylesModeInternal >= VisualStylesMode.Net11);
+                            resultBounds = buttonBounds;
                         }
-
-                        resultBounds = valBounds;
-                        valBounds = DataGridViewButtonCellRenderer.DataGridViewButtonRenderer.GetBackgroundContentRectangle(g, valBounds);
+                        else
+                        {
+                            resultBounds = valBounds;
+                            valBounds = DataGridViewButtonCellRenderer.DataGridViewButtonRenderer.GetBackgroundContentRectangle(g, valBounds);
+                        }
                     }
                     else
                     {
@@ -971,7 +987,22 @@ public partial class DataGridViewButtonCell : DataGridViewCell
             if (valBounds.Width > 0 && valBounds.Height > 0)
             {
                 Color textColor;
-                if (DataGridView.ApplyVisualStylesToInnerCells &&
+                if (useDarkModeRenderer && !renderedTextColor.IsEmpty)
+                {
+                    textColor = renderedTextColor;
+                }
+                else if (useDarkModeRenderer)
+                {
+                    PushButtonState state = (ButtonState & (ButtonState.Pushed | ButtonState.Checked)) != 0
+                        ? PushButtonState.Pressed
+                        : PushButtonState.Normal;
+                    textColor = DataGridViewButtonCellRenderer.GetDarkModeTextColor(
+                        (int)state,
+                        FlatStyle,
+                        DataGridView.DeviceDpi,
+                        DataGridView.EffectiveVisualStylesModeInternal >= VisualStylesMode.Net11);
+                }
+                else if (DataGridView.ApplyVisualStylesToInnerCells &&
                     (FlatStyle == FlatStyle.System || FlatStyle == FlatStyle.Standard))
                 {
                     textColor = DataGridViewButtonCellRenderer.DataGridViewButtonRenderer.GetColor(ColorProperty.TextColor);
@@ -1002,6 +1033,19 @@ public partial class DataGridViewButtonCell : DataGridViewCell
         }
 
         return resultBounds;
+    }
+
+    private static (Color BackColor, Color ForeColor) GetButtonColors(
+        DataGridViewCellStyle cellStyle,
+        bool cellSelected,
+        bool paintSelectionBackground)
+    {
+        Color backColor = paintSelectionBackground && cellSelected
+            ? cellStyle.SelectionBackColor
+            : cellStyle.BackColor;
+        Color foreColor = cellSelected ? cellStyle.SelectionForeColor : cellStyle.ForeColor;
+
+        return (backColor, foreColor);
     }
 
     public override string ToString() =>

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.cs
@@ -739,7 +739,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
                         if (paint && PaintContentBackground(paintParts))
                         {
                             Rectangle buttonBounds = valBounds;
-                            (valBounds, renderedTextColor) = DataGridViewButtonCellRenderer.DrawButton(
+                            (valBounds, renderedTextColor) = DrawButton(
                                 g,
                                 valBounds,
                                 pushButtonState,
@@ -751,7 +751,11 @@ public partial class DataGridViewButtonCell : DataGridViewCell
                         else
                         {
                             resultBounds = valBounds;
-                            valBounds = DataGridViewButtonCellRenderer.DataGridViewButtonRenderer.GetBackgroundContentRectangle(g, valBounds);
+                            valBounds = GetButtonContentBounds(
+                                g,
+                                valBounds,
+                                FlatStyle,
+                                DataGridView.DeviceDpi);
                         }
                     }
                     else
@@ -899,7 +903,20 @@ public partial class DataGridViewButtonCell : DataGridViewCell
             // Draw focus rectangle
             if (FlatStyle is FlatStyle.System or FlatStyle.Standard)
             {
-                ControlPaint.DrawFocusRectangle(g, Rectangle.Inflate(valBounds, -1, -1), Color.Empty, cellStyle.ForeColor);
+                Color focusBackColor = useDarkModeRenderer
+                    ? DataGridViewButtonCellRenderer.GetDarkModeBackgroundColor(
+                        pushButtonState,
+                        isDefault,
+                        FlatStyle)
+                    : cellStyle.ForeColor;
+                Rectangle focusBounds = useDarkModeRenderer
+                    ? Rectangle.Inflate(resultBounds, -2, -2)
+                    : Rectangle.Inflate(valBounds, -1, -1);
+                DrawFocusRectangle(
+                    g,
+                    focusBounds,
+                    cellStyle.ForeColor,
+                    focusBackColor);
             }
             else if (FlatStyle == FlatStyle.Flat)
             {
@@ -959,11 +976,11 @@ public partial class DataGridViewButtonCell : DataGridViewCell
                     options.DotNetOneButtonCompat = false;
                     ButtonBaseAdapter.LayoutData layout = options.Layout();
 
-                    ControlPaint.DrawFocusRectangle(
+                    DrawFocusRectangle(
                         g,
                         layout.Focus,
-                        Color.Empty,
-                        cellStyle.ForeColor);
+                        foreBrushColor,
+                        cellSelected ? cellStyle.SelectionBackColor : cellStyle.BackColor);
                 }
             }
         }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.cs
@@ -672,6 +672,21 @@ public partial class DataGridViewButtonCell : DataGridViewCell
             cellSelected,
             PaintSelectionBackground(paintParts));
         Color renderedTextColor = Color.Empty;
+        PushButtonState pushButtonState = PushButtonState.Normal;
+        if ((ButtonState & (ButtonState.Pushed | ButtonState.Checked)) != 0)
+        {
+            pushButtonState = PushButtonState.Pressed;
+        }
+        else if (DataGridView.MouseEnteredCellAddress.Y == rowIndex &&
+            DataGridView.MouseEnteredCellAddress.X == ColumnIndex && s_mouseInContentBounds)
+        {
+            pushButtonState = PushButtonState.Hot;
+        }
+
+        bool isDefault = PaintFocus(paintParts)
+            && cellCurrent
+            && DataGridView.ShowFocusCues
+            && DataGridView.Focused;
 
         if (paint && PaintBorder(paintParts))
         {
@@ -724,26 +739,11 @@ public partial class DataGridViewButtonCell : DataGridViewCell
                         if (paint && PaintContentBackground(paintParts))
                         {
                             Rectangle buttonBounds = valBounds;
-                            PushButtonState pbState = PushButtonState.Normal;
-                            if ((ButtonState & (ButtonState.Pushed | ButtonState.Checked)) != 0)
-                            {
-                                pbState = PushButtonState.Pressed;
-                            }
-                            else if (DataGridView.MouseEnteredCellAddress.Y == rowIndex &&
-                                DataGridView.MouseEnteredCellAddress.X == ColumnIndex && s_mouseInContentBounds)
-                            {
-                                pbState = PushButtonState.Hot;
-                            }
-
-                            if (PaintFocus(paintParts) && cellCurrent && DataGridView.ShowFocusCues && DataGridView.Focused)
-                            {
-                                pbState |= PushButtonState.Default;
-                            }
-
                             (valBounds, renderedTextColor) = DataGridViewButtonCellRenderer.DrawButton(
                                 g,
                                 valBounds,
-                                (int)pbState,
+                                pushButtonState,
+                                isDefault,
                                 FlatStyle,
                                 DataGridView.DeviceDpi,
                                 DataGridView.EffectiveVisualStylesModeInternal >= VisualStylesMode.Net11);
@@ -993,13 +993,10 @@ public partial class DataGridViewButtonCell : DataGridViewCell
                 }
                 else if (useDarkModeRenderer)
                 {
-                    PushButtonState state = (ButtonState & (ButtonState.Pushed | ButtonState.Checked)) != 0
-                        ? PushButtonState.Pressed
-                        : PushButtonState.Normal;
                     textColor = DataGridViewButtonCellRenderer.GetDarkModeTextColor(
-                        (int)state,
+                        pushButtonState,
+                        isDefault,
                         FlatStyle,
-                        DataGridView.DeviceDpi,
                         DataGridView.EffectiveVisualStylesModeInternal >= VisualStylesMode.Net11);
                 }
                 else if (DataGridView.ApplyVisualStylesToInnerCells &&

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewCell.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel;
 using System.Drawing;
+using System.Drawing.Drawing2D;
 using System.Globalization;
 using System.Text;
 using Windows.Win32.UI.Accessibility;
@@ -3586,6 +3587,29 @@ public abstract partial class DataGridViewCell : DataGridViewElement, ICloneable
     internal static bool PaintFocus(DataGridViewPaintParts paintParts)
     {
         return (paintParts & DataGridViewPaintParts.Focus) != 0;
+    }
+
+    internal static void DrawFocusRectangle(
+        Graphics graphics,
+        Rectangle bounds,
+        Color foreColor,
+        Color backColor)
+    {
+        if (!Application.IsDarkModeEnabled
+            || !AppContextSwitches.DataGridViewDarkModeTheming
+            || SystemInformation.HighContrast)
+        {
+            ControlPaint.DrawFocusRectangle(graphics, bounds, foreColor, backColor);
+            return;
+        }
+
+        bounds.Width--;
+        bounds.Height--;
+        using var focusPen = new Pen(DarkModeButtonColors.DefaultColors.FocusBorderColor)
+        {
+            DashStyle = DashStyle.Dot
+        };
+        graphics.DrawRectangle(focusPen, bounds);
     }
 
     internal static void PaintPadding(

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewCheckBoxCell.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewCheckBoxCell.cs
@@ -1148,7 +1148,9 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
             ptCurrentCell.Y == rowIndex)
         {
             // Draw focus rectangle
-            ControlPaint.DrawFocusRectangle(g, valBounds, cellStyle.BackColor, cellStyle.ForeColor);
+            Color focusForeColor = cellSelected ? cellStyle.SelectionForeColor : cellStyle.ForeColor;
+            Color focusBackColor = cellSelected ? cellStyle.SelectionBackColor : cellStyle.BackColor;
+            DrawFocusRectangle(g, valBounds, focusForeColor, focusBackColor);
         }
 
         Rectangle errorBounds = valBounds;

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.DataGridViewComboBoxCellRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.DataGridViewComboBoxCellRenderer.cs
@@ -16,8 +16,11 @@ public partial class DataGridViewComboBoxCell
         private static readonly VisualStyleElement s_comboBoxDropDownButtonRight = VisualStyleElement.ComboBox.DropDownButtonRight.Normal;
         private static readonly VisualStyleElement s_comboBoxDropDownButtonLeft = VisualStyleElement.ComboBox.DropDownButtonLeft.Normal;
         private static readonly VisualStyleElement s_comboBoxReadOnlyButton = VisualStyleElement.ComboBox.ReadOnlyButton.Normal;
-        private static readonly VisualStyleElement s_darkComboBoxDropDownButtonRight = CreateDarkModeElement(s_comboBoxDropDownButtonRight);
-        private static readonly VisualStyleElement s_darkComboBoxDropDownButtonLeft = CreateDarkModeElement(s_comboBoxDropDownButtonLeft);
+
+        // Dark Mode element for drop-down button (same as ComboBoxRenderer uses)
+        private static VisualStyleElement ComboBoxDropDownButtonElement => Application.IsDarkModeEnabled
+            ? VisualStyleElement.CreateElement($"{Control.DarkModeIdentifier}_{Control.ComboBoxButtonThemeIdentifier}::{Control.ComboboxClassIdentifier}", 1, 1)
+            : VisualStyleElement.ComboBox.DropDownButton.Normal;
 
         public static VisualStyleRenderer VisualStyleRenderer
         {
@@ -56,20 +59,22 @@ public partial class DataGridViewComboBoxCell
 
         public static void DrawDropDownButton(Graphics g, Rectangle bounds, ComboBoxState state, bool rightToLeft)
         {
-            bool useDarkMode = Application.IsDarkModeEnabled && AppContextSwitches.DataGridViewDarkModeTheming;
-            InitializeRenderer(GetDropDownButtonElement(rightToLeft, useDarkMode), (int)state);
+            // Use Dark Mode element when enabled
+            if (Application.IsDarkModeEnabled && AppContextSwitches.DataGridViewDarkModeTheming)
+            {
+                InitializeRenderer(ComboBoxDropDownButtonElement, (int)state);
+            }
+            else if (rightToLeft)
+            {
+                InitializeRenderer(s_comboBoxDropDownButtonLeft, (int)state);
+            }
+            else
+            {
+                InitializeRenderer(s_comboBoxDropDownButtonRight, (int)state);
+            }
 
             t_visualStyleRenderer.DrawBackground(g, bounds);
         }
-
-        public static VisualStyleElement GetDropDownButtonElement(bool rightToLeft, bool useDarkMode)
-            => (rightToLeft, useDarkMode) switch
-            {
-                (true, true) => s_darkComboBoxDropDownButtonLeft,
-                (true, false) => s_comboBoxDropDownButtonLeft,
-                (false, true) => s_darkComboBoxDropDownButtonRight,
-                _ => s_comboBoxDropDownButtonRight
-            };
 
         public static void DrawReadOnlyButton(Graphics g, Rectangle bounds, ComboBoxState state)
         {
@@ -104,11 +109,5 @@ public partial class DataGridViewComboBoxCell
                 t_visualStyleRenderer.SetParameters(visualStyleElement.ClassName, visualStyleElement.Part, state);
             }
         }
-
-        private static VisualStyleElement CreateDarkModeElement(VisualStyleElement element)
-            => VisualStyleElement.CreateElement(
-                $"{Control.DarkModeIdentifier}_{Control.ComboBoxButtonThemeIdentifier}::{Control.ComboboxClassIdentifier}",
-                element.Part,
-                element.State);
     }
 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.DataGridViewComboBoxCellRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.DataGridViewComboBoxCellRenderer.cs
@@ -17,11 +17,6 @@ public partial class DataGridViewComboBoxCell
         private static readonly VisualStyleElement s_comboBoxDropDownButtonLeft = VisualStyleElement.ComboBox.DropDownButtonLeft.Normal;
         private static readonly VisualStyleElement s_comboBoxReadOnlyButton = VisualStyleElement.ComboBox.ReadOnlyButton.Normal;
 
-        // Dark Mode element for drop-down button (same as ComboBoxRenderer uses)
-        private static VisualStyleElement ComboBoxDropDownButtonElement => Application.IsDarkModeEnabled
-            ? VisualStyleElement.CreateElement($"{Control.DarkModeIdentifier}_{Control.ComboBoxButtonThemeIdentifier}::{Control.ComboboxClassIdentifier}", 1, 1)
-            : VisualStyleElement.ComboBox.DropDownButton.Normal;
-
         public static VisualStyleRenderer VisualStyleRenderer
         {
             get
@@ -59,12 +54,27 @@ public partial class DataGridViewComboBoxCell
 
         public static void DrawDropDownButton(Graphics g, Rectangle bounds, ComboBoxState state, bool rightToLeft)
         {
-            // Use Dark Mode element when enabled
             if (Application.IsDarkModeEnabled && AppContextSwitches.DataGridViewDarkModeTheming)
             {
-                InitializeRenderer(ComboBoxDropDownButtonElement, (int)state);
+                g.FillRectangle(Brushes.Black, bounds);
+
+                if (bounds.Width >= 7 && bounds.Height >= 5)
+                {
+                    Point center = new(bounds.Left + bounds.Width / 2, bounds.Top + bounds.Height / 2);
+                    g.FillPolygon(
+                        Brushes.White,
+                        (ReadOnlySpan<Point>)
+                        [
+                            new(center.X - 3, center.Y - 2),
+                            new(center.X + 3, center.Y - 2),
+                            new(center.X, center.Y + 2)
+                        ]);
+                }
+
+                return;
             }
-            else if (rightToLeft)
+
+            if (rightToLeft)
             {
                 InitializeRenderer(s_comboBoxDropDownButtonLeft, (int)state);
             }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.DataGridViewComboBoxCellRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.DataGridViewComboBoxCellRenderer.cs
@@ -16,6 +16,8 @@ public partial class DataGridViewComboBoxCell
         private static readonly VisualStyleElement s_comboBoxDropDownButtonRight = VisualStyleElement.ComboBox.DropDownButtonRight.Normal;
         private static readonly VisualStyleElement s_comboBoxDropDownButtonLeft = VisualStyleElement.ComboBox.DropDownButtonLeft.Normal;
         private static readonly VisualStyleElement s_comboBoxReadOnlyButton = VisualStyleElement.ComboBox.ReadOnlyButton.Normal;
+        private static readonly VisualStyleElement s_darkComboBoxDropDownButtonRight = CreateDarkModeElement(s_comboBoxDropDownButtonRight);
+        private static readonly VisualStyleElement s_darkComboBoxDropDownButtonLeft = CreateDarkModeElement(s_comboBoxDropDownButtonLeft);
 
         public static VisualStyleRenderer VisualStyleRenderer
         {
@@ -54,23 +56,20 @@ public partial class DataGridViewComboBoxCell
 
         public static void DrawDropDownButton(Graphics g, Rectangle bounds, ComboBoxState state, bool rightToLeft)
         {
-            if (Application.IsDarkModeEnabled && AppContextSwitches.DataGridViewDarkModeTheming)
-            {
-                ComboBoxRenderer.DrawDropDownButton(g, bounds, state);
-                return;
-            }
-
-            if (rightToLeft)
-            {
-                InitializeRenderer(s_comboBoxDropDownButtonLeft, (int)state);
-            }
-            else
-            {
-                InitializeRenderer(s_comboBoxDropDownButtonRight, (int)state);
-            }
+            bool useDarkMode = Application.IsDarkModeEnabled && AppContextSwitches.DataGridViewDarkModeTheming;
+            InitializeRenderer(GetDropDownButtonElement(rightToLeft, useDarkMode), (int)state);
 
             t_visualStyleRenderer.DrawBackground(g, bounds);
         }
+
+        public static VisualStyleElement GetDropDownButtonElement(bool rightToLeft, bool useDarkMode)
+            => (rightToLeft, useDarkMode) switch
+            {
+                (true, true) => s_darkComboBoxDropDownButtonLeft,
+                (true, false) => s_comboBoxDropDownButtonLeft,
+                (false, true) => s_darkComboBoxDropDownButtonRight,
+                _ => s_comboBoxDropDownButtonRight
+            };
 
         public static void DrawReadOnlyButton(Graphics g, Rectangle bounds, ComboBoxState state)
         {
@@ -105,5 +104,11 @@ public partial class DataGridViewComboBoxCell
                 t_visualStyleRenderer.SetParameters(visualStyleElement.ClassName, visualStyleElement.Part, state);
             }
         }
+
+        private static VisualStyleElement CreateDarkModeElement(VisualStyleElement element)
+            => VisualStyleElement.CreateElement(
+                $"{Control.DarkModeIdentifier}_{Control.ComboBoxButtonThemeIdentifier}::{Control.ComboboxClassIdentifier}",
+                element.Part,
+                element.State);
     }
 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.DataGridViewComboBoxCellRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.DataGridViewComboBoxCellRenderer.cs
@@ -56,21 +56,7 @@ public partial class DataGridViewComboBoxCell
         {
             if (Application.IsDarkModeEnabled && AppContextSwitches.DataGridViewDarkModeTheming)
             {
-                g.FillRectangle(Brushes.Black, bounds);
-
-                if (bounds.Width >= 7 && bounds.Height >= 5)
-                {
-                    Point center = new(bounds.Left + bounds.Width / 2, bounds.Top + bounds.Height / 2);
-                    g.FillPolygon(
-                        Brushes.White,
-                        (ReadOnlySpan<Point>)
-                        [
-                            new(center.X - 3, center.Y - 2),
-                            new(center.X + 3, center.Y - 2),
-                            new(center.X, center.Y + 2)
-                        ]);
-                }
-
+                ComboBoxRenderer.DrawDropDownButton(g, bounds, state);
                 return;
             }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.DataGridViewComboBoxCellRenderer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.DataGridViewComboBoxCellRenderer.cs
@@ -45,6 +45,15 @@ public partial class DataGridViewComboBoxCell
         // Post theming functions
         public static void DrawBorder(Graphics g, Rectangle bounds)
         {
+            if (Application.IsDarkModeEnabled
+                && AppContextSwitches.DataGridViewDarkModeTheming
+                && !SystemInformation.HighContrast)
+            {
+                using var pen = DarkModeButtonColors.DefaultColors.SingleBorderColor.GetCachedPenScope();
+                g.DrawRectangle(pen, bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);
+                return;
+            }
+
             if (t_visualStyleRenderer is null)
             {
                 t_visualStyleRenderer = new VisualStyleRenderer(s_comboBoxBorder);
@@ -57,7 +66,12 @@ public partial class DataGridViewComboBoxCell
             t_visualStyleRenderer.DrawBackground(g, bounds);
         }
 
-        public static void DrawDropDownButton(Graphics g, Rectangle bounds, ComboBoxState state, bool rightToLeft)
+        public static void DrawDropDownButton(
+            Graphics g,
+            Rectangle bounds,
+            ComboBoxState state,
+            bool rightToLeft,
+            bool integrated = false)
         {
             // Use Dark Mode element when enabled
             if (Application.IsDarkModeEnabled && AppContextSwitches.DataGridViewDarkModeTheming)
@@ -73,16 +87,33 @@ public partial class DataGridViewComboBoxCell
                 InitializeRenderer(s_comboBoxDropDownButtonRight, (int)state);
             }
 
-            t_visualStyleRenderer.DrawBackground(g, bounds);
+            if (integrated && Application.IsDarkModeEnabled && !SystemInformation.HighContrast)
+            {
+                Rectangle rendererBounds = bounds;
+                rendererBounds.Width++;
+                if (!rightToLeft)
+                {
+                    rendererBounds.X--;
+                }
+
+                using (new GraphicsStateScope(g))
+                {
+                    g.IntersectClip(bounds);
+                    t_visualStyleRenderer.DrawBackground(g, rendererBounds);
+                }
+            }
+            else
+            {
+                t_visualStyleRenderer.DrawBackground(g, bounds);
+            }
         }
 
-        public static void DrawReadOnlyButton(Graphics g, Rectangle bounds, ComboBoxState state)
+        public static void DrawReadOnlyButton(Graphics g, Rectangle bounds, ComboBoxState state, Color backColor)
         {
             // Use Dark Mode element when enabled
             if (Application.IsDarkModeEnabled && AppContextSwitches.DataGridViewDarkModeTheming)
             {
-                // Draw dark background similar to ComboBox in Dark Mode
-                using var brush = new SolidBrush(Color.FromArgb(45, 45, 45));
+                using var brush = backColor.GetCachedSolidBrushScope();
                 g.FillRectangle(brush, bounds);
 
                 // Draw border

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.cs
@@ -2381,7 +2381,7 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
     {
         if (useDarkModeColors)
         {
-            return Color.White;
+            return cellSelected ? cellStyle.SelectionForeColor : cellStyle.ForeColor;
         }
 
         if (useVisualStyleTextColor)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.cs
@@ -2384,7 +2384,7 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
             return Color.White;
         }
 
-        if (useVisualStyleTextColor && !useDarkModeColors)
+        if (useVisualStyleTextColor)
         {
             return DataGridViewComboBoxCellRenderer.VisualStyleRenderer.GetColor(ColorProperty.TextColor);
         }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.cs
@@ -1893,14 +1893,6 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
         bool paintXPThemes = !paintFlat && DataGridView.ApplyVisualStylesToInnerCells;
         bool paintPostXPThemes = paintXPThemes && PostXPThemesExist;
 
-        ComboBoxState comboBoxState = ComboBoxState.Normal;
-        if (DataGridView.MouseEnteredCellAddress.Y == rowIndex &&
-            DataGridView.MouseEnteredCellAddress.X == ColumnIndex &&
-            s_mouseInDropDownButtonBounds)
-        {
-            comboBoxState = ComboBoxState.Hot;
-        }
-
         if (paint && PaintBorder(paintParts))
         {
             PaintBorder(g, clipBounds, cellBounds, cellStyle, advancedBorderStyle);
@@ -1915,6 +1907,14 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
         Point ptCurrentCell = DataGridView.CurrentCellAddress;
         bool cellCurrent = ptCurrentCell.X == ColumnIndex && ptCurrentCell.Y == rowIndex;
         bool cellEdited = cellCurrent && DataGridView.EditingControl is not null;
+        ComboBoxState comboBoxState = ComboBoxState.Normal;
+        if (DataGridView.MouseEnteredCellAddress.Y == rowIndex &&
+            DataGridView.MouseEnteredCellAddress.X == ColumnIndex &&
+            s_mouseInDropDownButtonBounds)
+        {
+            comboBoxState = ComboBoxState.Hot;
+        }
+
         bool cellSelected = (elementState & DataGridViewElementStates.Selected) != 0;
         bool drawComboBox = DisplayStyle == DataGridViewComboBoxDisplayStyle.ComboBox &&
                             ((DisplayStyleForCurrentCellOnly && cellCurrent) || !DisplayStyleForCurrentCellOnly);
@@ -2319,15 +2319,17 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
                                 flags |= TextFormatFlags.EndEllipsis;
                             }
 
-                            Color textColor;
-                            if (paintPostXPThemes && (drawDropDownButton || drawComboBox) && !SystemInformation.HighContrast)
-                            {
-                                textColor = DataGridViewComboBoxCellRenderer.VisualStyleRenderer.GetColor(ColorProperty.TextColor);
-                            }
-                            else
-                            {
-                                textColor = cellSelected ? cellStyle.SelectionForeColor : cellStyle.ForeColor;
-                            }
+                            bool useVisualStyleTextColor = paintPostXPThemes
+                                && (drawDropDownButton || drawComboBox)
+                                && !SystemInformation.HighContrast;
+                            bool useDarkModeColors = Application.IsDarkModeEnabled
+                                && AppContextSwitches.DataGridViewDarkModeTheming
+                                && !SystemInformation.HighContrast;
+                            Color textColor = GetTextColor(
+                                cellStyle,
+                                cellSelected,
+                                useVisualStyleTextColor,
+                                useDarkModeColors);
 
                             TextRenderer.DrawText(
                                 g,
@@ -2368,6 +2370,25 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
         }
 
         return resultBounds;
+    }
+
+    private static Color GetTextColor(
+        DataGridViewCellStyle cellStyle,
+        bool cellSelected,
+        bool useVisualStyleTextColor,
+        bool useDarkModeColors)
+    {
+        if (useDarkModeColors)
+        {
+            return Color.White;
+        }
+
+        if (useVisualStyleTextColor)
+        {
+            return DataGridViewComboBoxCellRenderer.VisualStyleRenderer.GetColor(ColorProperty.TextColor);
+        }
+
+        return cellSelected ? cellStyle.SelectionForeColor : cellStyle.ForeColor;
     }
 
     public override object? ParseFormattedValue(

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.cs
@@ -1892,6 +1892,9 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
 
         bool paintXPThemes = !paintFlat && DataGridView.ApplyVisualStylesToInnerCells;
         bool paintPostXPThemes = paintXPThemes && PostXPThemesExist;
+        bool useDarkModeComboBoxRenderer = Application.IsDarkModeEnabled
+            && AppContextSwitches.DataGridViewDarkModeTheming
+            && !SystemInformation.HighContrast;
 
         if (paint && PaintBorder(paintParts))
         {
@@ -1959,7 +1962,10 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
                 {
                     if (paintPostXPThemes)
                     {
-                        DataGridViewComboBoxCellRenderer.DrawBorder(g, valBounds);
+                        if (!useDarkModeComboBoxRenderer)
+                        {
+                            DataGridViewComboBoxCellRenderer.DrawBorder(g, valBounds);
+                        }
                     }
                     else
                     {
@@ -2054,11 +2060,16 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
                             {
                                 if (drawComboBox)
                                 {
-                                    DataGridViewComboBoxCellRenderer.DrawDropDownButton(g, dropRect, comboBoxState, DataGridView.RightToLeftInternal);
+                                    DataGridViewComboBoxCellRenderer.DrawDropDownButton(
+                                        g,
+                                        dropRect,
+                                        useDarkModeComboBoxRenderer && cellSelected ? ComboBoxState.Hot : comboBoxState,
+                                        DataGridView.RightToLeftInternal,
+                                        integrated: true);
                                 }
                                 else
                                 {
-                                    DataGridViewComboBoxCellRenderer.DrawReadOnlyButton(g, valBounds, comboBoxState);
+                                    DataGridViewComboBoxCellRenderer.DrawReadOnlyButton(g, valBounds, comboBoxState, brushColor);
                                     DataGridViewComboBoxCellRenderer.DrawDropDownButton(g, dropRect, ComboBoxState.Normal);
                                 }
 
@@ -2202,6 +2213,17 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
             }
         }
 
+        if (paint
+            && useDarkModeComboBoxRenderer
+            && paintPostXPThemes
+            && drawComboBox
+            && PaintContentBackground(paintParts)
+            && valBounds.Width > 0
+            && valBounds.Height > 0)
+        {
+            DataGridViewComboBoxCellRenderer.DrawBorder(g, valBounds);
+        }
+
         Rectangle errorBounds = valBounds;
         Rectangle textBounds = Rectangle.Inflate(valBounds, -2, -2);
 
@@ -2260,7 +2282,9 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
                     focusBounds.Width++;
                     focusBounds.Y--;
                     focusBounds.Height += 2;
-                    ControlPaint.DrawFocusRectangle(g, focusBounds, Color.Empty, cellStyle.ForeColor);
+                    Color focusForeColor = cellSelected ? cellStyle.SelectionForeColor : cellStyle.ForeColor;
+                    Color focusBackColor = cellSelected ? cellStyle.SelectionBackColor : cellStyle.BackColor;
+                    DrawFocusRectangle(g, focusBounds, focusForeColor, focusBackColor);
                 }
                 else if (paintPostXPThemes)
                 {
@@ -2271,12 +2295,16 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
                     focusBounds.Height -= 2;
                     if (focusBounds.Width > 0 && focusBounds.Height > 0)
                     {
-                        ControlPaint.DrawFocusRectangle(g, focusBounds, Color.Empty, cellStyle.ForeColor);
+                        Color focusForeColor = cellSelected ? cellStyle.SelectionForeColor : cellStyle.ForeColor;
+                        Color focusBackColor = cellSelected ? cellStyle.SelectionBackColor : cellStyle.BackColor;
+                        DrawFocusRectangle(g, focusBounds, focusForeColor, focusBackColor);
                     }
                 }
                 else
                 {
-                    ControlPaint.DrawFocusRectangle(g, textBounds, Color.Empty, cellStyle.ForeColor);
+                    Color focusForeColor = cellSelected ? cellStyle.SelectionForeColor : cellStyle.ForeColor;
+                    Color focusBackColor = cellSelected ? cellStyle.SelectionBackColor : cellStyle.BackColor;
+                    DrawFocusRectangle(g, textBounds, focusForeColor, focusBackColor);
                 }
             }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.cs
@@ -2324,7 +2324,8 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
                                 && !SystemInformation.HighContrast;
                             bool useDarkModeColors = Application.IsDarkModeEnabled
                                 && AppContextSwitches.DataGridViewDarkModeTheming
-                                && !SystemInformation.HighContrast;
+                                && !SystemInformation.HighContrast
+                                && (drawDropDownButton || drawComboBox);
                             Color textColor = GetTextColor(
                                 cellStyle,
                                 cellSelected,
@@ -2383,7 +2384,7 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
             return Color.White;
         }
 
-        if (useVisualStyleTextColor)
+        if (useVisualStyleTextColor && !useDarkModeColors)
         {
             return DataGridViewComboBoxCellRenderer.VisualStyleRenderer.GetColor(ColorProperty.TextColor);
         }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewImageCell.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewImageCell.cs
@@ -894,7 +894,9 @@ public partial class DataGridViewImageCell : DataGridViewCell
             && DataGridView.Focused)
         {
             // Draw focus rectangle
-            ControlPaint.DrawFocusRectangle(g, valBounds, Color.Empty, brushColor);
+            Color focusForeColor = cellSelected ? cellStyle.SelectionForeColor : cellStyle.ForeColor;
+            Color focusBackColor = cellSelected ? cellStyle.SelectionBackColor : cellStyle.BackColor;
+            DrawFocusRectangle(g, valBounds, focusForeColor, focusBackColor);
         }
 
         if (paint && DataGridView.ShowCellErrors && PaintErrorIcon(paintParts))

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewLinkCell.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewLinkCell.cs
@@ -1027,7 +1027,9 @@ public partial class DataGridViewLinkCell : DataGridViewCell
                         }
 
                         focusBounds.Height += 2;
-                        ControlPaint.DrawFocusRectangle(g, focusBounds, Color.Empty, brushColor);
+                        Color focusForeColor = cellSelected ? cellStyle.SelectionForeColor : cellStyle.ForeColor;
+                        Color focusBackColor = cellSelected ? cellStyle.SelectionBackColor : cellStyle.BackColor;
+                        DrawFocusRectangle(g, focusBounds, focusForeColor, focusBackColor);
                     }
 
                     Color linkColor;
@@ -1090,7 +1092,9 @@ public partial class DataGridViewLinkCell : DataGridViewCell
                     errorBounds.Height > 0)
                 {
                     // Draw focus rectangle
-                    ControlPaint.DrawFocusRectangle(g, errorBounds, Color.Empty, brushColor);
+                    Color focusForeColor = cellSelected ? cellStyle.SelectionForeColor : cellStyle.ForeColor;
+                    Color focusBackColor = cellSelected ? cellStyle.SelectionBackColor : cellStyle.BackColor;
+                    DrawFocusRectangle(g, errorBounds, focusForeColor, focusBackColor);
                 }
             }
         }
@@ -1105,7 +1109,9 @@ public partial class DataGridViewLinkCell : DataGridViewCell
                 valBounds.Height > 0)
             {
                 // Draw focus rectangle
-                ControlPaint.DrawFocusRectangle(g, valBounds, Color.Empty, brushColor);
+                Color focusForeColor = cellSelected ? cellStyle.SelectionForeColor : cellStyle.ForeColor;
+                Color focusBackColor = cellSelected ? cellStyle.SelectionBackColor : cellStyle.BackColor;
+                DrawFocusRectangle(g, valBounds, focusForeColor, focusBackColor);
             }
         }
         else if (computeErrorIconBounds)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewTextBoxCell.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/DataGridView/DataGridViewTextBoxCell.cs
@@ -710,7 +710,9 @@ public partial class DataGridViewTextBoxCell : DataGridViewCell
             // Draw focus rectangle
             if (PaintFocus(paintParts) && DataGridView.ShowFocusCues && DataGridView.Focused && notCollapsed)
             {
-                ControlPaint.DrawFocusRectangle(graphics, valBounds, Color.Empty, cellStyle.ForeColor);
+                Color focusForeColor = cellSelected ? cellStyle.SelectionForeColor : cellStyle.ForeColor;
+                Color focusBackColor = cellSelected ? cellStyle.SelectionBackColor : cellStyle.BackColor;
+                DrawFocusRectangle(graphics, valBounds, focusForeColor, focusBackColor);
             }
         }
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewButtonCellTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewButtonCellTests.cs
@@ -580,7 +580,7 @@ public class DataGridViewButtonCellTests : IDisposable
     }
 
     [WinFormsFact]
-    public void DrawButton_DarkMode_SystemStyle_AppliesPaddingAndUsesReadableDefaultTextColor()
+    public void DrawButton_DarkMode_SystemStyle_UsesStandardContentBoundsAndReadableDefaultTextColor()
     {
         if (SystemInformation.HighContrast)
         {
@@ -604,8 +604,11 @@ public class DataGridViewButtonCellTests : IDisposable
             Reflection.MethodInfo drawButton = rendererType.GetMethod(
                 "DrawButton",
                 Reflection.BindingFlags.Public | Reflection.BindingFlags.Static)!;
+            Reflection.MethodInfo getContentBounds = rendererType.GetMethod(
+                "GetContentBounds",
+                Reflection.BindingFlags.Public | Reflection.BindingFlags.Static)!;
 
-            object? result = drawButton.Invoke(
+            object? systemResult = drawButton.Invoke(
                 null,
                 [
                     graphics,
@@ -615,10 +618,25 @@ public class DataGridViewButtonCellTests : IDisposable
                     FlatStyle.System,
                     96
                 ]);
+            object? standardResult = drawButton.Invoke(
+                null,
+                [
+                    graphics,
+                    new Rectangle(0, 0, 30, 30),
+                    VisualStyles.PushButtonState.Normal,
+                    true,
+                    FlatStyle.Standard,
+                    96
+                ]);
 
-            (Rectangle ContentBounds, Color TextColor) renderResult = ((Rectangle, Color))result!;
-            renderResult.ContentBounds.Should().Be(new Rectangle(5, 5, 20, 20));
-            renderResult.TextColor.GetBrightness().Should().BeGreaterThan(0.5f);
+            (Rectangle ContentBounds, Color TextColor) systemRenderResult = ((Rectangle, Color))systemResult!;
+            (Rectangle ContentBounds, Color TextColor) standardRenderResult = ((Rectangle, Color))standardResult!;
+            Rectangle foregroundOnlyBounds = (Rectangle)getContentBounds.Invoke(
+                null,
+                [graphics, new Rectangle(0, 0, 30, 30), FlatStyle.System, 96])!;
+            systemRenderResult.ContentBounds.Should().Be(standardRenderResult.ContentBounds);
+            foregroundOnlyBounds.Should().Be(systemRenderResult.ContentBounds);
+            systemRenderResult.TextColor.GetBrightness().Should().BeGreaterThan(0.5f);
         }
         finally
         {

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewButtonCellTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewButtonCellTests.cs
@@ -482,6 +482,25 @@ public class DataGridViewButtonCellTests : IDisposable
     }
 
     [Fact]
+    public void GetButtonColors_ReturnsCellStyleColors()
+    {
+        DataGridViewCellStyle style = new()
+        {
+            BackColor = Color.Red,
+            ForeColor = Color.Green,
+            SelectionBackColor = Color.Blue,
+            SelectionForeColor = Color.Yellow
+        };
+
+        (Color BackColor, Color ForeColor) result = _dataGridViewButtonCell.TestAccessor.Dynamic.GetButtonColors(
+            style,
+            cellSelected: false,
+            paintSelectionBackground: true);
+
+        result.Should().Be((style.BackColor, style.ForeColor));
+    }
+
+    [Fact]
     public void ToString_ReturnsExpectedFormat_WithDefaultIndices()
     {
         string result = _dataGridViewButtonCell.ToString();

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewButtonCellTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewButtonCellTests.cs
@@ -350,8 +350,8 @@ public class DataGridViewButtonCellTests : IDisposable
 
             object? drawResult = drawButton.Invoke(
                 null,
-                [graphics, new Rectangle(0, 0, 20, 20), state, false, FlatStyle.Standard, 96, true]);
-            Color result = (Color)getTextColor.Invoke(null, [state, false, FlatStyle.Standard, true])!;
+                [graphics, new Rectangle(0, 0, 20, 20), state, false, FlatStyle.Standard, 96]);
+            Color result = (Color)getTextColor.Invoke(null, [state, false, FlatStyle.Standard])!;
             (Rectangle ContentBounds, Color TextColor) renderedButton = ((Rectangle, Color))drawResult!;
 
             renderedButton.TextColor.Should().Be(result);
@@ -564,8 +564,7 @@ public class DataGridViewButtonCellTests : IDisposable
                     VisualStyles.PushButtonState.Normal,
                     false,
                     FlatStyle.Standard,
-                    96,
-                    false
+                    96
                 ]);
 
             graphics.SmoothingMode.Should().Be(SmoothingMode.None);
@@ -580,12 +579,11 @@ public class DataGridViewButtonCellTests : IDisposable
     }
 
     [WinFormsTheory]
-    [InlineData(false, KnownColor.Red, KnownColor.Green)]
-    [InlineData(true, KnownColor.Blue, KnownColor.Yellow)]
+    [InlineData(false, KnownColor.Red)]
+    [InlineData(true, KnownColor.Blue)]
     public void Paint_DarkMode_UsesStyleColorOnlyForCellBackground(
         bool selected,
-        KnownColor expectedBackColor,
-        KnownColor expectedForeColor)
+        KnownColor expectedBackColor)
     {
         if (SystemInformation.HighContrast)
         {
@@ -614,7 +612,6 @@ public class DataGridViewButtonCellTests : IDisposable
             DataGridViewButtonCell cell = (DataGridViewButtonCell)dataGridView[0, 0];
             DataGridViewCellStyle inheritedStyle = cell.InheritedStyle;
             Color expectedBack = Color.FromKnownColor(expectedBackColor);
-            Color expectedFore = Color.FromKnownColor(expectedForeColor);
             inheritedStyle.BackColor.Should().Be(Color.Red);
             inheritedStyle.ForeColor.Should().Be(Color.Green);
             inheritedStyle.SelectionBackColor.Should().Be(Color.Blue);
@@ -640,40 +637,11 @@ public class DataGridViewButtonCellTests : IDisposable
 
             bitmap.GetPixel(0, 0).ToArgb().Should().Be(expectedBack.ToArgb());
             bitmap.GetPixel(15, 10).Should().NotBe(expectedBack);
-            (Color BackColor, Color ForeColor) colors = cell.TestAccessor.Dynamic.GetButtonColors(
-                inheritedStyle,
-                selected,
-                paintSelectionBackground: true);
-            colors.Should().Be((expectedBack, expectedFore));
         }
         finally
         {
             applicationAccessor.s_colorMode = previousColorMode;
         }
-    }
-
-    [Theory]
-    [InlineData(false, KnownColor.Red, KnownColor.Green)]
-    [InlineData(true, KnownColor.Blue, KnownColor.Yellow)]
-    public void GetButtonColors_ReturnsCellStyleColors(
-        bool selected,
-        KnownColor expectedBackColor,
-        KnownColor expectedForeColor)
-    {
-        DataGridViewCellStyle style = new()
-        {
-            BackColor = Color.Red,
-            ForeColor = Color.Green,
-            SelectionBackColor = Color.Blue,
-            SelectionForeColor = Color.Yellow
-        };
-
-        (Color BackColor, Color ForeColor) result = _dataGridViewButtonCell.TestAccessor.Dynamic.GetButtonColors(
-            style,
-            cellSelected: selected,
-            paintSelectionBackground: true);
-
-        result.Should().Be((Color.FromKnownColor(expectedBackColor), Color.FromKnownColor(expectedForeColor)));
     }
 
     [Fact]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewButtonCellTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewButtonCellTests.cs
@@ -547,6 +547,7 @@ public class DataGridViewButtonCellTests : IDisposable
                 enable: true);
             using Bitmap bitmap = new(20, 20);
             using Graphics graphics = Graphics.FromImage(bitmap);
+            graphics.Clear(Color.Red);
             graphics.SmoothingMode = SmoothingMode.None;
             graphics.SmoothingMode.Should().Be(SmoothingMode.None);
 
@@ -571,6 +572,53 @@ public class DataGridViewButtonCellTests : IDisposable
             (Rectangle ContentBounds, Color TextColor) renderResult = ((Rectangle, Color))result!;
             renderResult.TextColor.Should().NotBe(Color.Green);
             bitmap.GetPixel(10, 10).Should().NotBe(Color.Red);
+        }
+        finally
+        {
+            applicationAccessor.s_colorMode = previousColorMode;
+        }
+    }
+
+    [WinFormsFact]
+    public void DrawButton_DarkMode_SystemStyle_AppliesPaddingAndUsesReadableDefaultTextColor()
+    {
+        if (SystemInformation.HighContrast)
+        {
+            return;
+        }
+
+        var applicationAccessor = typeof(Application).TestAccessor.Dynamic;
+        SystemColorMode? previousColorMode = applicationAccessor.s_colorMode;
+
+        try
+        {
+            applicationAccessor.s_colorMode = SystemColorMode.Dark;
+            using AppContextSwitchScope scope = new(
+                "System.Windows.Forms.DataGridViewDarkModeTheming",
+                enable: true);
+            using Bitmap bitmap = new(30, 30);
+            using Graphics graphics = Graphics.FromImage(bitmap);
+            Type rendererType = typeof(DataGridViewButtonCell).GetNestedType(
+                "DataGridViewButtonCellRenderer",
+                Reflection.BindingFlags.NonPublic)!;
+            Reflection.MethodInfo drawButton = rendererType.GetMethod(
+                "DrawButton",
+                Reflection.BindingFlags.Public | Reflection.BindingFlags.Static)!;
+
+            object? result = drawButton.Invoke(
+                null,
+                [
+                    graphics,
+                    new Rectangle(0, 0, 30, 30),
+                    VisualStyles.PushButtonState.Normal,
+                    true,
+                    FlatStyle.System,
+                    96
+                ]);
+
+            (Rectangle ContentBounds, Color TextColor) renderResult = ((Rectangle, Color))result!;
+            renderResult.ContentBounds.Should().Be(new Rectangle(5, 5, 20, 20));
+            renderResult.TextColor.GetBrightness().Should().BeGreaterThan(0.5f);
         }
         finally
         {

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewButtonCellTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewButtonCellTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
+using System.Drawing.Drawing2D;
 
 namespace System.Windows.Forms.Tests;
 
@@ -316,6 +317,52 @@ public class DataGridViewButtonCellTests : IDisposable
     }
 
     [WinFormsTheory]
+    [InlineData(VisualStyles.PushButtonState.Normal)]
+    [InlineData(VisualStyles.PushButtonState.Hot)]
+    [InlineData(VisualStyles.PushButtonState.Pressed)]
+    public void GetDarkModeTextColor_MatchesDrawButtonTextColor(VisualStyles.PushButtonState state)
+    {
+        if (SystemInformation.HighContrast)
+        {
+            return;
+        }
+
+        var applicationAccessor = typeof(Application).TestAccessor.Dynamic;
+        SystemColorMode? previousColorMode = applicationAccessor.s_colorMode;
+
+        try
+        {
+            applicationAccessor.s_colorMode = SystemColorMode.Dark;
+            using AppContextSwitchScope scope = new(
+                "System.Windows.Forms.DataGridViewDarkModeTheming",
+                enable: true);
+            using Bitmap bitmap = new(20, 20);
+            using Graphics graphics = Graphics.FromImage(bitmap);
+            Type rendererType = typeof(DataGridViewButtonCell).GetNestedType(
+                "DataGridViewButtonCellRenderer",
+                Reflection.BindingFlags.NonPublic)!;
+            Reflection.MethodInfo drawButton = rendererType.GetMethod(
+                "DrawButton",
+                Reflection.BindingFlags.Public | Reflection.BindingFlags.Static)!;
+            Reflection.MethodInfo getTextColor = rendererType.GetMethod(
+                "GetDarkModeTextColor",
+                Reflection.BindingFlags.Public | Reflection.BindingFlags.Static)!;
+
+            object? drawResult = drawButton.Invoke(
+                null,
+                [graphics, new Rectangle(0, 0, 20, 20), state, false, FlatStyle.Standard, 96, true]);
+            Color result = (Color)getTextColor.Invoke(null, [state, false, FlatStyle.Standard, true])!;
+            (Rectangle ContentBounds, Color TextColor) renderedButton = ((Rectangle, Color))drawResult!;
+
+            renderedButton.TextColor.Should().Be(result);
+        }
+        finally
+        {
+            applicationAccessor.s_colorMode = previousColorMode;
+        }
+    }
+
+    [WinFormsTheory]
     [InlineData(ButtonState.Pushed, true)]
     [InlineData(ButtonState.Normal, false)]
     [InlineData(ButtonState.Checked, false)]
@@ -481,8 +528,137 @@ public class DataGridViewButtonCellTests : IDisposable
         dataGridViewCellStyle.Font.Should().Be(SystemFonts.DefaultFont);
     }
 
-    [Fact]
-    public void GetButtonColors_ReturnsCellStyleColors()
+    [WinFormsFact]
+    public void DrawButton_DarkMode_RestoresGraphicsState()
+    {
+        if (SystemInformation.HighContrast)
+        {
+            return;
+        }
+
+        var applicationAccessor = typeof(Application).TestAccessor.Dynamic;
+        SystemColorMode? previousColorMode = applicationAccessor.s_colorMode;
+
+        try
+        {
+            applicationAccessor.s_colorMode = SystemColorMode.Dark;
+            using AppContextSwitchScope scope = new(
+                "System.Windows.Forms.DataGridViewDarkModeTheming",
+                enable: true);
+            using Bitmap bitmap = new(20, 20);
+            using Graphics graphics = Graphics.FromImage(bitmap);
+            graphics.SmoothingMode = SmoothingMode.None;
+            graphics.SmoothingMode.Should().Be(SmoothingMode.None);
+
+            Type rendererType = typeof(DataGridViewButtonCell).GetNestedType(
+                "DataGridViewButtonCellRenderer",
+                Reflection.BindingFlags.NonPublic)!;
+            Reflection.MethodInfo drawButton = rendererType.GetMethod(
+                "DrawButton",
+                Reflection.BindingFlags.Public | Reflection.BindingFlags.Static)!;
+            object? result = drawButton.Invoke(
+                null,
+                [
+                    graphics,
+                    new Rectangle(0, 0, 20, 20),
+                    VisualStyles.PushButtonState.Normal,
+                    false,
+                    FlatStyle.Standard,
+                    96,
+                    false
+                ]);
+
+            graphics.SmoothingMode.Should().Be(SmoothingMode.None);
+            (Rectangle ContentBounds, Color TextColor) renderResult = ((Rectangle, Color))result!;
+            renderResult.TextColor.Should().NotBe(Color.Green);
+            bitmap.GetPixel(10, 10).Should().NotBe(Color.Red);
+        }
+        finally
+        {
+            applicationAccessor.s_colorMode = previousColorMode;
+        }
+    }
+
+    [WinFormsTheory]
+    [InlineData(false, KnownColor.Red, KnownColor.Green)]
+    [InlineData(true, KnownColor.Blue, KnownColor.Yellow)]
+    public void Paint_DarkMode_UsesStyleColorOnlyForCellBackground(
+        bool selected,
+        KnownColor expectedBackColor,
+        KnownColor expectedForeColor)
+    {
+        if (SystemInformation.HighContrast)
+        {
+            return;
+        }
+
+        var applicationAccessor = typeof(Application).TestAccessor.Dynamic;
+        SystemColorMode? previousColorMode = applicationAccessor.s_colorMode;
+
+        try
+        {
+            applicationAccessor.s_colorMode = SystemColorMode.Dark;
+            using AppContextSwitchScope scope = new(
+                "System.Windows.Forms.DataGridViewDarkModeTheming",
+                enable: true);
+            using DataGridView dataGridView = new();
+            using DataGridViewButtonColumn column = new();
+            column.DefaultCellStyle.BackColor = Color.Red;
+            column.DefaultCellStyle.ForeColor = Color.Green;
+            column.DefaultCellStyle.SelectionBackColor = Color.Blue;
+            column.DefaultCellStyle.SelectionForeColor = Color.Yellow;
+            column.DefaultCellStyle.Padding = new Padding(2);
+            dataGridView.Columns.Add(column);
+            dataGridView.Rows.Add();
+
+            DataGridViewButtonCell cell = (DataGridViewButtonCell)dataGridView[0, 0];
+            DataGridViewCellStyle inheritedStyle = cell.InheritedStyle;
+            Color expectedBack = Color.FromKnownColor(expectedBackColor);
+            Color expectedFore = Color.FromKnownColor(expectedForeColor);
+            inheritedStyle.BackColor.Should().Be(Color.Red);
+            inheritedStyle.ForeColor.Should().Be(Color.Green);
+            inheritedStyle.SelectionBackColor.Should().Be(Color.Blue);
+            inheritedStyle.SelectionForeColor.Should().Be(Color.Yellow);
+
+            using Bitmap bitmap = new(30, 20);
+            using Graphics graphics = Graphics.FromImage(bitmap);
+            DataGridViewAdvancedBorderStyle borderStyle = new();
+            cell.TestAccessor.Dynamic.Paint(
+                graphics,
+                new Rectangle(0, 0, 30, 20),
+                new Rectangle(0, 0, 30, 20),
+                0,
+                selected ? DataGridViewElementStates.Selected : DataGridViewElementStates.None,
+                null,
+                null,
+                null,
+                inheritedStyle,
+                borderStyle,
+                DataGridViewPaintParts.Background
+                    | DataGridViewPaintParts.ContentBackground
+                    | DataGridViewPaintParts.SelectionBackground);
+
+            bitmap.GetPixel(0, 0).ToArgb().Should().Be(expectedBack.ToArgb());
+            bitmap.GetPixel(15, 10).Should().NotBe(expectedBack);
+            (Color BackColor, Color ForeColor) colors = cell.TestAccessor.Dynamic.GetButtonColors(
+                inheritedStyle,
+                selected,
+                paintSelectionBackground: true);
+            colors.Should().Be((expectedBack, expectedFore));
+        }
+        finally
+        {
+            applicationAccessor.s_colorMode = previousColorMode;
+        }
+    }
+
+    [Theory]
+    [InlineData(false, KnownColor.Red, KnownColor.Green)]
+    [InlineData(true, KnownColor.Blue, KnownColor.Yellow)]
+    public void GetButtonColors_ReturnsCellStyleColors(
+        bool selected,
+        KnownColor expectedBackColor,
+        KnownColor expectedForeColor)
     {
         DataGridViewCellStyle style = new()
         {
@@ -494,10 +670,10 @@ public class DataGridViewButtonCellTests : IDisposable
 
         (Color BackColor, Color ForeColor) result = _dataGridViewButtonCell.TestAccessor.Dynamic.GetButtonColors(
             style,
-            cellSelected: false,
+            cellSelected: selected,
             paintSelectionBackground: true);
 
-        result.Should().Be((style.BackColor, style.ForeColor));
+        result.Should().Be((Color.FromKnownColor(expectedBackColor), Color.FromKnownColor(expectedForeColor)));
     }
 
     [Fact]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewCellTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewCellTests.cs
@@ -240,6 +240,55 @@ public partial class DataGridViewCellTests
         Assert.Equal(value, cell.ContextMenuStrip);
     }
 
+    [WinFormsFact]
+    public void DataGridViewCell_DrawFocusRectangle_DarkMode_UsesSharedFocusBorderColor()
+    {
+        if (SystemInformation.HighContrast)
+        {
+            return;
+        }
+
+        var applicationAccessor = typeof(Application).TestAccessor.Dynamic;
+        SystemColorMode? previousColorMode = applicationAccessor.s_colorMode;
+
+        try
+        {
+            applicationAccessor.s_colorMode = SystemColorMode.Dark;
+            using AppContextSwitchScope scope = new(
+                "System.Windows.Forms.DataGridViewDarkModeTheming",
+                enable: true);
+            using Bitmap bitmap = new(10, 10);
+            using Graphics graphics = Graphics.FromImage(bitmap);
+            graphics.Clear(Color.Black);
+
+            DataGridViewCell.DrawFocusRectangle(
+                graphics,
+                new Rectangle(1, 1, 8, 8),
+                Color.Red,
+                Color.Black);
+
+            Color expectedColor = DarkModeButtonColors.DefaultColors.FocusBorderColor;
+            bool containsFocusColor = false;
+            for (int y = 0; y < bitmap.Height && !containsFocusColor; y++)
+            {
+                for (int x = 0; x < bitmap.Width; x++)
+                {
+                    if (bitmap.GetPixel(x, y).ToArgb() == expectedColor.ToArgb())
+                    {
+                        containsFocusColor = true;
+                        break;
+                    }
+                }
+            }
+
+            containsFocusColor.Should().BeTrue();
+        }
+        finally
+        {
+            applicationAccessor.s_colorMode = previousColorMode;
+        }
+    }
+
     [WinFormsTheory]
     [MemberData(nameof(ContextMenuStrip_Set_TestData))]
     public void DataGridViewCell_ContextMenuStrip_SetWithRow_GetReturnsExpected(ContextMenuStrip value)

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewComboBoxCellTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewComboBoxCellTests.cs
@@ -279,11 +279,11 @@ public class DataGridViewComboBoxCellTests : IDisposable
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
-    public void GetTextColor_WithDarkModeColors_ReturnsWhite(bool selected)
+    public void GetTextColor_WithDarkModeColors_ReturnsThemeColor(bool selected)
     {
         DataGridViewCellStyle style = new()
         {
-            ForeColor = Color.White,
+            ForeColor = Color.Black,
             SelectionForeColor = Color.Yellow
         };
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewComboBoxCellTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewComboBoxCellTests.cs
@@ -297,6 +297,32 @@ public class DataGridViewComboBoxCellTests : IDisposable
     }
 
     [Theory]
+    [InlineData(false, false, "COMBOBOX", 6)]
+    [InlineData(true, false, "COMBOBOX", 7)]
+    [InlineData(false, true, "DarkMode_CFD::COMBOBOX", 6)]
+    [InlineData(true, true, "DarkMode_CFD::COMBOBOX", 7)]
+    public void GetDropDownButtonElement_ReturnsExpectedElement(
+        bool rightToLeft,
+        bool useDarkMode,
+        string expectedClassName,
+        int expectedPart)
+    {
+        Type rendererType = typeof(DataGridViewComboBoxCell).GetNestedType(
+            "DataGridViewComboBoxCellRenderer",
+            Reflection.BindingFlags.NonPublic)!;
+        Reflection.MethodInfo getElement = rendererType.GetMethod(
+            "GetDropDownButtonElement",
+            Reflection.BindingFlags.Public | Reflection.BindingFlags.Static)!;
+
+        VisualStyles.VisualStyleElement result = (VisualStyles.VisualStyleElement)getElement.Invoke(
+            null,
+            [rightToLeft, useDarkMode])!;
+
+        result.ClassName.Should().Be(expectedClassName);
+        result.Part.Should().Be(expectedPart);
+    }
+
+    [Theory]
     [InlineData(Keys.A, false, false, false, true)]
     [InlineData(Keys.F4, false, false, false, true)]
     [InlineData(Keys.Space, false, false, false, true)]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewComboBoxCellTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewComboBoxCellTests.cs
@@ -277,6 +277,26 @@ public class DataGridViewComboBoxCellTests : IDisposable
     }
 
     [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void GetTextColor_WithDarkModeColors_ReturnsWhite(bool selected)
+    {
+        DataGridViewCellStyle style = new()
+        {
+            ForeColor = Color.White,
+            SelectionForeColor = Color.Yellow
+        };
+
+        Color result = _dataGridViewComboBoxCell.TestAccessor.Dynamic.GetTextColor(
+            style,
+            selected,
+            useVisualStyleTextColor: true,
+            useDarkModeColors: true);
+
+        result.Should().Be(Color.White);
+    }
+
+    [Theory]
     [InlineData(Keys.A, false, false, false, true)]
     [InlineData(Keys.F4, false, false, false, true)]
     [InlineData(Keys.Space, false, false, false, true)]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewComboBoxCellTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewComboBoxCellTests.cs
@@ -277,52 +277,6 @@ public class DataGridViewComboBoxCellTests : IDisposable
     }
 
     [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public void GetTextColor_WithDarkModeColors_ReturnsThemeColor(bool selected)
-    {
-        DataGridViewCellStyle style = new()
-        {
-            ForeColor = Color.Black,
-            SelectionForeColor = Color.Yellow
-        };
-
-        Color result = _dataGridViewComboBoxCell.TestAccessor.Dynamic.GetTextColor(
-            style,
-            selected,
-            useVisualStyleTextColor: true,
-            useDarkModeColors: true);
-
-        result.Should().Be(Color.White);
-    }
-
-    [Theory]
-    [InlineData(false, false, "COMBOBOX", 6)]
-    [InlineData(true, false, "COMBOBOX", 7)]
-    [InlineData(false, true, "DarkMode_CFD::COMBOBOX", 6)]
-    [InlineData(true, true, "DarkMode_CFD::COMBOBOX", 7)]
-    public void GetDropDownButtonElement_ReturnsExpectedElement(
-        bool rightToLeft,
-        bool useDarkMode,
-        string expectedClassName,
-        int expectedPart)
-    {
-        Type rendererType = typeof(DataGridViewComboBoxCell).GetNestedType(
-            "DataGridViewComboBoxCellRenderer",
-            Reflection.BindingFlags.NonPublic)!;
-        Reflection.MethodInfo getElement = rendererType.GetMethod(
-            "GetDropDownButtonElement",
-            Reflection.BindingFlags.Public | Reflection.BindingFlags.Static)!;
-
-        VisualStyles.VisualStyleElement result = (VisualStyles.VisualStyleElement)getElement.Invoke(
-            null,
-            [rightToLeft, useDarkMode])!;
-
-        result.ClassName.Should().Be(expectedClassName);
-        result.Part.Should().Be(expectedPart);
-    }
-
-    [Theory]
     [InlineData(Keys.A, false, false, false, true)]
     [InlineData(Keys.F4, false, false, false, true)]
     [InlineData(Keys.Space, false, false, false, true)]

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewComboBoxCellTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataGridViewComboBoxCellTests.cs
@@ -276,6 +276,60 @@ public class DataGridViewComboBoxCellTests : IDisposable
         result.Should().Be(new Size(-1, -1));
     }
 
+    [WinFormsTheory]
+    [InlineData(false, KnownColor.Lime)]
+    [InlineData(true, KnownColor.Yellow)]
+    public void Paint_DarkMode_UsesCellStyleTextColor(bool selected, KnownColor expectedColor)
+    {
+        if (SystemInformation.HighContrast)
+        {
+            return;
+        }
+
+        var applicationAccessor = typeof(Application).TestAccessor.Dynamic;
+        SystemColorMode? previousColorMode = applicationAccessor.s_colorMode;
+
+        try
+        {
+            applicationAccessor.s_colorMode = SystemColorMode.Dark;
+            using AppContextSwitchScope scope = new(
+                "System.Windows.Forms.DataGridViewDarkModeTheming",
+                enable: true);
+            using DataGridView dataGridView = new();
+            using DataGridViewComboBoxColumn column = new();
+            column.Items.Add("MMMM");
+            column.DefaultCellStyle.BackColor = Color.Black;
+            column.DefaultCellStyle.ForeColor = Color.Lime;
+            column.DefaultCellStyle.SelectionBackColor = Color.Black;
+            column.DefaultCellStyle.SelectionForeColor = Color.Yellow;
+            dataGridView.Columns.Add(column);
+            dataGridView.Rows.Add("MMMM");
+
+            DataGridViewComboBoxCell cell = (DataGridViewComboBoxCell)dataGridView[0, 0];
+            using Bitmap bitmap = new(120, 30);
+            using Graphics graphics = Graphics.FromImage(bitmap);
+            graphics.Clear(Color.Black);
+            cell.TestAccessor.Dynamic.Paint(
+                graphics,
+                new Rectangle(0, 0, bitmap.Width, bitmap.Height),
+                new Rectangle(0, 0, bitmap.Width, bitmap.Height),
+                0,
+                selected ? DataGridViewElementStates.Selected : DataGridViewElementStates.None,
+                "MMMM",
+                "MMMM",
+                null,
+                cell.InheritedStyle,
+                new DataGridViewAdvancedBorderStyle(),
+                DataGridViewPaintParts.ContentForeground);
+
+            ContainsPixel(bitmap, Color.FromKnownColor(expectedColor)).Should().BeTrue();
+        }
+        finally
+        {
+            applicationAccessor.s_colorMode = previousColorMode;
+        }
+    }
+
     [Theory]
     [InlineData(Keys.A, false, false, false, true)]
     [InlineData(Keys.F4, false, false, false, true)]
@@ -325,6 +379,23 @@ public class DataGridViewComboBoxCellTests : IDisposable
             TypeDescriptor.GetConverter(typeof(string)));
 
         result.Should().Be("test");
+    }
+
+    private static bool ContainsPixel(Bitmap bitmap, Color color)
+    {
+        int argb = color.ToArgb();
+        for (int y = 0; y < bitmap.Height; y++)
+        {
+            for (int x = 0; x < bitmap.Width; x++)
+            {
+                if (bitmap.GetPixel(x, y).ToArgb() == argb)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     [Fact]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #15077

## Root Cause

DataGridViewComboBoxCell continued using visual-style colors that could return dark text on a dark background. 
DataGridViewButtonCell used the legacy visual-style renderer instead of the dark-mode renderers used by regular WinForms buttons. 

## Proposed changes

- Render DataGridView ComboBox text, border, and drop-down button using dark-compatible colors.
- Reuse the existing WinForms dark-mode Button renderers for DataGridView Button cells.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

-  Customers using dark-mode DataGridViews receive readable ComboBox content and consistent Button rendering, with clearer mouse and keyboard interaction feedback.

## Regression? 

- No

## Risk

- minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
ComboBox cell text could be unreadable against a dark background.
DataGridView Button cells did not visually match regular WinForms buttons in dark mode.

<img width="1380" height="317" alt="BeforeChanges" src="https://github.com/user-attachments/assets/8860fe95-4a9f-4f11-81f8-4f8b78f21099" />


### After
ComboBox text is readable in both selected and unselected dark-mode cells.
DataGridView Button cells use the same dark-mode rendering as regular WinForms buttons.

https://github.com/user-attachments/assets/cef9511c-ee6f-43f9-830e-764fd64e334a



## Test methodology <!-- How did you ensure quality? -->

- Manual test and unit test


## Test environment(s) <!-- Remove any that don't apply -->

- .net 11.0.0-beta.26458.117


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/15075)