### PR TITLE
Test InputLanguage without modifying the Windows language list

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Input/InputLanguage.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Input/InputLanguage.cs
@@ -186,48 +186,56 @@ public sealed class InputLanguage
     ///  </see>
     ///  of the current input language.
     /// </summary>
-    private string LanguageTag
-    {
-        get
-        {
-            // According to the GetKeyboardLayout API function docs low word of HKL contains input language identifier.
-            int langId = PARAM.LOWORD(_handle);
+    // The low word of HKL contains the input language identifier.
+    private string LanguageTag => GetLanguageTag(PARAM.LOWORD(_handle), GetTransientLanguages);
 
-            // We need to convert the language identifier to a language tag, because they are deprecated and may have a
-            // transient value.
-            // https://learn.microsoft.com/globalization/locale/other-locale-names#lcid
-            // https://learn.microsoft.com/windows/win32/winmsg/wm-inputlangchange#remarks
-            //
-            // It turns out that the LCIDToLocaleName API, which is used inside CultureInfo, may return incorrect
-            // language tags for transient language identifiers. For example, it returns "nqo-GN" and "jv-Java-ID"
-            // instead of the "nqo" and "jv-Java" (as seen in the Get-WinUserLanguageList PowerShell cmdlet).
-            //
-            // Try to extract proper language tag from registry as a workaround approved by a Windows team.
-            // https://github.com/dotnet/winforms/pull/8573#issuecomment-1542600949
-            //
-            // NOTE: this logic may break in future versions of Windows since it is not documented.
-            if (langId is (int)PInvoke.LOCALE_TRANSIENT_KEYBOARD1
-                or (int)PInvoke.LOCALE_TRANSIENT_KEYBOARD2
-                or (int)PInvoke.LOCALE_TRANSIENT_KEYBOARD3
-                or (int)PInvoke.LOCALE_TRANSIENT_KEYBOARD4)
+    internal static string GetLanguageTag(int langId, Func<IEnumerable<KeyValuePair<string, int>>> getTransientLanguages)
+    {
+        // We need to convert the language identifier to a language tag, because they are deprecated and may have a
+        // transient value.
+        // https://learn.microsoft.com/globalization/locale/other-locale-names#lcid
+        // https://learn.microsoft.com/windows/win32/winmsg/wm-inputlangchange#remarks
+        //
+        // It turns out that the LCIDToLocaleName API, which is used inside CultureInfo, may return incorrect
+        // language tags for transient language identifiers. For example, it returns "nqo-GN" and "jv-Java-ID"
+        // instead of the "nqo" and "jv-Java" (as seen in the Get-WinUserLanguageList PowerShell cmdlet).
+        //
+        // Try to extract proper language tag from registry as a workaround approved by a Windows team.
+        // https://github.com/dotnet/winforms/pull/8573#issuecomment-1542600949
+        //
+        // NOTE: this logic may break in future versions of Windows since it is not documented.
+        if (langId is (int)PInvoke.LOCALE_TRANSIENT_KEYBOARD1
+            or (int)PInvoke.LOCALE_TRANSIENT_KEYBOARD2
+            or (int)PInvoke.LOCALE_TRANSIENT_KEYBOARD3
+            or (int)PInvoke.LOCALE_TRANSIENT_KEYBOARD4)
+        {
+            foreach ((string language, int transientLangId) in getTransientLanguages())
             {
-                using RegistryKey? key = Registry.CurrentUser.OpenSubKey(UserProfileRegistryPath);
-                if (key is not null && key.GetValue("Languages") is string[] languages)
+                if (transientLangId == langId)
                 {
-                    foreach (string language in languages)
-                    {
-                        using RegistryKey? subKey = key.OpenSubKey(language);
-                        if (subKey is not null
-                            && subKey.GetValue("TransientLangId") is int transientLangId
-                            && transientLangId == langId)
-                        {
-                            return language;
-                        }
-                    }
+                    return language;
                 }
             }
+        }
 
-            return CultureInfo.GetCultureInfo(langId).Name;
+        return CultureInfo.GetCultureInfo(langId).Name;
+    }
+
+    private static IEnumerable<KeyValuePair<string, int>> GetTransientLanguages()
+    {
+        using RegistryKey? key = Registry.CurrentUser.OpenSubKey(UserProfileRegistryPath);
+        if (key is null || key.GetValue("Languages") is not string[] languages)
+        {
+            yield break;
+        }
+
+        foreach (string language in languages)
+        {
+            using RegistryKey? subKey = key.OpenSubKey(language);
+            if (subKey?.GetValue("TransientLangId") is int transientLangId)
+            {
+                yield return new(language, transientLangId);
+            }
         }
     }
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/InputLanguageChangedEventArgsTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/InputLanguageChangedEventArgsTests.cs
@@ -12,8 +12,11 @@ public class InputLanguageChangedEventArgsTests
 {
     public static IEnumerable<object[]> Ctor_CultureInfo_Byte_TestData()
     {
-        yield return new object[] { new CultureInfo("en-US"), 0 };
-        yield return new object[] { new CultureInfo("en-US"), 1 };
+        foreach (InputLanguage language in InputLanguage.InstalledInputLanguages)
+        {
+            yield return new object[] { language.Culture, 0 };
+            yield return new object[] { language.Culture, 1 };
+        }
     }
 
     [Theory]
@@ -47,20 +50,17 @@ public class InputLanguageChangedEventArgsTests
 
     public static IEnumerable<object[]> Ctor_InputLanguage_Byte_TestData()
     {
-        yield return new object[] { InputLanguage.FromCulture(CultureInfo.InvariantCulture), 0 };
-        yield return new object[] { InputLanguage.FromCulture(new CultureInfo("en")), 1 };
+        foreach (InputLanguage language in InputLanguage.InstalledInputLanguages)
+        {
+            yield return new object[] { language, 0 };
+            yield return new object[] { language, 1 };
+        }
     }
 
     [Theory]
     [MemberData(nameof(Ctor_InputLanguage_Byte_TestData))]
     public void Ctor_InputLanguage_Byte(InputLanguage inputLanguage, byte charSet)
     {
-        if (inputLanguage is null)
-        {
-            // Couldn't get the language.
-            return;
-        }
-
         InputLanguageChangedEventArgs e = new(inputLanguage, charSet);
         Assert.Equal(inputLanguage, e.InputLanguage);
         Assert.Equal(inputLanguage.Culture, e.Culture);

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/InputLanguageChangingEventArgsTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/InputLanguageChangingEventArgsTests.cs
@@ -12,8 +12,11 @@ public class InputLanguageChangingEventArgsTests
 {
     public static IEnumerable<object[]> Ctor_CultureInfo_Bool_TestData()
     {
-        yield return new object[] { new CultureInfo("en-US"), true };
-        yield return new object[] { new CultureInfo("en-US"), false };
+        foreach (InputLanguage language in InputLanguage.InstalledInputLanguages)
+        {
+            yield return new object[] { language.Culture, true };
+            yield return new object[] { language.Culture, false };
+        }
     }
 
     [Theory]
@@ -48,20 +51,17 @@ public class InputLanguageChangingEventArgsTests
 
     public static IEnumerable<object[]> Ctor_InputLanguage_Bool_TestData()
     {
-        yield return new object[] { InputLanguage.FromCulture(CultureInfo.InvariantCulture), true };
-        yield return new object[] { InputLanguage.FromCulture(new CultureInfo("en")), false };
+        foreach (InputLanguage language in InputLanguage.InstalledInputLanguages)
+        {
+            yield return new object[] { language, true };
+            yield return new object[] { language, false };
+        }
     }
 
     [Theory]
     [MemberData(nameof(Ctor_InputLanguage_Bool_TestData))]
     public void Ctor_InputLanguage_Bool(InputLanguage inputLanguage, bool sysCharSet)
     {
-        if (inputLanguage is null)
-        {
-            // Couldn't get the language.
-            return;
-        }
-
         InputLanguageChangingEventArgs e = new(inputLanguage, sysCharSet);
         Assert.Equal(inputLanguage, e.InputLanguage);
         Assert.Equal(inputLanguage.Culture, e.Culture);

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/InputLanguageTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/InputLanguageTests.cs
@@ -40,24 +40,27 @@ public class InputLanguageTests
     [Fact]
     public void InputLanguage_CurrentInputLanguage_Set_GetReturnsExpected()
     {
-        InputLanguage language = InputLanguage.CurrentInputLanguage;
+        InputLanguage original = InputLanguage.CurrentInputLanguage;
         try
         {
             // Set null.
             InputLanguage.CurrentInputLanguage = null;
             Assert.Equal(InputLanguage.DefaultInputLanguage, InputLanguage.CurrentInputLanguage);
 
-            // Set other.
-            InputLanguage.CurrentInputLanguage = language;
-            Assert.Equal(language, InputLanguage.CurrentInputLanguage);
+            foreach (InputLanguage language in InputLanguage.InstalledInputLanguages)
+            {
+                // Set other.
+                InputLanguage.CurrentInputLanguage = language;
+                Assert.Equal(language, InputLanguage.CurrentInputLanguage);
 
-            // Set same.
-            InputLanguage.CurrentInputLanguage = language;
-            Assert.Equal(language, InputLanguage.CurrentInputLanguage);
+                // Set same.
+                InputLanguage.CurrentInputLanguage = language;
+                Assert.Equal(language, InputLanguage.CurrentInputLanguage);
+            }
         }
-        catch
+        finally
         {
-            InputLanguage.CurrentInputLanguage = language;
+            InputLanguage.CurrentInputLanguage = original;
         }
     }
 
@@ -65,7 +68,15 @@ public class InputLanguageTests
     public void InputLanguage_CurrentInputLanguage_SetInvalidValue_ThrowsArgumentException()
     {
         InputLanguage language = Assert.IsType<InputLanguage>(Activator.CreateInstance(typeof(InputLanguage), BindingFlags.Instance | BindingFlags.NonPublic, null, [(IntPtr)250], null));
-        Assert.Throws<ArgumentException>("value", () => InputLanguage.CurrentInputLanguage = language);
+        InputLanguage original = InputLanguage.CurrentInputLanguage;
+        try
+        {
+            Assert.Throws<ArgumentException>("value", () => InputLanguage.CurrentInputLanguage = language);
+        }
+        finally
+        {
+            InputLanguage.CurrentInputLanguage = original;
+        }
     }
 
     public static IEnumerable<object[]> Equals_TestData()
@@ -85,11 +96,16 @@ public class InputLanguageTests
     [Fact]
     public void InputLanguage_FromCulture_Roundtrip_Success()
     {
-        InputLanguage language = InputLanguage.CurrentInputLanguage;
-        InputLanguage result = InputLanguage.FromCulture(language.Culture);
-        Assert.NotSame(language, result);
-        Assert.Equal(language, result);
-        VerifyInputLanguage(result);
+        InputLanguageCollection installed = InputLanguage.InstalledInputLanguages;
+        foreach (InputLanguage language in installed)
+        {
+            InputLanguage result = InputLanguage.FromCulture(language.Culture);
+            Assert.NotNull(result);
+            Assert.NotSame(language, result);
+            Assert.Equal(language.Culture, result.Culture);
+            Assert.Equal(installed.Cast<InputLanguage>().First(item => item.Culture.Equals(language.Culture)), result);
+            VerifyInputLanguage(result);
+        }
     }
 
     [Fact]
@@ -132,34 +148,67 @@ public class InputLanguageTests
 
     public static IEnumerable<object[]> SupplementalInputLanguages_TestData()
     {
-        yield return new object[] { "got-Goth", "000C0C00", "Gothic" };
-        yield return new object[] { "jv-Java", "00110C00", "Javanese" };
-        yield return new object[] { "zgh-Tfng", "0000105F", "Tifinagh (Basic)" };
-
-        // N’Ko input test failed in Windows 11 version 21H2.
-        if (OsVersion.IsWindows11_22H2OrGreater())
+        foreach (string languageTag in new[] { "got-Goth", "jv-Java", "zgh-Tfng", "nqo" })
         {
-            yield return new object[] { "nqo", "00090C00", "N’Ko" };
+            yield return new object[] { languageTag, (int)PInvoke.LOCALE_TRANSIENT_KEYBOARD1 };
+            yield return new object[] { languageTag, (int)PInvoke.LOCALE_TRANSIENT_KEYBOARD2 };
+            yield return new object[] { languageTag, (int)PInvoke.LOCALE_TRANSIENT_KEYBOARD3 };
+            yield return new object[] { languageTag, (int)PInvoke.LOCALE_TRANSIENT_KEYBOARD4 };
         }
     }
 
     [Theory]
     [MemberData(nameof(SupplementalInputLanguages_TestData))]
-    public void InputLanguage_FromCulture_SupplementalInputLanguages_Expected(string languageTag, string layoutId, string layoutName)
+    public void InputLanguage_GetLanguageTag_SupplementalInputLanguages_Expected(string languageTag, int langId)
     {
-        // Also installs default keyboard layout for this language
-        // https://learn.microsoft.com/windows-hardware/manufacture/desktop/default-input-locales-for-windows-language-packs
-        InstallUserLanguage(languageTag);
+        KeyValuePair<string, int>[] languages = [new("en-US", 0x0409), new(languageTag, langId), new("fr-FR", 0x040c)];
+        string actual = InputLanguage.GetLanguageTag(langId, () => languages);
+        Assert.Equal(languageTag, actual);
+    }
 
-        try
+    [Theory]
+    [InlineData(0x0409, "en-US")]
+    [InlineData(0x0415, "pl-PL")]
+    public void InputLanguage_GetLanguageTag_StandardLanguage_DoesNotReadUserProfile(int langId, string expected)
+    {
+        Assert.Equal(expected, InputLanguage.GetLanguageTag(langId, () => throw new InvalidOperationException()));
+    }
+
+    [Theory]
+    [InlineData((int)PInvoke.LOCALE_TRANSIENT_KEYBOARD1)]
+    [InlineData((int)PInvoke.LOCALE_TRANSIENT_KEYBOARD2)]
+    [InlineData((int)PInvoke.LOCALE_TRANSIENT_KEYBOARD3)]
+    [InlineData((int)PInvoke.LOCALE_TRANSIENT_KEYBOARD4)]
+    public void InputLanguage_GetLanguageTag_DuplicateMatches_ReturnsFirst(int langId)
+    {
+        KeyValuePair<string, int>[] languages = [new("got-Goth", langId), new("jv-Java", langId)];
+        Assert.Equal("got-Goth", InputLanguage.GetLanguageTag(langId, () => languages));
+    }
+
+    [Theory]
+    [InlineData((int)PInvoke.LOCALE_TRANSIENT_KEYBOARD1)]
+    [InlineData((int)PInvoke.LOCALE_TRANSIENT_KEYBOARD2)]
+    [InlineData((int)PInvoke.LOCALE_TRANSIENT_KEYBOARD3)]
+    [InlineData((int)PInvoke.LOCALE_TRANSIENT_KEYBOARD4)]
+    public void InputLanguage_GetLanguageTag_NoMatch_UsesCultureInfoFallback(int langId)
+    {
+        // A transient ID may not be known to CultureInfo on this machine. Preserve that behavior too.
+        string expected = null;
+        Exception expectedException = Record.Exception(() => expected = CultureInfo.GetCultureInfo(langId).Name);
+        KeyValuePair<string, int>[][] languageLists = [[], [new("en-US", 0x0409)]];
+        foreach (KeyValuePair<string, int>[] languages in languageLists)
         {
-            CultureInfo culture = new(languageTag);
-            InputLanguage language = InputLanguage.FromCulture(culture);
-            VerifyInputLanguage(language, languageTag, layoutId, layoutName);
-        }
-        finally
-        {
-            UninstallUserLanguage(languageTag);
+            bool readLanguages = false;
+            string actual = null;
+            Exception actualException = Record.Exception(() => actual = InputLanguage.GetLanguageTag(langId, () =>
+            {
+                readLanguages = true;
+                return languages;
+            }));
+
+            Assert.True(readLanguages);
+            Assert.Equal(expectedException?.GetType(), actualException?.GetType());
+            Assert.Equal(expected, actual);
         }
     }
 
@@ -210,43 +259,5 @@ public class InputLanguageTests
         Assert.NotEmpty(language.LayoutName);
         Assert.NotEqual(SR.UnknownInputLanguageLayout, language.LayoutName);
         Assert.DoesNotContain('\0', language.LayoutName);
-    }
-
-    private static void RunPowerShellScript(string path)
-    {
-        using Process process = new();
-
-        process.StartInfo.FileName = "powershell.exe";
-        process.StartInfo.Arguments = $"-NoProfile -ExecutionPolicy ByPass -File \"{path}\"";
-
-        process.Start();
-        process.WaitForExit();
-    }
-
-    private static void InstallUserLanguage(string languageTag)
-    {
-        string file = Path.Join(Path.GetTempPath(), $"install-language-{languageTag}.ps1");
-        string script = $$"""
-            $list = Get-WinUserLanguageList
-            $list.Add("{{languageTag}}")
-            Set-WinUserLanguageList $list -force
-            """;
-
-        using TempFile tempFile = new(file, script);
-        RunPowerShellScript(tempFile.Path);
-    }
-
-    private static void UninstallUserLanguage(string languageTag)
-    {
-        string file = Path.Join(Path.GetTempPath(), $"uninstall-language-{languageTag}.ps1");
-        string script = $$"""
-            $list = Get-WinUserLanguageList
-            $item = $list | Where-Object {$_.LanguageTag -like "{{languageTag}}"}
-            $list.Remove($item)
-            Set-WinUserLanguageList $list -force
-            """;
-
-        using TempFile tempFile = new(file, script);
-        RunPowerShellScript(tempFile.Path);
     }
 }


### PR DESCRIPTION
Fixes #13274

cc @LeafShi1: this issue is still assigned to you. I did not find an open PR touching
these files; please let me know if there is ongoing work to coordinate with. Opening
as a draft for that coordination and review of the small internal testability extraction.

## Proposed changes

- Replace the supplemental-language tests' PowerShell install/uninstall steps with
  deterministic tests of the existing language-tag mapping. Tests no longer call
  `Set-WinUserLanguageList` or modify the user's installed language list.
- Extract an internal mapping helper with a per-call language source. Cover all four
  transient keyboard IDs with `got-Goth`, `jv-Java`, `zgh-Tfng`, and `nqo`, plus
  non-transient bypass, first-match selection, and the existing `CultureInfo` fallback
  for empty/nonmatching sources. Production registry lookup remains lazy and ordered.
- Use installed layouts for `FromCulture`, current-language, and associated event-args
  tests. Handle multiple layouts sharing a culture without assuming that `FromCulture`
  selects a particular handle other than the first matching installed layout.
- Restore the original current input language in `finally`, on success and failure.
  The old setter test's `catch` swallowed assertion failures. Remove event-args tests'
  early returns that could pass without exercising the constructor.

## Customer Impact

- Contributors can run these tests without adding/removing Windows languages or
  having an `en-US` input layout installed.
- Supplemental mapping coverage no longer depends on Windows applying a language-list
  update before the next assertion. Real installed-layout integration coverage remains.

## Regression?

- No new product behavior is intended; this addresses existing test issues.

## Risk

- Low: four InputLanguage-related files only; no public API changes or global test hook.
- The internal extraction preserves the transient-ID gate, registry order, first-match
  behavior, fallback, and disposal. It does not change `FromCulture` or layout activation.

## Test methodology

- Based on `main` at `8efd9a920dba90722f8db1f7e943f74837d26579`.
- Baseline `InputLanguage*` selection: **34 passed, 4 failed**. The four event-args cases
  required an unavailable `en-US` input language. The old supplemental installer test
  was deliberately not executed because it changes the real Windows language list;
  this is not a claim to have reproduced the installation timing race in #13274.
- Patched `InputLanguage*` selection: **64 passed, 0 failed, 0 skipped** with each of
  `--culture pl-PL` and `--culture en-US`, without an exclusion filter.
- Controlled mutation checks: removing the fourth transient ID caused six mapping
  failures; an injected setter assertion was reported with `finally` but incorrectly
  passed with the old `catch` policy. All temporary mutations were removed.
- Release build: zero warnings and errors. No retries or skip conditions added.
  Validation is targeted; the full repository test suite was not run for this PR.

Targeted invocation after building the unit-test project:

```powershell
.\.dotnet\dotnet.exe artifacts\bin\System.Windows.Forms.Tests\Release\net11.0-windows7.0\System.Windows.Forms.Tests.dll `
  --culture pl-PL --filter-class 'System.Windows.Forms.Tests.InputLanguage*'
```

## Test environment(s)

- Windows 11 25H2 x64, build 26200.9168; Polish input layout, no `en-US` input layout.
- SDK `11.0.100-rc.1.26420.103`; test runtime `12.0.0-alpha.1.26458.117` as required by main.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/15076)