### PR TITLE
Isolate ListViewItem hover tests from the physical cursor

### DIFF
--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/ListViewItem.IKeyboardToolTipTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/ListViewItem.IKeyboardToolTipTests.cs
@@ -4,6 +4,8 @@
 #nullable disable
 
 using System.Drawing;
+using Moq;
+using Moq.Protected;
 using static System.Windows.Forms.ListViewItem;
 
 namespace System.Windows.Forms.Tests;
@@ -682,10 +684,8 @@ public class ListViewItem_IKeyboardToolTipTests
         Assert.Equal(expected, ((IKeyboardToolTip)listViewItem).HasRtlModeEnabled());
     }
 
-    [ActiveIssue("https://github.com/dotnet/winforms/issues/12319")]
     [WinFormsTheory]
-    // Comment the data out due to ActiveIssue "https://github.com/dotnet/winforms/issues/12319".
-    // [InlineData(true, true, true, true)]
+    [InlineData(true, true, true, true)]
     [InlineData(true, true, false, false)]
     [InlineData(true, false, true, true)]
     [InlineData(true, false, false, false)]
@@ -696,33 +696,29 @@ public class ListViewItem_IKeyboardToolTipTests
         bool isHovered,
         bool expected)
     {
-        Point initialPosition = Cursor.Position;
-        try
+        Mock<ListView> mockListView = new() { CallBase = true };
+        using ListView listView = mockListView.Object;
+        listView.VirtualMode = virtualMode;
+        listView.VirtualListSize = 1;
+
+        // Cover every possible virtual-screen coordinate without moving the physical cursor.
+        // https://learn.microsoft.com/windows/win32/gdi/the-virtual-screen
+        Rectangle bounds = isHovered
+            ? new(short.MinValue, short.MinValue, ushort.MaxValue + 1, ushort.MaxValue + 1)
+            : Rectangle.Empty;
+        Mock<ListView.ListViewAccessibleObject> mockAccessibleObject = new(MockBehavior.Strict, listView);
+        mockAccessibleObject.Setup(a => a.Bounds).Returns(bounds);
+        mockListView.Protected().Setup<AccessibleObject>("CreateAccessibilityInstance").Returns(mockAccessibleObject.Object);
+
+        ListViewItem listViewItem = new();
+        if (insideListView)
         {
-            ListViewItem listViewItem = new();
-            using var listView = GetListView(virtualMode);
-
-            if (insideListView)
-            {
-                listViewItem = AssignItemToListView(listView, listViewItem);
-            }
-
-            listView.CreateControl();
-
-            Point position = listView.AccessibilityObject.Bounds.Location;
-            if (!isHovered)
-            {
-                position.X--;
-                position.Y--;
-            }
-
-            Cursor.Position = position;
-            Assert.Equal(expected, ((IKeyboardToolTip)listViewItem).IsHoveredWithMouse());
+            listViewItem = AssignItemToListView(listView, listViewItem);
         }
-        finally
-        {
-            Cursor.Position = initialPosition;
-        }
+
+        Assert.Equal(expected, ((IKeyboardToolTip)listViewItem).IsHoveredWithMouse());
+        mockAccessibleObject.VerifyGet(a => a.Bounds, insideListView ? Times.AtLeastOnce() : Times.Never());
+        Assert.False(listView.IsHandleCreated);
     }
 
     [WinFormsTheory]


### PR DESCRIPTION
Fixes #12319

## Proposed changes

- Replace physical cursor movement in the ListViewItem hover test with controlled
  accessibility bounds: an empty rectangle for outside and a rectangle covering the
  documented signed-16-bit virtual-screen coordinate range for inside. Neither value
  depends on the current monitor arrangement or DPI.
- Keep the real `ListViewItem.IKeyboardToolTip.IsHoveredWithMouse` implementation.
  Use the existing Moq protected-factory pattern to substitute only the accessibility
  bounds, with normal ListView behavior retained via `CallBase`.
- Restore the disabled virtual-mode/hovered case and remove its ActiveIssue marker.
  Keep the existing attached/detached and inside/outside cases. Verify that attached
  items consult the bounds and that the test does not create a native control handle.

## Customer Impact

- Running this test no longer moves the user's cursor or races with mouse movement
  from another test or process.
- The previously disabled virtual-mode case runs again without requiring an
  interactive cursor-positioning step.

## Regression?

- No product regression is being changed; this fixes existing test isolation.

## Risk

- Low: one test file only, no product or public API changes, no new dependency,
  retries, skip conditions, or shared mutable state.
- The test still verifies the real hover decision, not a mocked hover result.
  Real native accessibility geometry remains outside this test's scope.

## Test methodology

- Base: current `main`, `8efd9a920dba90722f8db1f7e943f74837d26579`.
- Targeted hover theory: **5 passed, 0 failed, 0 skipped**, with both `pl-PL` and
  `en-US`, including the restored virtual-mode case.
- Controlled mutation: temporarily force virtual-mode hover to return false. The
  restored positive case fails, and the bounds-read check also detects the bypass
  in the virtual-mode/outside case. Mutation removed before the final build/test.
- The original cursor-moving test was not executed on the active desktop. A local
  structural guard found its two `Cursor.Position` writes and passes after the fix;
  this is not a claim to reproduce the original intermittent CI failure.
- Broader class comparison: baseline **70 passed / 9 failed** (hover excluded to
  avoid moving the cursor); patched **75 passed / 9 failed**, with no exclusions or
  skips. The same nine unchanged `ViewLargeIcon` neighboring-rectangle cases fail
  before and after. Their layout assumptions are deliberately outside this PR.
- Release build: zero warnings/errors; `git diff --check` passes. The full repository
  suite was not run for this change.

Run the target from the built `System.Windows.Forms.Tests` executable with:

```text
--filter-method System.Windows.Forms.Tests.ListViewItem_IKeyboardToolTipTests.ListViewItemKeyboardToolTip_InvokeIsHoveredWithMouse_ReturnsExpected
```

## Test environment(s)

- Windows 11 25H2 x64, build 26200.9168.
- SDK `11.0.100-rc.1.26420.103`; runtime `12.0.0-alpha.1.26458.117`.
- Bounds rationale: [Windows virtual-screen coordinate limits](https://learn.microsoft.com/windows/win32/gdi/the-virtual-screen).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/15078)