### PR TITLE
[Experimental Agent] Fix COM ownership and HTML subscription lifetimes/Alternative fix attempt

### DIFF
--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/Composition.NativeToRuntimeAdapter.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Ole/Composition.NativeToRuntimeAdapter.cs
@@ -98,13 +98,37 @@ internal unsafe partial class Composition<TOleServices, TNrbfSerializer, TDataFo
 
         public void SetData(ref FORMATETC formatIn, ref STGMEDIUM medium, bool release)
         {
-            Com.STGMEDIUM nativeMedium = (Com.STGMEDIUM)medium;
-            Com.FORMATETC nativeFormat = Unsafe.As<FORMATETC, Com.FORMATETC>(ref formatIn);
-            using var nativeDataObject = _nativeDataObject.GetInterface();
-            HRESULT result = nativeDataObject.Value->SetData(&nativeFormat, &nativeMedium, release);
-            medium = (STGMEDIUM)nativeMedium;
-            nativeMedium.ReleaseUnknown();
-            result.ThrowOnFailure();
+            Com.IUnknown* releaseOwner = null;
+            try
+            {
+                Com.STGMEDIUM nativeMedium = (Com.STGMEDIUM)medium;
+
+                // Conversion acquired this reference, independently of the managed release owner.
+                // Guard it before GetInterface and preserve its identity if native code changes the medium.
+                releaseOwner = nativeMedium.pUnkForRelease;
+                Com.FORMATETC nativeFormat = Unsafe.As<FORMATETC, Com.FORMATETC>(ref formatIn);
+                using var nativeDataObject = _nativeDataObject.GetInterface();
+                HRESULT result = nativeDataObject.Value->SetData(&nativeFormat, &nativeMedium, release);
+                if (release && result.Succeeded)
+                {
+                    // The recipient may already have released the medium. Neither re-wrap its owner nor
+                    // release our transferred reference again; leave the caller's managed medium unchanged.
+                    releaseOwner = null;
+                    return;
+                }
+
+                medium = (STGMEDIUM)nativeMedium;
+                result.ThrowOnFailure();
+            }
+            finally
+            {
+                // Borrowing or a failed transfer leaves only the conversion reference ours to release,
+                // including when interface retrieval, the call, or conversion back to managed code fails.
+                if (releaseOwner is not null)
+                {
+                    releaseOwner->Release();
+                }
+            }
         }
     }
 }

--- a/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/AgileComPointer.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/AgileComPointer.cs
@@ -31,6 +31,16 @@ internal unsafe class AgileComPointer<TInterface> :
     private readonly uint _memoryPressure;
 
     /// <summary>
+    ///  Gets whether this owner's registration has been revoked.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   This is a state snapshot, not synchronization with concurrent disposal or a test of the native object's lifetime.
+    ///  </para>
+    /// </remarks>
+    public bool IsDisposed => Volatile.Read(ref _cookie) == 0;
+
+    /// <summary>
     ///  Creates an <see cref="AgileComPointer{TInterface}"/> for the given <paramref name="interface"/>.
     /// </summary>
     /// <param name="interface">The COM interface pointer.</param>

--- a/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/ComHelpers.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/ComHelpers.cs
@@ -193,7 +193,9 @@ internal static unsafe partial class ComHelpers
             return false;
         }
 
-        return TryGetObjectForIUnknown(unknown, out @object);
+        // The input is borrowed, but QueryInterface gave us a separate reference that must be released
+        // even when the managed cast fails. Leaking it can root a CCW's target after the caller releases its input.
+        return TryGetObjectForIUnknown(unknown, takeOwnership: true, out @object);
     }
 
     /// <inheritdoc cref="TryGetObjectForIUnknown{TObject}(ComUnknown*, bool, out TObject)"/>
@@ -285,8 +287,10 @@ internal static unsafe partial class ComHelpers
             return GetObjectForIUnknown(unknown);
         }
 
-        unknown->QueryInterface(IID.Get<ComUnknown>(), (void**)&unknown).ThrowOnFailure();
-        return GetObjectForIUnknown(unknown);
+        // Borrow the caller's pointer and scope only our QueryInterface reference.
+        using ComScope<ComUnknown> queriedUnknown = new(null);
+        unknown->QueryInterface(IID.Get<ComUnknown>(), queriedUnknown).ThrowOnFailure();
+        return GetObjectForIUnknown(queriedUnknown.Value);
     }
 
     /// <inheritdoc cref="GetObjectForIUnknown(ComUnknown*)"/>
@@ -296,6 +300,12 @@ internal static unsafe partial class ComHelpers
     /// <summary>
     ///  Gets a runtime callable wrapper for the given IUnknown. Will attempt to unwrap ComWrapper RCWs if available.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   The input is borrowed. Creating or retrieving a managed wrapper does not release a reference acquired
+    ///   by the caller; the caller must still release it, even when this returns the original managed object.
+    ///  </para>
+    /// </remarks>
     /// <exception cref="ArgumentNullException"><paramref name="unknown"/> is <see langword="null"/>.</exception>
     internal static object GetObjectForIUnknown(ComUnknown* unknown)
     {

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Windows/Win32/AgileComPointerTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Windows/Win32/AgileComPointerTests.cs
@@ -25,6 +25,86 @@ public class AgileComPointerTests
         Assert.Equal(0u, count);
     }
 
+    [StaTheory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public unsafe void AgileComPointer_GetManagedObject_Ownership_Git(bool useTypedHelper)
+    {
+        using MemoryStream data = new([42]);
+        ComManagedStream source = new(data);
+        using var stream = ComHelpers.GetComScope<IStream>(source);
+        using var observer = stream.Query<IUnknown>();
+        uint beforeRegistration = GetReferenceCount(observer.Value);
+        uint afterRegistration;
+        uint[] afterRetrieval = new uint[3];
+
+        using (AgileComPointer<IStream> agileStream = new(stream.Value, takeOwnership: false))
+        {
+            afterRegistration = GetReferenceCount(observer.Value);
+
+            for (int retrievalIndex = 0; retrievalIndex < afterRetrieval.Length; retrievalIndex++)
+            {
+                object actual;
+                if (useTypedHelper)
+                {
+                    actual = agileStream.GetManagedObject();
+                }
+                else
+                {
+                    using var retrieved = agileStream.GetInterface();
+                    actual = ComHelpers.GetObjectForIUnknown(retrieved.AsUnknown);
+                }
+
+                Assert.Same(source, actual);
+                Assert.True(((ComManagedStream)actual).GetDataStream().CanRead);
+                afterRetrieval[retrievalIndex] = GetReferenceCount(observer.Value);
+            }
+        }
+
+        uint afterDisposal = GetReferenceCount(observer.Value);
+        uint expectedRegistered = beforeRegistration + 1;
+        uint[] expectedCounts =
+        [
+            expectedRegistered,
+            expectedRegistered,
+            expectedRegistered,
+            expectedRegistered,
+            beforeRegistration
+        ];
+        uint[] actualCounts = [afterRegistration, .. afterRetrieval, afterDisposal];
+        Assert.Equal(expectedCounts, actualCounts);
+        Assert.Equal(42, source.GetDataStream().ReadByte());
+        Assert.Equal(HRESULT.S_OK, stream.Value->Commit(0));
+
+        static uint GetReferenceCount(IUnknown* unknown)
+        {
+            unknown->AddRef();
+            return unknown->Release();
+        }
+    }
+
+    [StaFact]
+    public unsafe void AgileComPointer_IsDisposed_TracksOnlyItsOwnRegistration()
+    {
+        using MemoryStream data = new();
+        ComManagedStream source = new(data);
+        using var stream = ComHelpers.GetComScope<IStream>(source);
+        using AgileComPointer<IStream> first = new(stream.Value, takeOwnership: false);
+        using AgileComPointer<IStream> second = new(stream.Value, takeOwnership: false);
+        Assert.False(first.IsDisposed);
+        Assert.False(second.IsDisposed);
+
+        first.Dispose();
+        first.Dispose();
+
+        Assert.True(first.IsDisposed);
+        Assert.False(second.IsDisposed);
+        using var retained = second.GetInterface();
+        Assert.Equal(HRESULT.S_OK, retained.Value->Commit(0));
+        second.Dispose();
+        Assert.True(second.IsDisposed);
+    }
+
     [StaFact]
     public async Task AgileComPointer_MultiThread_COMPointerValue_ForSameObject()
     {

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Windows/Win32/ComHelpersTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Windows/Win32/ComHelpersTests.cs
@@ -1,0 +1,290 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using Windows.Win32.System.Com;
+using Windows.Win32.System.Ole;
+
+namespace System.Windows.Forms.Primitives.Tests.Windows.Win32;
+
+/// <summary>
+///  Verifies native reference ownership separately from managed object identity.
+/// </summary>
+public unsafe class ComHelpersTests
+{
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void GetObjectForIUnknown_BorrowsInput(bool typedPointer, bool useScope)
+    {
+        using MemoryStream data = new([42]);
+        ComManagedStream source = new(data);
+        using var stream = ComHelpers.GetComScope<IStream>(source);
+        using var observer = stream.Query<IUnknown>();
+        uint before = GetReferenceCount(observer);
+
+        object actual = (typedPointer, useScope) switch
+        {
+            (true, true) => ComHelpers.GetObjectForIUnknown(stream),
+            (true, false) => ComHelpers.GetObjectForIUnknown(stream.Value),
+            (false, true) => ComHelpers.GetObjectForIUnknown(observer),
+            (false, false) => ComHelpers.GetObjectForIUnknown(observer.Value)
+        };
+
+        Assert.Same(source, actual);
+        Assert.Equal(before, GetReferenceCount(observer));
+        Assert.Equal(42, ((ComManagedStream)actual).GetDataStream().ReadByte());
+        Assert.Equal(HRESULT.S_OK, stream.Value->Commit(0));
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void TryGetObjectForIUnknown_BorrowsInput(bool typedPointer, bool useScope)
+    {
+        using MemoryStream data = new([42]);
+        ComManagedStream source = new(data);
+        using var stream = ComHelpers.GetComScope<IStream>(source);
+        using var observer = stream.Query<IUnknown>();
+        uint before = GetReferenceCount(observer);
+
+        ComManagedStream? actual;
+        bool success = (typedPointer, useScope) switch
+        {
+            (true, true) => ComHelpers.TryGetObjectForIUnknown(stream, out actual),
+            (true, false) => ComHelpers.TryGetObjectForIUnknown(stream.Value, out actual),
+            (false, true) => ComHelpers.TryGetObjectForIUnknown(observer, out actual),
+            (false, false) => ComHelpers.TryGetObjectForIUnknown(observer.Value, out actual)
+        };
+
+        Assert.True(success);
+        Assert.Same(source, actual);
+        Assert.Equal(before, GetReferenceCount(observer));
+        Assert.Equal(42, actual!.GetDataStream().ReadByte());
+        Assert.Equal(HRESULT.S_OK, stream.Value->Commit(0));
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void TryGetObjectForIUnknown_FailedCast_BorrowsInput(bool typedPointer, bool useScope)
+    {
+        using MemoryStream data = new([42]);
+        ComManagedStream source = new(data);
+        using var stream = ComHelpers.GetComScope<IStream>(source);
+        using var observer = stream.Query<IUnknown>();
+        uint before = GetReferenceCount(observer);
+
+        string? actual;
+        bool success = (typedPointer, useScope) switch
+        {
+            (true, true) => ComHelpers.TryGetObjectForIUnknown(stream, out actual),
+            (true, false) => ComHelpers.TryGetObjectForIUnknown(stream.Value, out actual),
+            (false, true) => ComHelpers.TryGetObjectForIUnknown(observer, out actual),
+            (false, false) => ComHelpers.TryGetObjectForIUnknown(observer.Value, out actual)
+        };
+
+        Assert.False(success);
+        Assert.Null(actual);
+        Assert.Equal(before, GetReferenceCount(observer));
+        Assert.Equal(42, source.GetDataStream().ReadByte());
+        Assert.Equal(HRESULT.S_OK, stream.Value->Commit(0));
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void TryGetObjectForIUnknown_ReleasesInputOnlyWhenTakingOwnership(bool takeOwnership, bool failedCast)
+    {
+        using MemoryStream data = new([42]);
+        ComManagedStream source = new(data);
+        using var observer = ComHelpers.GetComScope<IUnknown>(source);
+        IUnknown* input = observer.Value;
+        input->AddRef();
+        uint before = GetReferenceCount(observer);
+
+        try
+        {
+            if (failedCast)
+            {
+                Assert.False(ComHelpers.TryGetObjectForIUnknown(input, takeOwnership, out string? actual));
+                Assert.Null(actual);
+            }
+            else
+            {
+                Assert.True(ComHelpers.TryGetObjectForIUnknown(input, takeOwnership, out ComManagedStream? actual));
+                Assert.Same(source, actual);
+            }
+
+            Assert.Equal(takeOwnership ? before - 1 : before, GetReferenceCount(observer));
+            Assert.Equal(42, source.GetDataStream().ReadByte());
+        }
+        finally
+        {
+            if (!takeOwnership)
+            {
+                input->Release();
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    [InlineData(true, true, false)]
+    [InlineData(false, true, true)]
+    [InlineData(true, true, true)]
+    public void GetObjectForIUnknown_BorrowsRuntimeCcw(bool typedPointer, bool tryGet, bool failedCast)
+    {
+        using MemoryStream data = new([42]);
+        ComManagedStream source = new(data);
+
+        // Bypass our manual ComWrappers CCW to cover the built-in interop unwrapping path.
+        using ComScope<IUnknown> observer = new((IUnknown*)Marshal.GetIUnknownForObject(source));
+        using var stream = observer.Query<IStream>();
+        uint before = GetReferenceCount(observer);
+
+        if (failedCast)
+        {
+            string? actual;
+            bool success = typedPointer
+                ? ComHelpers.TryGetObjectForIUnknown(stream.Value, out actual)
+                : ComHelpers.TryGetObjectForIUnknown(observer.Value, out actual);
+            Assert.False(success);
+            Assert.Null(actual);
+        }
+        else
+        {
+            object? actual;
+            if (tryGet)
+            {
+                bool success = typedPointer
+                    ? ComHelpers.TryGetObjectForIUnknown(stream.Value, out actual)
+                    : ComHelpers.TryGetObjectForIUnknown(observer.Value, out actual);
+                Assert.True(success);
+            }
+            else
+            {
+                actual = typedPointer
+                    ? ComHelpers.GetObjectForIUnknown(stream.Value)
+                    : ComHelpers.GetObjectForIUnknown(observer.Value);
+            }
+
+            Assert.Same(source, actual);
+            Assert.Same(data, Assert.IsType<ComManagedStream>(actual).GetDataStream());
+        }
+
+        Assert.Equal(before, GetReferenceCount(observer));
+        Assert.Equal(42, source.GetDataStream().ReadByte());
+        Assert.Equal(HRESULT.S_OK, stream.Value->Commit(0));
+    }
+
+    [StaTheory]
+    [InlineData(false, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    [InlineData(true, true, false)]
+    [InlineData(false, true, true)]
+    [InlineData(true, true, true)]
+    public void GetObjectForIUnknown_Ownership_NativeRcw(bool useTypedHelper, bool tryGet, bool failedCast)
+    {
+        using ComScope<IUnknown> observer = new(null);
+        uint beforeRetrieval;
+        uint[] afterRetrieval = new uint[3];
+        uint afterCleanup;
+        {
+            using ComScope<IFont> created = new(null);
+            string fontName = "Arial";
+            FONTDESC description = new()
+            {
+                cbSizeofstruct = (uint)sizeof(FONTDESC),
+                cySize = (CY)10f,
+                sWeight = 400,
+                sCharset = 1
+            };
+
+            fixed (char* name = fontName)
+            {
+                description.lpstrName = name;
+                Guid interfaceId = IID.GetRef<IFont>();
+                PInvoke.OleCreateFontIndirect(&description, &interfaceId, created).ThrowOnFailure();
+            }
+
+            object expected = Marshal.GetObjectForIUnknown((nint)created.Value);
+            try
+            {
+                Assert.True(Marshal.IsComObject(expected));
+                var nativeFont = (IFont.Interface)expected;
+                Assert.NotEqual(IntPtr.Zero, nativeFont.hFont);
+
+                using (ComScope<IUnknown> warmUnknown = created.Query<IUnknown>())
+                {
+                    Assert.Same(expected, ComHelpers.GetObjectForIUnknown(warmUnknown.Value));
+                }
+
+                created.Value->QueryInterface(IID.Get<IUnknown>(), observer).ThrowOnFailure();
+                beforeRetrieval = GetReferenceCount(observer.Value);
+
+                for (int retrievalIndex = 0; retrievalIndex < afterRetrieval.Length; retrievalIndex++)
+                {
+                    if (failedCast)
+                    {
+                        string? actual;
+                        bool success = useTypedHelper
+                            ? ComHelpers.TryGetObjectForIUnknown(created.Value, out actual)
+                            : ComHelpers.TryGetObjectForIUnknown(observer.Value, out actual);
+                        Assert.False(success);
+                        Assert.Null(actual);
+                    }
+                    else
+                    {
+                        object? actual;
+                        if (tryGet)
+                        {
+                            bool success = useTypedHelper
+                                ? ComHelpers.TryGetObjectForIUnknown(created.Value, out actual)
+                                : ComHelpers.TryGetObjectForIUnknown(observer.Value, out actual);
+                            Assert.True(success);
+                        }
+                        else
+                        {
+                            actual = useTypedHelper
+                                ? ComHelpers.GetObjectForIUnknown(created.Value)
+                                : ComHelpers.GetObjectForIUnknown(observer.Value);
+                        }
+
+                        Assert.Same(expected, actual);
+                        Assert.NotEqual(IntPtr.Zero, ((IFont.Interface)actual!).hFont);
+                    }
+
+                    Assert.NotEqual(IntPtr.Zero, nativeFont.hFont);
+                    afterRetrieval[retrievalIndex] = GetReferenceCount(observer.Value);
+                }
+            }
+            finally
+            {
+                Marshal.FinalReleaseComObject(expected);
+            }
+        }
+
+        afterCleanup = GetReferenceCount(observer.Value);
+        uint[] expectedCounts = [beforeRetrieval, beforeRetrieval, beforeRetrieval, 1];
+        uint[] actualCounts = [.. afterRetrieval, afterCleanup];
+        Assert.Equal(expectedCounts, actualCounts);
+    }
+
+    private static uint GetReferenceCount(IUnknown* unknown)
+    {
+        unknown->AddRef();
+        return unknown->Release();
+    }
+}

--- a/src/System.Windows.Forms/System/Windows/Forms/ActiveX/AxHost.ConnectionPointCookie.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/ActiveX/AxHost.ConnectionPointCookie.cs
@@ -101,7 +101,9 @@ public abstract partial class AxHost
                 : base(connectionPoint, takeOwnership: true)
             {
                 uint cookie = 0;
-                IUnknown* ccw = ComHelpers.TryGetComPointer<IUnknown>(sink, out HRESULT hr);
+                // Advise retains its own sink reference. Without releasing this temporary CCW,
+                // even Unadvise cannot collect the sink and the HTML manager/host it references.
+                using var ccw = ComHelpers.TryGetComScope<IUnknown>(sink, out HRESULT hr);
                 if (hr.Failed || connectionPoint->Advise(ccw, &cookie).Failed)
                 {
                     Dispose();

--- a/src/System.Windows.Forms/System/Windows/Forms/ActiveX/AxHost.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/ActiveX/AxHost.cs
@@ -3314,9 +3314,15 @@ public abstract unsafe partial class AxHost : Control, ISupportInitialize, ICust
             cbSize = (uint)sizeof(QACONTROL)
         };
 
-        qaContainer.pClientSite = ComHelpers.GetComPointer<IOleClientSite>(_oleSite);
-        qaContainer.pPropertyNotifySink = ComHelpers.GetComPointer<IPropertyNotifySink>(_oleSite);
-        qaContainer.pFont = GetIFontPointerFromFont(GetParentContainer()._parent.Font);
+        // QuickActivate borrows these pointers; any references retained by the control are independent.
+        // Release our temporary references even if activation fails, or the site CCW can keep this host
+        // alive after the native control is destroyed and the native font will leak.
+        using var clientSite = ComHelpers.GetComScope<IOleClientSite>(_oleSite);
+        using var propertyNotifySink = ComHelpers.GetComScope<IPropertyNotifySink>(_oleSite);
+        using ComScope<IFont> font = new(GetIFontPointerFromFont(GetParentContainer()._parent.Font));
+        qaContainer.pClientSite = clientSite.Value;
+        qaContainer.pPropertyNotifySink = propertyNotifySink.Value;
+        qaContainer.pFont = font.Value;
         qaContainer.dwAppearance = 0;
         qaContainer.lcid = (int)PInvokeCore.GetThreadLocale();
 
@@ -3659,6 +3665,12 @@ public abstract unsafe partial class AxHost : Control, ISupportInitialize, ICust
         catch
         {
         }
+        finally
+        {
+            // The RCW owns its own reference. Keeping the creation reference would leak the native font
+            // even after the RCW is released; conversion failure must release it as well.
+            ifont->Release();
+        }
 
         return null;
     }
@@ -3734,8 +3746,11 @@ public abstract unsafe partial class AxHost : Control, ISupportInitialize, ICust
         {
             FONTDESC fontdesc = GetFONTDESCFromFont(font);
             fontdesc.lpstrName = n;
-            PInvoke.OleCreateFontIndirect(in fontdesc, in IID.GetRef<IFontDisp>(), out void* lplpvObj).ThrowOnFailure();
-            return ComHelpers.GetObjectForIUnknown((IFontDisp*)lplpvObj);
+            // Conversion gives the RCW its own reference, not ownership of OleCreateFontIndirect's reference.
+            // Release the creation reference so the font can be destroyed when the RCW is released.
+            using ComScope<IFontDisp> nativeFont = new(null);
+            PInvoke.OleCreateFontIndirect(&fontdesc, IID.Get<IFontDisp>(), nativeFont).ThrowOnFailure();
+            return ComHelpers.GetObjectForIUnknown(nativeFont);
         }
     }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/HtmlDocument.HtmlDocumentShim.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/HtmlDocument.HtmlDocumentShim.cs
@@ -22,7 +22,7 @@ public sealed unsafe partial class HtmlDocument
     /// </summary>
     internal class HtmlDocumentShim : HtmlShim
     {
-        private readonly AgileComPointer<IHTMLWindow2>? _associatedWindow;
+        private AgileComPointer<IHTMLWindow2>? _associatedWindow;
         private AxHost.ConnectionPointCookie? _cookie;
         private HtmlDocument _htmlDocument;
 
@@ -45,18 +45,25 @@ public sealed unsafe partial class HtmlDocument
         internal HtmlDocument Document => _htmlDocument;
 
         /// Support IHtmlDocument3.AttachHandler
-        public override void AttachEventHandler(string eventName, EventHandler eventHandler)
+        protected override bool AttachEventProxy(HtmlToClrEventProxy proxy)
         {
             // IE likes to call back on an IDispatch of DISPID=0 when it has an event,
             // the HtmlToClrEventProxy helps us fake out the CLR so that we can call back on
             // our EventHandler properly.
 
-            HtmlToClrEventProxy proxy = AddEventProxy(eventName, eventHandler);
             using var htmlDoc3 = _htmlDocument.GetHtmlDocument<IHTMLDocument3>();
-            using BSTR name = new(eventName);
+            using BSTR name = new(proxy.EventName);
             using var dispatch = ComHelpers.GetComScope<IDispatch>(proxy);
             VARIANT_BOOL result = default;
             htmlDoc3.Value->attachEvent(name, dispatch, &result).ThrowOnFailure();
+            if (IsDisposed && result)
+            {
+                // Retain this scoped interface for rollback if native attachment reenters disposal.
+                htmlDoc3.Value->detachEvent(name, dispatch).ThrowOnFailure();
+                ObjectDisposedException.ThrowIf(IsDisposed, this);
+            }
+
+            return result;
         }
 
         //
@@ -66,30 +73,29 @@ public sealed unsafe partial class HtmlDocument
         {
             if (_cookie is null || !_cookie.Connected)
             {
-                _cookie = new AxHost.ConnectionPointCookie(
+                AxHost.ConnectionPointCookie cookie = new(
                     NativeHtmlDocument2,
                     new HTMLDocumentEvents2(_htmlDocument),
                     typeof(Interop.Mshtml.DHTMLDocumentEvents2),
                     throwException: false);
 
-                if (!_cookie.Connected)
+                if (IsDisposed)
                 {
-                    _cookie = null;
+                    cookie.Disconnect();
+                    return;
                 }
+
+                _cookie = cookie.Connected ? cookie : null;
             }
         }
 
         /// Support IHtmlDocument3.DetachHandler
-        public override void DetachEventHandler(string eventName, EventHandler eventHandler)
+        protected override void DetachEventProxy(HtmlToClrEventProxy proxy)
         {
-            HtmlToClrEventProxy? proxy = RemoveEventProxy(eventHandler);
-            if (proxy is not null)
-            {
-                using var htmlDoc3 = _htmlDocument.GetHtmlDocument<IHTMLDocument3>();
-                using BSTR name = new(eventName);
-                using var dispatch = ComHelpers.GetComScope<IDispatch>(proxy);
-                htmlDoc3.Value->detachEvent(name, dispatch).ThrowOnFailure();
-            }
+            using var htmlDoc3 = _htmlDocument.GetHtmlDocument<IHTMLDocument3>();
+            using BSTR name = new(proxy.EventName);
+            using var dispatch = ComHelpers.GetComScope<IDispatch>(proxy);
+            htmlDoc3.Value->detachEvent(name, dispatch).ThrowOnFailure();
         }
 
         //
@@ -97,17 +103,33 @@ public sealed unsafe partial class HtmlDocument
         //
         public override void DisconnectFromEvents()
         {
-            _cookie?.Disconnect();
+            AxHost.ConnectionPointCookie? cookie = _cookie;
             _cookie = null;
+            cookie?.Disconnect();
         }
 
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
-            if (disposing)
+            try
             {
-                _htmlDocument?.NativeHtmlDocument2.Dispose();
-                _htmlDocument = null!;
+                base.Dispose(disposing);
+            }
+            finally
+            {
+                if (disposing)
+                {
+                    HtmlDocument? document = _htmlDocument;
+                    _htmlDocument = null!;
+                    try
+                    {
+                        document?.NativeHtmlDocument2.Dispose();
+                    }
+                    finally
+                    {
+                        // This independent GIT registration keeps the old window alive even after unadvising.
+                        DisposeHelper.NullAndDispose(ref _associatedWindow);
+                    }
+                }
             }
         }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/HtmlDocument.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/HtmlDocument.cs
@@ -573,38 +573,39 @@ public sealed unsafe partial class HtmlDocument
 
     public void DetachEventHandler(string eventName, EventHandler eventHandler)
     {
-        HtmlDocumentShim? shim = DocumentShim;
+        // Removal must not recreate a shim whose native document has already unloaded or been disposed.
+        HtmlDocumentShim? shim = ShimManager.GetDocumentShim(this);
         shim?.DetachEventHandler(eventName, eventHandler);
     }
 
     public event HtmlElementEventHandler? Click
     {
         add => DocumentShim.AddHandler(s_eventClick, value);
-        remove => DocumentShim.RemoveHandler(s_eventClick, value);
+        remove => ShimManager.GetDocumentShim(this)?.RemoveHandler(s_eventClick, value);
     }
 
     public event HtmlElementEventHandler? ContextMenuShowing
     {
         add => DocumentShim.AddHandler(s_eventContextMenuShowing, value);
-        remove => DocumentShim.RemoveHandler(s_eventContextMenuShowing, value);
+        remove => ShimManager.GetDocumentShim(this)?.RemoveHandler(s_eventContextMenuShowing, value);
     }
 
     public event HtmlElementEventHandler? Focusing
     {
         add => DocumentShim.AddHandler(s_eventFocusing, value);
-        remove => DocumentShim.RemoveHandler(s_eventFocusing, value);
+        remove => ShimManager.GetDocumentShim(this)?.RemoveHandler(s_eventFocusing, value);
     }
 
     public event HtmlElementEventHandler? LosingFocus
     {
         add => DocumentShim.AddHandler(s_eventLosingFocus, value);
-        remove => DocumentShim.RemoveHandler(s_eventLosingFocus, value);
+        remove => ShimManager.GetDocumentShim(this)?.RemoveHandler(s_eventLosingFocus, value);
     }
 
     public event HtmlElementEventHandler? MouseDown
     {
         add => DocumentShim.AddHandler(s_eventMouseDown, value);
-        remove => DocumentShim.RemoveHandler(s_eventMouseDown, value);
+        remove => ShimManager.GetDocumentShim(this)?.RemoveHandler(s_eventMouseDown, value);
     }
 
     /// <summary>
@@ -613,31 +614,31 @@ public sealed unsafe partial class HtmlDocument
     public event HtmlElementEventHandler? MouseLeave
     {
         add => DocumentShim.AddHandler(s_eventMouseLeave, value);
-        remove => DocumentShim.RemoveHandler(s_eventMouseLeave, value);
+        remove => ShimManager.GetDocumentShim(this)?.RemoveHandler(s_eventMouseLeave, value);
     }
 
     public event HtmlElementEventHandler? MouseMove
     {
         add => DocumentShim.AddHandler(s_eventMouseMove, value);
-        remove => DocumentShim.RemoveHandler(s_eventMouseMove, value);
+        remove => ShimManager.GetDocumentShim(this)?.RemoveHandler(s_eventMouseMove, value);
     }
 
     public event HtmlElementEventHandler? MouseOver
     {
         add => DocumentShim.AddHandler(s_eventMouseOver, value);
-        remove => DocumentShim.RemoveHandler(s_eventMouseOver, value);
+        remove => ShimManager.GetDocumentShim(this)?.RemoveHandler(s_eventMouseOver, value);
     }
 
     public event HtmlElementEventHandler? MouseUp
     {
         add => DocumentShim.AddHandler(s_eventMouseUp, value);
-        remove => DocumentShim.RemoveHandler(s_eventMouseUp, value);
+        remove => ShimManager.GetDocumentShim(this)?.RemoveHandler(s_eventMouseUp, value);
     }
 
     public event HtmlElementEventHandler? Stop
     {
         add => DocumentShim.AddHandler(s_eventStop, value);
-        remove => DocumentShim.RemoveHandler(s_eventStop, value);
+        remove => ShimManager.GetDocumentShim(this)?.RemoveHandler(s_eventStop, value);
     }
 
     private static Color ColorFromVARIANT(VARIANT vColor)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/HtmlElement.HtmlElementShim.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/HtmlElement.HtmlElementShim.cs
@@ -43,7 +43,7 @@ public sealed partial class HtmlElement
             typeof(Interop.Mshtml.DHTMLScriptEvents2)
         ];
 
-        private readonly AgileComPointer<IHTMLWindow2>? _associatedWindow;
+        private AgileComPointer<IHTMLWindow2>? _associatedWindow;
         private AxHost.ConnectionPointCookie? _cookie;   // To hook up events from the native HtmlElement
         private HtmlElement _htmlElement;
 
@@ -70,18 +70,24 @@ public sealed partial class HtmlElement
         internal HtmlElement Element => _htmlElement;
 
         /// Support IHTMLElement2.AttachEventHandler
-        public override void AttachEventHandler(string eventName, EventHandler eventHandler)
+        protected override bool AttachEventProxy(HtmlToClrEventProxy proxy)
         {
             // IE likes to call back on an IDispatch of DISPID=0 when it has an event,
             // the HtmlToClrEventProxy helps us fake out the CLR so that we can call back on
             // our EventHandler properly.
 
-            HtmlToClrEventProxy proxy = AddEventProxy(eventName, eventHandler);
             using var htmlElement2 = _htmlElement.GetHtmlElement<IHTMLElement2>();
-            using BSTR name = new(eventName);
+            using BSTR name = new(proxy.EventName);
             using var dispatch = ComHelpers.GetComScope<IDispatch>(proxy);
             VARIANT_BOOL result;
             htmlElement2.Value->attachEvent(name, dispatch, &result).ThrowOnFailure();
+            if (IsDisposed && result)
+            {
+                htmlElement2.Value->detachEvent(name, dispatch).ThrowOnFailure();
+                ObjectDisposedException.ThrowIf(IsDisposed, this);
+            }
+
+            return result;
         }
 
         public override void ConnectToEvents()
@@ -90,45 +96,60 @@ public sealed partial class HtmlElement
             {
                 for (int i = 0; i < s_dispInterfaceTypes.Length && _cookie is null; i++)
                 {
-                    _cookie = new AxHost.ConnectionPointCookie(
+                    AxHost.ConnectionPointCookie cookie = new(
                         NativeHtmlElement,
                         new HTMLElementEvents2(_htmlElement),
                         s_dispInterfaceTypes[i],
                         throwException: false);
-                    if (!_cookie.Connected)
+                    if (IsDisposed)
                     {
-                        _cookie = null;
+                        cookie.Disconnect();
+                        return;
                     }
+
+                    _cookie = cookie.Connected ? cookie : null;
                 }
             }
         }
 
         /// Support IHTMLElement2.DetachHandler
-        public override void DetachEventHandler(string eventName, EventHandler eventHandler)
+        protected override void DetachEventProxy(HtmlToClrEventProxy proxy)
         {
-            HtmlToClrEventProxy? proxy = RemoveEventProxy(eventHandler);
-            if (proxy is not null)
-            {
-                using var htmlElement2 = _htmlElement.GetHtmlElement<IHTMLElement2>();
-                using BSTR name = new(eventName);
-                using var dispatch = ComHelpers.GetComScope<IDispatch>(proxy);
-                htmlElement2.Value->detachEvent(name, dispatch).ThrowOnFailure();
-            }
+            using var htmlElement2 = _htmlElement.GetHtmlElement<IHTMLElement2>();
+            using BSTR name = new(proxy.EventName);
+            using var dispatch = ComHelpers.GetComScope<IDispatch>(proxy);
+            htmlElement2.Value->detachEvent(name, dispatch).ThrowOnFailure();
         }
 
         public override void DisconnectFromEvents()
         {
-            _cookie?.Disconnect();
+            AxHost.ConnectionPointCookie? cookie = _cookie;
             _cookie = null;
+            cookie?.Disconnect();
         }
 
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
-            if (disposing)
+            try
             {
-                _htmlElement?.NativeHtmlElement?.Dispose();
-                _htmlElement = null!;
+                base.Dispose(disposing);
+            }
+            finally
+            {
+                if (disposing)
+                {
+                    HtmlElement? element = _htmlElement;
+                    _htmlElement = null!;
+                    try
+                    {
+                        element?.NativeHtmlElement.Dispose();
+                    }
+                    finally
+                    {
+                        // Unadvising does not release the separate registration used to identify the owning window.
+                        DisposeHelper.NullAndDispose(ref _associatedWindow);
+                    }
+                }
             }
         }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/HtmlElement.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/HtmlElement.cs
@@ -513,7 +513,8 @@ public sealed unsafe partial class HtmlElement
 
     public void DetachEventHandler(string eventName, EventHandler eventHandler)
     {
-        ElementShim.DetachEventHandler(eventName, eventHandler);
+        // Cleanup after unload/disposal must not create a new native owner just to remove a handler.
+        ShimManager.GetElementShim(this)?.DetachEventHandler(eventName, eventHandler);
     }
 
     public void Focus()
@@ -681,103 +682,103 @@ public sealed unsafe partial class HtmlElement
     public event HtmlElementEventHandler? Click
     {
         add => ElementShim.AddHandler(s_eventClick, value);
-        remove => ElementShim.RemoveHandler(s_eventClick, value);
+        remove => ShimManager.GetElementShim(this)?.RemoveHandler(s_eventClick, value);
     }
 
     public event HtmlElementEventHandler? DoubleClick
     {
         add => ElementShim.AddHandler(s_eventDoubleClick, value);
-        remove => ElementShim.RemoveHandler(s_eventDoubleClick, value);
+        remove => ShimManager.GetElementShim(this)?.RemoveHandler(s_eventDoubleClick, value);
     }
 
     public event HtmlElementEventHandler? Drag
     {
         add => ElementShim.AddHandler(s_eventDrag, value);
-        remove => ElementShim.RemoveHandler(s_eventDrag, value);
+        remove => ShimManager.GetElementShim(this)?.RemoveHandler(s_eventDrag, value);
     }
 
     public event HtmlElementEventHandler? DragEnd
     {
         add => ElementShim.AddHandler(s_eventDragEnd, value);
-        remove => ElementShim.RemoveHandler(s_eventDragEnd, value);
+        remove => ShimManager.GetElementShim(this)?.RemoveHandler(s_eventDragEnd, value);
     }
 
     public event HtmlElementEventHandler? DragLeave
     {
         add => ElementShim.AddHandler(s_eventDragLeave, value);
-        remove => ElementShim.RemoveHandler(s_eventDragLeave, value);
+        remove => ShimManager.GetElementShim(this)?.RemoveHandler(s_eventDragLeave, value);
     }
 
     public event HtmlElementEventHandler? DragOver
     {
         add => ElementShim.AddHandler(s_eventDragOver, value);
-        remove => ElementShim.RemoveHandler(s_eventDragOver, value);
+        remove => ShimManager.GetElementShim(this)?.RemoveHandler(s_eventDragOver, value);
     }
 
     public event HtmlElementEventHandler? Focusing
     {
         add => ElementShim.AddHandler(s_eventFocusing, value);
-        remove => ElementShim.RemoveHandler(s_eventFocusing, value);
+        remove => ShimManager.GetElementShim(this)?.RemoveHandler(s_eventFocusing, value);
     }
 
     public event HtmlElementEventHandler? GotFocus
     {
         add => ElementShim.AddHandler(s_eventGotFocus, value);
-        remove => ElementShim.RemoveHandler(s_eventGotFocus, value);
+        remove => ShimManager.GetElementShim(this)?.RemoveHandler(s_eventGotFocus, value);
     }
 
     public event HtmlElementEventHandler? LosingFocus
     {
         add => ElementShim.AddHandler(s_eventLosingFocus, value);
-        remove => ElementShim.RemoveHandler(s_eventLosingFocus, value);
+        remove => ShimManager.GetElementShim(this)?.RemoveHandler(s_eventLosingFocus, value);
     }
 
     public event HtmlElementEventHandler? LostFocus
     {
         add => ElementShim.AddHandler(s_eventLostFocus, value);
-        remove => ElementShim.RemoveHandler(s_eventLostFocus, value);
+        remove => ShimManager.GetElementShim(this)?.RemoveHandler(s_eventLostFocus, value);
     }
 
     public event HtmlElementEventHandler? KeyDown
     {
         add => ElementShim.AddHandler(s_eventKeyDown, value);
-        remove => ElementShim.RemoveHandler(s_eventKeyDown, value);
+        remove => ShimManager.GetElementShim(this)?.RemoveHandler(s_eventKeyDown, value);
     }
 
     public event HtmlElementEventHandler? KeyPress
     {
         add => ElementShim.AddHandler(s_eventKeyPress, value);
-        remove => ElementShim.RemoveHandler(s_eventKeyPress, value);
+        remove => ShimManager.GetElementShim(this)?.RemoveHandler(s_eventKeyPress, value);
     }
 
     public event HtmlElementEventHandler? KeyUp
     {
         add => ElementShim.AddHandler(s_eventKeyUp, value);
-        remove => ElementShim.RemoveHandler(s_eventKeyUp, value);
+        remove => ShimManager.GetElementShim(this)?.RemoveHandler(s_eventKeyUp, value);
     }
 
     public event HtmlElementEventHandler? MouseMove
     {
         add => ElementShim.AddHandler(s_eventMouseMove, value);
-        remove => ElementShim.RemoveHandler(s_eventMouseMove, value);
+        remove => ShimManager.GetElementShim(this)?.RemoveHandler(s_eventMouseMove, value);
     }
 
     public event HtmlElementEventHandler? MouseDown
     {
         add => ElementShim.AddHandler(s_eventMouseDown, value);
-        remove => ElementShim.RemoveHandler(s_eventMouseDown, value);
+        remove => ShimManager.GetElementShim(this)?.RemoveHandler(s_eventMouseDown, value);
     }
 
     public event HtmlElementEventHandler? MouseOver
     {
         add => ElementShim.AddHandler(s_eventMouseOver, value);
-        remove => ElementShim.RemoveHandler(s_eventMouseOver, value);
+        remove => ShimManager.GetElementShim(this)?.RemoveHandler(s_eventMouseOver, value);
     }
 
     public event HtmlElementEventHandler? MouseUp
     {
         add => ElementShim.AddHandler(s_eventMouseUp, value);
-        remove => ElementShim.RemoveHandler(s_eventMouseUp, value);
+        remove => ShimManager.GetElementShim(this)?.RemoveHandler(s_eventMouseUp, value);
     }
 
     /// <summary>
@@ -786,7 +787,7 @@ public sealed unsafe partial class HtmlElement
     public event HtmlElementEventHandler? MouseEnter
     {
         add => ElementShim.AddHandler(s_eventMouseEnter, value);
-        remove => ElementShim.RemoveHandler(s_eventMouseEnter, value);
+        remove => ShimManager.GetElementShim(this)?.RemoveHandler(s_eventMouseEnter, value);
     }
 
     /// <summary>
@@ -795,7 +796,7 @@ public sealed unsafe partial class HtmlElement
     public event HtmlElementEventHandler? MouseLeave
     {
         add => ElementShim.AddHandler(s_eventMouseLeave, value);
-        remove => ElementShim.RemoveHandler(s_eventMouseLeave, value);
+        remove => ShimManager.GetElementShim(this)?.RemoveHandler(s_eventMouseLeave, value);
     }
 
     public static unsafe bool operator ==(HtmlElement? left, HtmlElement? right)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/HtmlShim.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/HtmlShim.cs
@@ -2,23 +2,27 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
+using System.Runtime.ExceptionServices;
 using Windows.Win32.Web.MsHtml;
 
 namespace System.Windows.Forms;
 
-/// This is essentially a proxy object between the native
-/// html objects and our managed ones. We want the managed
-/// HtmlDocument, HtmlWindow and HtmlElement to be super-lightweight,
-/// which means that we shouldn't have things that tie up their lifetimes
-/// contained within them. The "Shim" is essentially the object that
-/// manages events coming out of the HtmlDocument, HtmlElement and HtmlWindow
-/// and serves them back up to the user.
-
+/// <summary>
+///  Owns the native event connections and managed delegates for an HTML wrapper.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Connection-point events and individually attached dispatch proxies have independent lifetimes.
+///   Removing the last standard handler must not detach proxies registered through AttachEventHandler.
+///  </para>
+/// </remarks>
 internal abstract class HtmlShim : IDisposable
 {
     private EventHandlerList? _events;
     private int _eventCount;
-    private Dictionary<EventHandler, HtmlToClrEventProxy>? _attachedEventList;
+    private List<(EventHandler Handler, HtmlToClrEventProxy Proxy)>? _attachedEventList;
+
+    internal bool IsDisposed { get; private set; }
 
     protected HtmlShim()
     {
@@ -27,23 +31,83 @@ internal abstract class HtmlShim : IDisposable
     private EventHandlerList Events =>
         _events ??= new EventHandlerList();
 
-    /// Support IHtml*3.AttachHandler
-    public abstract void AttachEventHandler(string eventName, EventHandler eventHandler);
+    public void AttachEventHandler(string eventName, EventHandler eventHandler)
+    {
+        ObjectDisposedException.ThrowIf(IsDisposed, this);
+        ArgumentNullException.ThrowIfNull(eventHandler);
+
+        HtmlToClrEventProxy proxy = new(eventName, eventHandler);
+        if (!AttachEventProxy(proxy))
+        {
+            // MSHTML rejects some names (including null) with S_OK/false. Preserve the existing
+            // no-op behavior, but do not retain a proxy for a registration that never happened.
+            Debug.WriteLine("The native HTML object did not attach the event.");
+            return;
+        }
+
+        // A native call can reenter disposal. Do not leave a new connection outside the disposed owner.
+        if (IsDisposed)
+        {
+            DetachEventProxy(proxy);
+            throw new ObjectDisposedException(GetType().Name);
+        }
+
+        // Each attach creates a distinct native dispatch identity, even for the same name and delegate.
+        // Retaining only one proxy loses the information needed to detach the earlier registrations.
+        (_attachedEventList ??= []).Add((eventHandler, proxy));
+    }
+
+    protected abstract bool AttachEventProxy(HtmlToClrEventProxy proxy);
+
+    protected abstract void DetachEventProxy(HtmlToClrEventProxy proxy);
 
     public void AddHandler(object key, Delegate? value)
     {
-        _eventCount++;
+        ObjectDisposedException.ThrowIf(IsDisposed, this);
+        if (value is null)
+        {
+            return;
+        }
+
+        _eventCount += value.GetInvocationList().Length;
         Events.AddHandler(key, value);
         OnEventHandlerAdded();
     }
 
-    protected HtmlToClrEventProxy AddEventProxy(string eventName, EventHandler eventHandler)
+    public void DetachEventHandler(string eventName, EventHandler eventHandler)
     {
-        _attachedEventList ??= [];
+        if (_attachedEventList is not { } registrations)
+        {
+            return;
+        }
 
-        HtmlToClrEventProxy proxy = new(eventName, eventHandler);
-        _attachedEventList[eventHandler] = proxy;
-        return proxy;
+        for (int index = registrations.Count - 1; index >= 0; index--)
+        {
+            var registration = registrations[index];
+            if (registration.Handler != eventHandler || registration.Proxy.EventName != eventName)
+            {
+                continue;
+            }
+
+            // Remove before the COM call so a reentrant detach cannot select the same proxy.
+            registrations.RemoveAt(index);
+            try
+            {
+                DetachEventProxy(registration.Proxy);
+            }
+            catch (Exception exception) when (!exception.IsCriticalException())
+            {
+                if (!IsDisposed)
+                {
+                    // A failed detach must remain owned and retryable, not become an untracked native sink.
+                    (_attachedEventList ??= []).Insert(Math.Min(index, _attachedEventList.Count), registration);
+                }
+
+                throw;
+            }
+
+            return;
+        }
     }
 
     public abstract IHTMLWindow2.Interface? AssociatedWindow { get; }
@@ -51,31 +115,19 @@ internal abstract class HtmlShim : IDisposable
     /// create connectionpoint cookie
     public abstract void ConnectToEvents();
 
-    /// Support IHtml*3.DetachEventHandler
-    public abstract void DetachEventHandler(string eventName, EventHandler eventHandler);
-
-    /// disconnect from connectionpoint cookie
-    /// inheriting classes should override to disconnect from ConnectionPoint and call base.
-    public virtual void DisconnectFromEvents()
-    {
-        if (_attachedEventList is not null)
-        {
-            EventHandler[] events = new EventHandler[_attachedEventList.Count];
-            _attachedEventList.Keys.CopyTo(events, 0);
-
-            foreach (EventHandler eh in events)
-            {
-                HtmlToClrEventProxy proxy = _attachedEventList[eh];
-                DetachEventHandler(proxy.EventName, eh);
-            }
-        }
-    }
+    public abstract void DisconnectFromEvents();
 
     /// return the sender for events, usually the HtmlWindow, HtmlElement, HtmlDocument
     protected abstract object GetEventSender();
 
     public void Dispose()
     {
+        if (IsDisposed)
+        {
+            return;
+        }
+
+        IsDisposed = true;
         Dispose(true);
         GC.SuppressFinalize(this);
     }
@@ -84,15 +136,46 @@ internal abstract class HtmlShim : IDisposable
     {
         if (disposing)
         {
-            DisconnectFromEvents();
+            var registrations = _attachedEventList;
+            _attachedEventList = null;
             _events?.Dispose();
             _events = null;
+            _eventCount = 0;
+
+            List<Exception>? exceptions = null;
+            try
+            {
+                DisconnectFromEvents();
+            }
+            catch (Exception exception) when (!exception.IsCriticalException())
+            {
+                (exceptions ??= []).Add(exception);
+            }
+
+            if (registrations is not null)
+            {
+                foreach (var registration in registrations)
+                {
+                    try
+                    {
+                        DetachEventProxy(registration.Proxy);
+                    }
+                    catch (Exception exception) when (!exception.IsCriticalException())
+                    {
+                        (exceptions ??= []).Add(exception);
+                    }
+                }
+            }
+
+            // Attempt every independent release before reporting failures; one failed native detach
+            // must not leave unrelated event sources and their subscribers connected.
+            ThrowCleanupExceptions(exceptions);
         }
     }
 
     public void FireEvent(object key, EventArgs e)
     {
-        Delegate? delegateToInvoke = Events[key];
+        Delegate? delegateToInvoke = _events?[key];
 
         if (delegateToInvoke is not null)
         {
@@ -132,23 +215,51 @@ internal abstract class HtmlShim : IDisposable
 
     public void RemoveHandler(object key, Delegate? value)
     {
-        _eventCount--;
-        Events.RemoveHandler(key, value);
-        OnEventHandlerRemoved();
+        if (_events is null || value is null)
+        {
+            return;
+        }
+
+        int before = _events[key]?.GetInvocationList().Length ?? 0;
+        _events.RemoveHandler(key, value);
+        int removed = before - (_events[key]?.GetInvocationList().Length ?? 0);
+        if (removed > 0)
+        {
+            // Unmatched -= is a no-op. Counting it (or counting a multicast delegate as one)
+            // disconnects the native source while valid handlers are still stored in EventHandlerList.
+            _eventCount -= removed;
+            OnEventHandlerRemoved();
+        }
     }
 
-    protected HtmlToClrEventProxy? RemoveEventProxy(EventHandler eventHandler)
+    internal static void DisposeAll(IEnumerable<HtmlShim> shims)
     {
-        if (_attachedEventList is null)
+        List<Exception>? exceptions = null;
+        foreach (HtmlShim shim in shims)
         {
-            return null;
+            try
+            {
+                shim.Dispose();
+            }
+            catch (Exception exception) when (!exception.IsCriticalException())
+            {
+                (exceptions ??= []).Add(exception);
+            }
         }
 
-        if (_attachedEventList.Remove(eventHandler, out HtmlToClrEventProxy? proxy))
+        ThrowCleanupExceptions(exceptions);
+    }
+
+    private static void ThrowCleanupExceptions(List<Exception>? exceptions)
+    {
+        if (exceptions is { Count: 1 })
         {
-            return proxy;
+            ExceptionDispatchInfo.Throw(exceptions[0]);
         }
 
-        return null;
+        if (exceptions is { Count: > 1 })
+        {
+            throw new AggregateException(exceptions);
+        }
     }
 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/HtmlShimManager.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/HtmlShimManager.cs
@@ -17,6 +17,7 @@ internal sealed class HtmlShimManager : IDisposable
     private Dictionary<HtmlWindow, HtmlWindow.HtmlWindowShim>? _htmlWindowShims;
     private Dictionary<HtmlElement, HtmlElement.HtmlElementShim>? _htmlElementShims;
     private Dictionary<HtmlDocument, HtmlDocument.HtmlDocumentShim>? _htmlDocumentShims;
+    private bool _disposed;
 
     internal HtmlShimManager()
     {
@@ -28,6 +29,8 @@ internal sealed class HtmlShimManager : IDisposable
     /// </summary>
     public void AddDocumentShim(HtmlDocument doc)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ObjectDisposedException.ThrowIf(doc.NativeHtmlDocument2.IsDisposed, doc);
         HtmlDocument.HtmlDocumentShim? shim = null;
 
         if (_htmlDocumentShims is null)
@@ -53,6 +56,8 @@ internal sealed class HtmlShimManager : IDisposable
     /// </summary>
     public void AddWindowShim(HtmlWindow window)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ObjectDisposedException.ThrowIf(window.NativeHtmlWindow.IsDisposed, window);
         HtmlWindow.HtmlWindowShim? shim = null;
         if (_htmlWindowShims is null)
         {
@@ -66,11 +71,8 @@ internal sealed class HtmlShimManager : IDisposable
             _htmlWindowShims[window] = shim;
         }
 
-        if (shim is not null)
-        {
-            // strictly not necessary, but here for future use.
-            OnShimAdded(shim);
-        }
+        // Reuse an existing shim as well: application subscriptions may have created it first.
+        (shim ?? _htmlWindowShims[window]).EnsureWindowObservation();
     }
 
     /// <summary> AddElementShim - adds a HtmlDocumentShim to list of shims to manage
@@ -78,6 +80,8 @@ internal sealed class HtmlShimManager : IDisposable
     /// </summary>
     public void AddElementShim(HtmlElement element)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ObjectDisposedException.ThrowIf(element.NativeHtmlElement.IsDisposed, element);
         HtmlElement.HtmlElementShim? shim = null;
 
         if (_htmlElementShims is null)
@@ -100,7 +104,9 @@ internal sealed class HtmlShimManager : IDisposable
 
     internal HtmlDocument.HtmlDocumentShim? GetDocumentShim(HtmlDocument document)
     {
-        if (_htmlDocumentShims is null)
+        // Dictionary equality queries COM identity. A revoked wrapper can share a cached hash with
+        // a live replacement after navigation, so reject it before the comparer queries its dead registration.
+        if (_htmlDocumentShims is null || document.NativeHtmlDocument2.IsDisposed)
         {
             return null;
         }
@@ -115,7 +121,7 @@ internal sealed class HtmlShimManager : IDisposable
 
     internal HtmlElement.HtmlElementShim? GetElementShim(HtmlElement element)
     {
-        if (_htmlElementShims is null)
+        if (_htmlElementShims is null || element.NativeHtmlElement.IsDisposed)
         {
             return null;
         }
@@ -130,7 +136,7 @@ internal sealed class HtmlShimManager : IDisposable
 
     internal HtmlWindow.HtmlWindowShim? GetWindowShim(HtmlWindow window)
     {
-        if (_htmlWindowShims is null)
+        if (_htmlWindowShims is null || window.NativeHtmlWindow.IsDisposed)
         {
             return null;
         }
@@ -145,15 +151,28 @@ internal sealed class HtmlShimManager : IDisposable
 
     private unsafe void OnShimAdded(HtmlShim addedShim)
     {
-        Debug.Assert(addedShim is not null, "Why are we calling this with a null shim?");
-        if (addedShim is not null and not HtmlWindow.HtmlWindowShim)
+        IHTMLWindow2.Interface? associatedWindow = addedShim.AssociatedWindow;
+        if (associatedWindow is null)
         {
-            // We need to add a window shim here for documents and elements
-            // so we can sync Window.Unload. The window shim itself will trap
-            // the unload event and call back on us on OnWindowUnloaded. When
-            // that happens we know we can free all our ptrs to COM.
-            AddWindowShim(new HtmlWindow(this, ComHelpers.GetComPointer<IHTMLWindow2>(addedShim.AssociatedWindow)));
+            return;
         }
+
+        using var nativeWindow = ComHelpers.GetComScope<IHTMLWindow2>(associatedWindow);
+        if (_htmlWindowShims is not null)
+        {
+            foreach (var (window, shim) in _htmlWindowShims)
+            {
+                if (window.NativeHtmlWindow.IsSameNativeObject(nativeWindow.Value))
+                {
+                    shim.EnsureWindowObservation();
+                    return;
+                }
+            }
+        }
+
+        // Only create a wrapper when the manager needs a new owner. A discarded duplicate wrapper
+        // would leave another GIT registration waiting for finalization on every shim addition.
+        AddWindowShim(new HtmlWindow(this, ComHelpers.GetComPointer<IHTMLWindow2>(associatedWindow)));
     }
 
     /// <summary>
@@ -162,92 +181,90 @@ internal sealed class HtmlShimManager : IDisposable
     /// </summary>
     internal void OnWindowUnloaded(HtmlWindow unloadedWindow)
     {
-        Debug.Assert(unloadedWindow is not null, "Why are we calling this with a null window?");
-        if (unloadedWindow is not null)
+        if (_disposed)
         {
-            //
-            // prune documents
-            //
-            if (_htmlDocumentShims is not null)
+            return;
+        }
+
+        List<HtmlShim> unloadedShims = [];
+        if (_htmlDocumentShims is not null)
+        {
+            foreach (HtmlDocument.HtmlDocumentShim shim in _htmlDocumentShims.Values.ToArray())
             {
-                HtmlDocument.HtmlDocumentShim[] shims = new HtmlDocument.HtmlDocumentShim[_htmlDocumentShims.Count];
-                _htmlDocumentShims.Values.CopyTo(shims, 0);
-
-                foreach (HtmlDocument.HtmlDocumentShim shim in shims)
+                if (IsAssociatedWindow(shim, unloadedWindow))
                 {
-                    if (shim.AssociatedWindow == unloadedWindow.NativeHtmlWindow)
-                    {
-                        _htmlDocumentShims.Remove(shim.Document);
-                        shim.Dispose();
-                    }
-                }
-            }
-
-            //
-            // prune elements
-            //
-            if (_htmlElementShims is not null)
-            {
-                HtmlElement.HtmlElementShim[] shims = new HtmlElement.HtmlElementShim[_htmlElementShims.Count];
-                _htmlElementShims.Values.CopyTo(shims, 0);
-
-                foreach (HtmlElement.HtmlElementShim shim in shims)
-                {
-                    if (shim.AssociatedWindow == unloadedWindow.NativeHtmlWindow)
-                    {
-                        _htmlElementShims.Remove(shim.Element);
-                        shim.Dispose();
-                    }
-                }
-            }
-
-            // Prune the particular window from the list.
-            if (_htmlWindowShims is not null)
-            {
-                if (_htmlWindowShims.Remove(unloadedWindow, out HtmlWindow.HtmlWindowShim? shim))
-                {
-                    shim.Dispose();
+                    _htmlDocumentShims.Remove(shim.Document);
+                    unloadedShims.Add(shim);
                 }
             }
         }
+
+        if (_htmlElementShims is not null)
+        {
+            foreach (HtmlElement.HtmlElementShim shim in _htmlElementShims.Values.ToArray())
+            {
+                if (IsAssociatedWindow(shim, unloadedWindow))
+                {
+                    _htmlElementShims.Remove(shim.Element);
+                    unloadedShims.Add(shim);
+                }
+            }
+        }
+
+        if (_htmlWindowShims is not null
+            && _htmlWindowShims.Remove(unloadedWindow, out HtmlWindow.HtmlWindowShim? windowShim))
+        {
+            unloadedShims.Add(windowShim);
+        }
+
+        // Remove all affected owners before native releases can reenter the manager. Attempt every
+        // disposal even if one detach fails, without disturbing another frame's live subscriptions.
+        HtmlShim.DisposeAll(unloadedShims);
+    }
+
+    private static unsafe bool IsAssociatedWindow(HtmlShim shim, HtmlWindow window)
+    {
+        IHTMLWindow2.Interface? associatedWindow = shim.AssociatedWindow;
+        if (associatedWindow is null)
+        {
+            return false;
+        }
+
+        // RCWs and AgileComPointer wrappers are not comparable; COM identity must be queried
+        // in the same apartment or the unloaded page's shims will never be removed.
+        using var nativeWindow = ComHelpers.GetComScope<IHTMLWindow2>(associatedWindow);
+        return window.NativeHtmlWindow.IsSameNativeObject(nativeWindow.Value);
     }
 
     public void Dispose()
     {
-        Dispose(true);
-    }
-
-    private void Dispose(bool disposing)
-    {
-        if (disposing)
+        if (_disposed)
         {
-            if (_htmlElementShims is not null)
-            {
-                foreach (HtmlElement.HtmlElementShim shim in _htmlElementShims.Values)
-                {
-                    shim.Dispose();
-                }
-            }
-
-            if (_htmlDocumentShims is not null)
-            {
-                foreach (HtmlDocument.HtmlDocumentShim shim in _htmlDocumentShims.Values)
-                {
-                    shim.Dispose();
-                }
-            }
-
-            if (_htmlWindowShims is not null)
-            {
-                foreach (HtmlWindow.HtmlWindowShim shim in _htmlWindowShims.Values)
-                {
-                    shim.Dispose();
-                }
-            }
-
-            _htmlWindowShims = null;
-            _htmlDocumentShims = null;
-            _htmlWindowShims = null;
+            return;
         }
+
+        _disposed = true;
+        List<HtmlShim> shims = [];
+        if (_htmlElementShims is not null)
+        {
+            shims.AddRange(_htmlElementShims.Values);
+        }
+
+        if (_htmlDocumentShims is not null)
+        {
+            shims.AddRange(_htmlDocumentShims.Values);
+        }
+
+        if (_htmlWindowShims is not null)
+        {
+            shims.AddRange(_htmlWindowShims.Values);
+        }
+
+        // A retained browser/wrapper must not retain disposed element shims through the manager.
+        // Clear before releasing COM objects, which may call back into this manager.
+        _htmlElementShims = null;
+        _htmlDocumentShims = null;
+        _htmlWindowShims = null;
+        HtmlShim.DisposeAll(shims);
     }
 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/HtmlWindow.HTMLWindowEvents2.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/HtmlWindow.HTMLWindowEvents2.cs
@@ -73,14 +73,23 @@ public sealed partial class HtmlWindow
 
         public void onunload(IHTMLEventObj evtObj)
         {
+            HtmlWindowShim? shim = _parent.ShimManager.GetWindowShim(_parent);
             HtmlElementEventArgs e = new(_parent.ShimManager, evtObj);
-            FireEvent(s_eventUnload, e);
-            _parent?.WindowShim.OnWindowUnload();
+            try
+            {
+                shim?.FireEvent(s_eventUnload, e);
+            }
+            finally
+            {
+                // User handlers may dispose the browser or throw. Retain the original shim rather
+                // than looking up the lazy WindowShim property and recreating an owner during teardown.
+                shim?.OnWindowUnload();
+            }
         }
 
         private void FireEvent(object key, EventArgs e)
         {
-            _parent?.WindowShim.FireEvent(key, e);
+            _parent.ShimManager.GetWindowShim(_parent)?.FireEvent(key, e);
         }
     }
 }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/HtmlWindow.HtmlWindowShim.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/HtmlWindow.HtmlWindowShim.cs
@@ -26,6 +26,7 @@ public sealed partial class HtmlWindow
     {
         private AxHost.ConnectionPointCookie? _cookie;
         private HtmlWindow _htmlWindow;
+        private bool _observeWindowUnload;
 
         public HtmlWindowShim(HtmlWindow window)
         {
@@ -37,19 +38,41 @@ public sealed partial class HtmlWindow
         public IHTMLWindow2.Interface NativeHtmlWindow => (IHTMLWindow2.Interface)_htmlWindow.NativeHtmlWindow.GetManagedObject();
 
         /// Support IHtmlDocument3.AttachHandler
-        public override void AttachEventHandler(string eventName, EventHandler eventHandler)
+        protected override bool AttachEventProxy(HtmlToClrEventProxy proxy)
         {
             // IE likes to call back on an IDispatch of DISPID=0 when it has an event,
             // the HtmlToClrEventProxy helps us fake out the CLR so that we can call back on
             // our EventHandler properly.
 
-            HtmlToClrEventProxy proxy = AddEventProxy(eventName, eventHandler);
             using var htmlWindow3 = _htmlWindow.GetHtmlWindow<IHTMLWindow3>();
-            using BSTR name = new(eventName);
+            using BSTR name = new(proxy.EventName);
             using var dispatch = ComHelpers.GetComScope<IDispatch>(proxy);
             VARIANT_BOOL result;
             htmlWindow3.Value->attachEvent(name, dispatch, &result).ThrowOnFailure();
-            Debug.Assert(result, "failed to add event");
+            if (IsDisposed && result)
+            {
+                htmlWindow3.Value->detachEvent(name, dispatch).ThrowOnFailure();
+                ObjectDisposedException.ThrowIf(IsDisposed, this);
+            }
+
+            return result;
+        }
+
+        internal void EnsureWindowObservation()
+        {
+            ObjectDisposedException.ThrowIf(IsDisposed, this);
+            // The manager needs unload even when the application subscribes only to document/element
+            // events. Otherwise its dictionaries root old pages and delegates indefinitely.
+            _observeWindowUnload = true;
+            ConnectToEvents();
+        }
+
+        protected override void OnEventHandlerRemoved()
+        {
+            if (!_observeWindowUnload)
+            {
+                base.OnEventHandlerRemoved();
+            }
         }
 
         /// Support HTMLWindowEvents2
@@ -57,46 +80,60 @@ public sealed partial class HtmlWindow
         {
             if (_cookie is null || !_cookie.Connected)
             {
-                _cookie = new AxHost.ConnectionPointCookie(
+                AxHost.ConnectionPointCookie cookie = new(
                     NativeHtmlWindow,
                     new HTMLWindowEvents2(_htmlWindow),
                     typeof(DHTMLWindowEvents2),
                     throwException: false);
-                if (!_cookie.Connected)
+                if (IsDisposed)
                 {
-                    _cookie = null;
+                    cookie.Disconnect();
+                    return;
+                }
+
+                _cookie = cookie.Connected ? cookie : null;
+                if (_observeWindowUnload && _cookie is null)
+                {
+                    // Not every window exposes this connection point. Preserve the existing
+                    // nonthrowing subscription behavior; manager disposal still releases its shims.
+                    Debug.WriteLine("HTML window unload observation is unavailable; cleanup is deferred to manager disposal.");
                 }
             }
         }
 
         /// Support IHTMLWindow3.DetachHandler
-        public override void DetachEventHandler(string eventName, EventHandler eventHandler)
+        protected override void DetachEventProxy(HtmlToClrEventProxy proxy)
         {
-            HtmlToClrEventProxy? proxy = RemoveEventProxy(eventHandler);
-            if (proxy is not null)
-            {
-                using var htmlWindow3 = _htmlWindow.GetHtmlWindow<IHTMLWindow3>();
-                using BSTR name = new(eventName);
-                using var dispatch = ComHelpers.GetComScope<IDispatch>(proxy);
-                htmlWindow3.Value->detachEvent(name, dispatch).ThrowOnFailure();
-            }
+            using var htmlWindow3 = _htmlWindow.GetHtmlWindow<IHTMLWindow3>();
+            using BSTR name = new(proxy.EventName);
+            using var dispatch = ComHelpers.GetComScope<IDispatch>(proxy);
+            htmlWindow3.Value->detachEvent(name, dispatch).ThrowOnFailure();
         }
 
         public override void DisconnectFromEvents()
         {
-            _cookie?.Disconnect();
+            AxHost.ConnectionPointCookie? cookie = _cookie;
             _cookie = null;
+            cookie?.Disconnect();
         }
 
         public void OnWindowUnload() => _htmlWindow?.ShimManager.OnWindowUnloaded(_htmlWindow);
 
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
-            if (disposing)
+            try
             {
-                _htmlWindow?.NativeHtmlWindow?.Dispose();
-                _htmlWindow = null!;
+                base.Dispose(disposing);
+            }
+            finally
+            {
+                if (disposing)
+                {
+                    HtmlWindow? window = _htmlWindow;
+                    _htmlWindow = null!;
+                    _observeWindowUnload = false;
+                    window?.NativeHtmlWindow.Dispose();
+                }
             }
         }
 

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/HtmlWindow.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/HtmlWindow.cs
@@ -277,8 +277,11 @@ public sealed unsafe partial class HtmlWindow
         return confirmed;
     }
 
-    public void DetachEventHandler(string eventName, EventHandler eventHandler) =>
-        WindowShim.DetachEventHandler(eventName, eventHandler);
+    public void DetachEventHandler(string eventName, EventHandler eventHandler)
+    {
+        // A removal must not resurrect the lazy window shim during unload or browser disposal.
+        ShimManager.GetWindowShim(this)?.DetachEventHandler(eventName, eventHandler);
+    }
 
     public void Focus()
     {
@@ -417,43 +420,43 @@ public sealed unsafe partial class HtmlWindow
     public event HtmlElementErrorEventHandler? Error
     {
         add => WindowShim.AddHandler(s_eventError, value);
-        remove => WindowShim.RemoveHandler(s_eventError, value);
+        remove => ShimManager.GetWindowShim(this)?.RemoveHandler(s_eventError, value);
     }
 
     public event HtmlElementEventHandler? GotFocus
     {
         add => WindowShim.AddHandler(s_eventGotFocus, value);
-        remove => WindowShim.RemoveHandler(s_eventGotFocus, value);
+        remove => ShimManager.GetWindowShim(this)?.RemoveHandler(s_eventGotFocus, value);
     }
 
     public event HtmlElementEventHandler? Load
     {
         add => WindowShim.AddHandler(s_eventLoad, value);
-        remove => WindowShim.RemoveHandler(s_eventLoad, value);
+        remove => ShimManager.GetWindowShim(this)?.RemoveHandler(s_eventLoad, value);
     }
 
     public event HtmlElementEventHandler? LostFocus
     {
         add => WindowShim.AddHandler(s_eventLostFocus, value);
-        remove => WindowShim.RemoveHandler(s_eventLostFocus, value);
+        remove => ShimManager.GetWindowShim(this)?.RemoveHandler(s_eventLostFocus, value);
     }
 
     public event HtmlElementEventHandler? Resize
     {
         add => WindowShim.AddHandler(s_eventResize, value);
-        remove => WindowShim.RemoveHandler(s_eventResize, value);
+        remove => ShimManager.GetWindowShim(this)?.RemoveHandler(s_eventResize, value);
     }
 
     public event HtmlElementEventHandler? Scroll
     {
         add => WindowShim.AddHandler(s_eventScroll, value);
-        remove => WindowShim.RemoveHandler(s_eventScroll, value);
+        remove => ShimManager.GetWindowShim(this)?.RemoveHandler(s_eventScroll, value);
     }
 
     public event HtmlElementEventHandler? Unload
     {
         add => WindowShim.AddHandler(s_eventUnload, value);
-        remove => WindowShim.RemoveHandler(s_eventUnload, value);
+        remove => ShimManager.GetWindowShim(this)?.RemoveHandler(s_eventUnload, value);
     }
 
     public static unsafe bool operator ==(HtmlWindow? left, HtmlWindow? right)

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/WebBrowser.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/WebBrowser.cs
@@ -1108,15 +1108,33 @@ public unsafe partial class WebBrowser : WebBrowserBase
 
     protected override void Dispose(bool disposing)
     {
-        if (disposing)
+        try
         {
-            _htmlShimManager?.Dispose();
-
-            DetachSink();
-            ActiveXSite.Dispose();
+            if (disposing)
+            {
+                try
+                {
+                    _htmlShimManager?.Dispose();
+                }
+                finally
+                {
+                    // A failed HTML detach must not prevent the browser's own event/site and
+                    // native instance from being released. The original error still propagates.
+                    try
+                    {
+                        DetachSink();
+                    }
+                    finally
+                    {
+                        ActiveXSite.Dispose();
+                    }
+                }
+            }
         }
-
-        base.Dispose(disposing);
+        finally
+        {
+            base.Dispose(disposing);
+        }
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/WebBrowserBase.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/WebBrowserBase.cs
@@ -832,16 +832,20 @@ public unsafe partial class WebBrowserBase : Control
             // First, create the ActiveX control
             Debug.Assert(_activeXInstance is null, "activeXInstance must be null");
 
-            HRESULT hr = PInvokeCore.CoCreateInstance(
-                in _clsid,
-                null,
-                CLSCTX.CLSCTX_INPROC_SERVER,
-                IID.GetRef<IUnknown>(),
-                out void* unknown);
+            // The RCW retains its own reference; leaving CoCreateInstance's reference outstanding
+            // would keep the native browser alive even after FinalReleaseComObject during disposal.
+            using ComScope<IUnknown> unknown = new(null);
+            fixed (Guid* clsid = &_clsid)
+            {
+                PInvokeCore.CoCreateInstance(
+                    clsid,
+                    null,
+                    CLSCTX.CLSCTX_INPROC_SERVER,
+                    IID.Get<IUnknown>(),
+                    unknown).ThrowOnFailure();
+            }
 
-            hr.ThrowOnFailure();
-
-            _activeXInstance = ComHelpers.GetObjectForIUnknown((IUnknown*)unknown);
+            _activeXInstance = ComHelpers.GetObjectForIUnknown(unknown);
 
             Debug.Assert(_activeXInstance is not null, "w/o an exception being thrown we must have an object...");
 
@@ -893,7 +897,10 @@ public unsafe partial class WebBrowserBase : Control
             {
                 // Simply setting the site to the ActiveX control should activate it.
                 // And this will take us to the Running state.
-                _axOleObject!.SetClientSite(ComHelpers.GetComPointer<IOleClientSite>(ActiveXSite));
+                // SetClientSite borrows this reference and retains its own. Without releasing our
+                // temporary reference, the site CCW roots the managed host after native browser destruction.
+                using var clientSite = ComHelpers.GetComScope<IOleClientSite>(ActiveXSite);
+                _axOleObject!.SetClientSite(clientSite);
             }
 
             // We start receiving events now (but we do this only if we are not in DesignMode).

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/WebBrowserContainer.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/WebBrowser/WebBrowserContainer.cs
@@ -103,8 +103,10 @@ internal unsafe class WebBrowserContainer : IOleContainer.Interface, IOleInPlace
             return HRESULT.S_OK;
         }
 
-        IOleClientSite* clientSite;
-        oleObject.Value->GetClientSite(&clientSite);
+        // GetClientSite returns an owned reference, whereas conversion only borrows it.
+        // Leaving that reference outstanding roots the site's managed host after browser disposal.
+        using ComScope<IOleClientSite> clientSite = new(null);
+        oleObject.Value->GetClientSite(clientSite);
         object clientSiteObject = ComHelpers.GetObjectForIUnknown(clientSite);
         if (clientSiteObject is WebBrowserSiteBase webBrowserSiteBase)
         {

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/AxHost.ConnectionPointCookieTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/AxHost.ConnectionPointCookieTests.cs
@@ -9,7 +9,7 @@ using Windows.Win32.System.Ole;
 namespace System.Windows.Forms.Tests;
 
 [Collection("Sequential")] // workaround for WebBrowser control corrupting memory when run on multiple UI threads (instantiated via GUID)
-public class AxHostConnectionPointCookieTests
+public partial class AxHostConnectionPointCookieTests
 {
     private static Guid CLSID_WebBrowser { get; } = new("8856f961-340a-11d0-a96b-00c04fd705a2");
 

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/AxHostConnectionPointCookieTests.Ownership.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/AxHostConnectionPointCookieTests.Ownership.cs
@@ -1,0 +1,138 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Windows.Win32.System.Com;
+using Windows.Win32.System.Ole;
+
+namespace System.Windows.Forms.Tests;
+
+/// <summary>
+///  Checks caller-owned sink references separately from the connection point's subscription reference.
+/// </summary>
+public partial class AxHostConnectionPointCookieTests
+{
+    [StaTheory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public unsafe void ConnectionPointCookie_Ownership_BalancesTemporarySink(bool failAdvise)
+    {
+        using OwnershipConnectionPoint source = new() { FailAdvise = failAdvise };
+        OwnershipNotifySink sink = new();
+        using var nativeSink = ComHelpers.GetComScope<IPropertyNotifySink>(sink);
+        using var observer = nativeSink.Query<IUnknown>();
+        uint before = GetSinkReferenceCount(observer.Value);
+        AxHost.ConnectionPointCookie cookie = new(source, sink, typeof(IPropertyNotifySink.Interface), throwException: false);
+        try
+        {
+            Assert.Equal(!failAdvise, cookie.Connected);
+            Assert.Equal(failAdvise ? before : before + 1, GetSinkReferenceCount(observer.Value));
+            if (!failAdvise)
+            {
+                source.Notify();
+                Assert.Equal(1, sink.Calls);
+            }
+        }
+        finally
+        {
+            cookie.Disconnect();
+        }
+
+        Assert.Equal(before, GetSinkReferenceCount(observer.Value));
+        Assert.Equal(HRESULT.S_OK, nativeSink.Value->OnChanged(0));
+        Assert.Equal(failAdvise ? 1 : 2, sink.Calls);
+        cookie.Disconnect();
+        Assert.Equal(before, GetSinkReferenceCount(observer.Value));
+    }
+
+    private static unsafe uint GetSinkReferenceCount(IUnknown* unknown)
+    {
+        unknown->AddRef();
+        return unknown->Release();
+    }
+
+    /// <summary>
+    ///  Provides a controlled subscription owner, including failure without retaining a sink.
+    /// </summary>
+    private sealed unsafe class OwnershipConnectionPoint :
+        IConnectionPoint.Interface,
+        IConnectionPointContainer.Interface,
+        IManagedWrapper<IConnectionPoint, IConnectionPointContainer>,
+        IDisposable
+    {
+        private AgileComPointer<IUnknown>? _sink;
+        public bool FailAdvise { get; init; }
+
+        public HRESULT GetConnectionInterface(Guid* iid)
+        {
+            *iid = IID.GetRef<IPropertyNotifySink>();
+            return HRESULT.S_OK;
+        }
+
+        public HRESULT GetConnectionPointContainer(IConnectionPointContainer** container)
+        {
+            *container = ComHelpers.GetComPointer<IConnectionPointContainer>(this);
+            return HRESULT.S_OK;
+        }
+
+        public HRESULT FindConnectionPoint(Guid* iid, IConnectionPoint** connectionPoint)
+        {
+            *connectionPoint = ComHelpers.GetComPointer<IConnectionPoint>(this);
+            return HRESULT.S_OK;
+        }
+
+        public HRESULT Advise(IUnknown* sink, uint* cookie)
+        {
+            *cookie = 0;
+            if (FailAdvise)
+            {
+                return HRESULT.E_FAIL;
+            }
+
+            _sink = new AgileComPointer<IUnknown>(sink, takeOwnership: false);
+            *cookie = 1;
+            return HRESULT.S_OK;
+        }
+
+        public HRESULT Unadvise(uint cookie)
+        {
+            DisposeHelper.NullAndDispose(ref _sink);
+            return HRESULT.S_OK;
+        }
+
+        public HRESULT EnumConnections(IEnumConnections** connections)
+        {
+            *connections = null;
+            return HRESULT.E_NOTIMPL;
+        }
+
+        public HRESULT EnumConnectionPoints(IEnumConnectionPoints** connectionPoints)
+        {
+            *connectionPoints = null;
+            return HRESULT.E_NOTIMPL;
+        }
+
+        public void Notify()
+        {
+            using var sink = _sink!.GetInterface<IPropertyNotifySink>();
+            sink.Value->OnChanged(0).ThrowOnFailure();
+        }
+
+        public void Dispose() => DisposeHelper.NullAndDispose(ref _sink);
+    }
+
+    /// <summary>
+    ///  Exposes a managed sink whose native reference count is not affected by RCW caching.
+    /// </summary>
+    private sealed class OwnershipNotifySink : IPropertyNotifySink.Interface, IManagedWrapper<IPropertyNotifySink>
+    {
+        public int Calls { get; private set; }
+
+        public HRESULT OnChanged(int dispID)
+        {
+            Calls++;
+            return HRESULT.S_OK;
+        }
+
+        public HRESULT OnRequestEdit(int dispID) => HRESULT.S_OK;
+    }
+}

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/AxHostTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/AxHostTests.cs
@@ -1471,6 +1471,124 @@ public class AxHostTests
         Assert.Equal(1, result.GdiCharSet);
     }
 
+    [WinFormsTheory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public unsafe void AxHost_FontConversion_ReleasesNativeReferences(bool useAxHost, bool dispatch)
+    {
+        using Font font = new("Arial", 10);
+        object nativeFont;
+        if (useAxHost)
+        {
+            nativeFont = dispatch ? SubAxHost.GetIFontDispFromFont(font) : SubAxHost.GetIFontFromFont(font);
+        }
+        else
+        {
+            using ComScope<IUnknown> created = new(null);
+            Guid interfaceId = dispatch ? IID.GetRef<IFontDisp>() : IID.GetRef<IFont>();
+            FONTDESC description = new()
+            {
+                cbSizeofstruct = (uint)sizeof(FONTDESC),
+                cySize = (CY)font.SizeInPoints,
+                sWeight = 400,
+                sCharset = 1
+            };
+
+            fixed (char* name = font.Name)
+            {
+                description.lpstrName = name;
+                PInvoke.OleCreateFontIndirect(&description, &interfaceId, created).ThrowOnFailure();
+            }
+
+            nativeFont = Marshal.GetObjectForIUnknown((nint)created.Value);
+        }
+
+        Assert.True(Marshal.IsComObject(nativeFont));
+        using ComScope<IUnknown> observer = new((IUnknown*)Marshal.GetIUnknownForObject(nativeFont));
+        try
+        {
+            // Releasing the creation reference must not invalidate the returned RCW.
+            IFont.Interface result = (IFont.Interface)nativeFont;
+            using BSTR name = result.Name;
+            Assert.Equal(font.Name, name.ToString());
+            Assert.InRange(result.Size.int64 / 10_000f, font.SizeInPoints - 0.25f, font.SizeInPoints + 0.25f);
+        }
+        finally
+        {
+            Marshal.FinalReleaseComObject(nativeFont);
+        }
+
+        // Direct creation establishes the native font has no hidden owner after RCW teardown.
+        // The observer keeps it alive while the balanced probe detects a leaked creation reference.
+        observer.Value->AddRef();
+        uint remainingReferences = observer.Value->Release();
+        Assert.Equal(1u, remainingReferences);
+    }
+
+    [WinFormsTheory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public unsafe void AxHost_QuickActivate_ReleasesBorrowedReferences(bool failActivation, bool throwOnActivation)
+    {
+        using Font font = new("Arial", 10, FontStyle.Regular, GraphicsUnit.Point);
+        using ContainerControl parent = new() { Font = font };
+        using SubAxHost control = new(EmptyClsidString);
+        parent.Controls.Add(control);
+        object site = control.TestAccessor.Dynamic._oleSite;
+        using var siteObserver = ComHelpers.GetComScope<IUnknown>(site);
+        siteObserver.Value->AddRef();
+        uint before = siteObserver.Value->Release();
+        HRESULT activationResult = failActivation ? HRESULT.E_FAIL : HRESULT.S_OK;
+        using QuickActivateReferenceOwner activeX = new(activationResult, throwOnActivation);
+
+        control.TestAccessor.Dynamic._instance = activeX;
+        try
+        {
+            if (throwOnActivation)
+            {
+                Assert.Same(activeX.ActivationException, Assert.Throws<InvalidOperationException>(() =>
+                {
+                    control.TestAccessor.Dynamic.QuickActivate();
+                }));
+            }
+            else
+            {
+                Assert.Equal(!failActivation, (bool)control.TestAccessor.Dynamic.QuickActivate());
+            }
+        }
+        finally
+        {
+            // The fake is a managed object, not an RCW for AxHost's native-instance teardown.
+            control.TestAccessor.Dynamic._instance = null;
+        }
+
+        Assert.Equal(1, activeX.ActivationCount);
+        using BSTR fontName = activeX.Font->Name;
+        Assert.Equal(font.Name, fontName.ToString());
+        Assert.Throws<NotImplementedException>(() => activeX.ClientSite->SaveObject());
+        Assert.Equal(HRESULT.S_OK, activeX.PropertyNotifySink->OnRequestEdit(PInvokeCore.DISPID_AMBIENT_FONT));
+
+        activeX.Font->AddRef();
+        uint fontReferences = activeX.Font->Release();
+        Assert.Equal(1u, fontReferences);
+        Assert.Equal(fontReferences + 1, activeX.FontReferencesDuringActivation);
+
+        // Both site interfaces share one CCW. Only the fake's two retained references may remain;
+        // neither temporary caller reference can survive, even when the activation call throws.
+        siteObserver.Value->AddRef();
+        uint after = siteObserver.Value->Release();
+        Assert.Equal(before + 2, after);
+        Assert.Equal(after + 2, activeX.SiteReferencesDuringActivation);
+
+        activeX.Dispose();
+        siteObserver.Value->AddRef();
+        Assert.Equal(before, siteObserver.Value->Release());
+        GC.KeepAlive(control);
+    }
+
     [WinFormsFact]
     public void AxHost_GetIFontDispFromFont_InvokeComplexStyle_Roundtrips()
     {
@@ -3097,6 +3215,78 @@ public class AxHostTests
         AxHost.ConnectionPointCookie cookie = site.TestAccessor.Dynamic._connectionPoint;
         cookie.Should().NotBeNull();
         cookie.Connected.Should().BeTrue();
+    }
+
+    /// <summary>
+    ///  Retains independent font and site references while the real AxHost quick-activation path runs.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Keeping the references after success or failure lets the test detect premature releases as well as leaks
+    ///   without requiring an installed ActiveX control or relying on an RCW's internal reference count.
+    ///  </para>
+    /// </remarks>
+    private unsafe class QuickActivateReferenceOwner(HRESULT activationResult, bool throwOnActivation)
+        : IQuickActivate.Interface, IDisposable
+    {
+        private IFont* _font;
+        private IOleClientSite* _clientSite;
+        private IPropertyNotifySink* _propertyNotifySink;
+
+        public IFont* Font => _font;
+
+        public IOleClientSite* ClientSite => _clientSite;
+
+        public IPropertyNotifySink* PropertyNotifySink => _propertyNotifySink;
+
+        public int ActivationCount { get; private set; }
+
+        public uint FontReferencesDuringActivation { get; private set; }
+
+        public uint SiteReferencesDuringActivation { get; private set; }
+
+        public InvalidOperationException ActivationException { get; } = new("Activation failed.");
+
+        /// <inheritdoc/>
+        public HRESULT QuickActivate(QACONTAINER* container, QACONTROL* control)
+        {
+            ActivationCount++;
+            Assert.NotNull(container->pFont);
+            Assert.NotNull(container->pClientSite);
+            Assert.NotNull(container->pPropertyNotifySink);
+            _font = container->pFont;
+            _clientSite = container->pClientSite;
+            _propertyNotifySink = container->pPropertyNotifySink;
+            _font->AddRef();
+            _clientSite->AddRef();
+            _propertyNotifySink->AddRef();
+
+            _font->AddRef();
+            FontReferencesDuringActivation = _font->Release();
+            _clientSite->AddRef();
+            SiteReferencesDuringActivation = _clientSite->Release();
+
+            if (throwOnActivation)
+            {
+                throw ActivationException;
+            }
+
+            return activationResult;
+        }
+
+        /// <inheritdoc/>
+        public HRESULT SetContentExtent(SIZE* size) => HRESULT.E_NOTIMPL;
+
+        /// <inheritdoc/>
+        public HRESULT GetContentExtent(SIZE* size) => HRESULT.E_NOTIMPL;
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            DisposeHelper.NullAndRelease(ref _font);
+            DisposeHelper.NullAndRelease(ref _clientSite);
+            DisposeHelper.NullAndRelease(ref _propertyNotifySink);
+        }
     }
 
     private class SubComponentEditor : ComponentEditor

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataObjectTests.Ownership.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/DataObjectTests.Ownership.cs
@@ -1,0 +1,285 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+using Com = Windows.Win32.System.Com;
+using IComDataObject = System.Runtime.InteropServices.ComTypes.IDataObject;
+
+namespace System.Windows.Forms.Tests;
+
+/// <summary>
+///  Verifies native storage-medium ownership when DataObject forwards runtime COM calls.
+/// </summary>
+public partial class DataObjectTests
+{
+    [StaTheory]
+    [InlineData(false, false, false, false)]
+    [InlineData(false, false, true, false)]
+    [InlineData(false, true, false, false)]
+    [InlineData(false, true, true, false)]
+    [InlineData(true, false, false, false)]
+    [InlineData(true, false, true, false)]
+    [InlineData(true, true, false, false)]
+    [InlineData(true, true, true, false)]
+    [InlineData(true, true, false, true)]
+    [InlineData(true, true, true, true)]
+    public unsafe void IComDataObjectSetData_NativeAdapter_Ownership(
+        bool succeeds,
+        bool release,
+        bool hasReleaseOwner,
+        bool releaseWithinCall)
+    {
+        using MemoryStream data = new([42]);
+        Com.ComManagedStream source = new(data);
+        using var stream = ComHelpers.GetComScope<Com.IStream>(source);
+        using var observer = stream.Query<Com.IUnknown>();
+        uint baseline = GetSetDataReferenceCount(observer);
+        using SetDataNativeRecipient recipient = new(succeeds ? HRESULT.S_OK : HRESULT.E_FAIL, releaseWithinCall);
+        using var nativeDataObject = ComHelpers.GetComScope<Com.IDataObject>(recipient);
+
+        // The pointer constructor selects Composition.Create(IDataObject*), not the runtime-object
+        // overload that would call a managed mock directly and bypass NativeToRuntimeAdapter.
+        DataObject dataObject = new(nativeDataObject.Value);
+        GetSetDataRuntimeAdapter(dataObject);
+        IComDataObject runtimeDataObject = dataObject;
+        FORMATETC format = new()
+        {
+            cfFormat = (short)DataFormats.GetFormat(DataFormats.Text).Id,
+            dwAspect = DVASPECT.DVASPECT_CONTENT,
+            lindex = -1,
+            tymed = TYMED.TYMED_ISTREAM
+        };
+        STGMEDIUM medium = new()
+        {
+            tymed = TYMED.TYMED_ISTREAM,
+            unionmember = (nint)stream.Value,
+            pUnkForRelease = hasReleaseOwner ? source : null
+        };
+        STGMEDIUM original = medium;
+
+        // TYMED_ISTREAM owns a stream reference even when pUnkForRelease is non-null:
+        // ReleaseStgMedium releases both. Conversion supplies only the additional release-owner reference.
+        stream.Value->AddRef();
+
+        try
+        {
+            Exception? exception = Record.Exception(() => runtimeDataObject.SetData(ref format, ref medium, release));
+            bool transferred = succeeds && release;
+
+            if (succeeds)
+            {
+                Assert.Null(exception);
+            }
+            else
+            {
+                Assert.Equal((int)HRESULT.E_FAIL, Assert.IsType<COMException>(exception).HResult);
+            }
+
+            Assert.Equal(1, recipient.SetDataCalls);
+            Assert.Equal(release, recipient.ReleaseRequested);
+            Assert.Equal(transferred, recipient.AcceptedOwnership);
+            Assert.Equal((nint)stream.Value, recipient.DataPointer);
+            Assert.Equal(hasReleaseOwner ? (nint)observer.Value : 0, recipient.ReleaseOwner);
+            Assert.Equal(baseline + (hasReleaseOwner ? 2u : 1u), recipient.ReferencesDuringCall);
+            Assert.Equal((ushort)format.cfFormat, recipient.Format.cfFormat);
+            Assert.Equal((uint)format.tymed, recipient.Format.tymed);
+            Assert.Equal(format.lindex, recipient.Format.lindex);
+
+            // Even if ReleaseStgMedium changed the transferred native structure during the call,
+            // the public managed ref parameter and its original managed owner stay usable.
+            Assert.Equal(original.tymed, medium.tymed);
+            Assert.Equal(original.unionmember, medium.unionmember);
+            Assert.Same(original.pUnkForRelease, medium.pUnkForRelease);
+            if (hasReleaseOwner)
+            {
+                Assert.Same(data, Assert.IsType<Com.ComManagedStream>(medium.pUnkForRelease).GetDataStream());
+            }
+
+            uint callerReferences = !transferred ? 1u : 0u;
+            uint retainedReferences = transferred && !releaseWithinCall ? (hasReleaseOwner ? 2u : 1u) : 0u;
+            Assert.Equal(baseline + callerReferences + retainedReferences, GetSetDataReferenceCount(observer));
+            Assert.Equal(transferred && !releaseWithinCall, recipient.HasRetainedMedium);
+            Assert.Equal(transferred && releaseWithinCall ? 1 : 0, recipient.MediumReleases);
+
+            recipient.ReleaseRetainedMedium();
+            Assert.Equal(baseline + callerReferences, GetSetDataReferenceCount(observer));
+            Assert.Equal(transferred ? 1 : 0, recipient.MediumReleases);
+            Assert.Equal(HRESULT.S_OK, stream.Value->Commit(0));
+            Assert.Equal(42, source.GetDataStream().ReadByte());
+        }
+        finally
+        {
+            recipient.ReleaseRetainedMedium();
+            if (!recipient.AcceptedOwnership)
+            {
+                stream.Value->Release();
+            }
+
+            // Keep both observer scopes safe to dispose if a regression over-released the medium.
+            // Counts above are asserted before repairing test-only references.
+            RestoreSetDataReferenceCount(observer, baseline);
+            GC.KeepAlive(dataObject);
+        }
+    }
+
+    [StaTheory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public unsafe void IComDataObjectSetData_NativeAdapter_InterfaceFailure_ReleasesConversionReference(
+        bool release,
+        bool hasReleaseOwner)
+    {
+        using MemoryStream data = new([42]);
+        Com.ComManagedStream source = new(data);
+        using var stream = ComHelpers.GetComScope<Com.IStream>(source);
+        using var observer = stream.Query<Com.IUnknown>();
+        uint baseline = GetSetDataReferenceCount(observer);
+        using SetDataNativeRecipient recipient = new(HRESULT.S_OK, releaseWithinCall: false);
+        using var nativeDataObject = ComHelpers.GetComScope<Com.IDataObject>(recipient);
+        DataObject dataObject = new(nativeDataObject.Value);
+        IComDataObject adapter = GetSetDataRuntimeAdapter(dataObject);
+        var agileDataObject = (AgileComPointer<Com.IDataObject>)adapter.TestAccessor.Dynamic._nativeDataObject;
+
+        // Revoke this adapter's registration so GetInterface fails after medium conversion,
+        // without invalidating the independent reference used by the other Composition adapter.
+        agileDataObject.Dispose();
+        using var unavailable = agileDataObject.TryGetInterface(out HRESULT expectedError);
+        Assert.True(expectedError.Failed);
+
+        FORMATETC format = new() { tymed = TYMED.TYMED_ISTREAM };
+        STGMEDIUM medium = new()
+        {
+            tymed = TYMED.TYMED_ISTREAM,
+            unionmember = (nint)stream.Value,
+            pUnkForRelease = hasReleaseOwner ? source : null
+        };
+
+        try
+        {
+            IComDataObject runtimeDataObject = dataObject;
+            Exception? exception = Record.Exception(() => runtimeDataObject.SetData(ref format, ref medium, release));
+            Assert.NotNull(exception);
+            Assert.Equal((int)expectedError, exception.HResult);
+            Assert.Equal(0, recipient.SetDataCalls);
+            Assert.Equal(baseline, GetSetDataReferenceCount(observer));
+            Assert.Equal(TYMED.TYMED_ISTREAM, medium.tymed);
+            Assert.Equal((nint)stream.Value, medium.unionmember);
+            Assert.Same(hasReleaseOwner ? source : null, medium.pUnkForRelease);
+            Assert.Equal(HRESULT.S_OK, stream.Value->Commit(0));
+            Assert.Equal(42, source.GetDataStream().ReadByte());
+        }
+        finally
+        {
+            RestoreSetDataReferenceCount(observer, baseline);
+            GC.KeepAlive(dataObject);
+        }
+    }
+
+    private static IComDataObject GetSetDataRuntimeAdapter(DataObject dataObject)
+    {
+        object composition = dataObject.TestAccessor.Dynamic._innerData;
+        var adapter = (IComDataObject)composition.TestAccessor.Dynamic._runtimeDataObject;
+        Assert.Equal("NativeToRuntimeAdapter", adapter.GetType().Name);
+        return adapter;
+    }
+
+    private static unsafe uint GetSetDataReferenceCount(Com.IUnknown* unknown)
+    {
+        unknown->AddRef();
+        return unknown->Release();
+    }
+
+    private static unsafe void RestoreSetDataReferenceCount(Com.IUnknown* observer, uint expected)
+    {
+        uint count = GetSetDataReferenceCount(observer);
+        while (count < expected)
+        {
+            count = observer->AddRef();
+        }
+
+        while (count > expected)
+        {
+            count = observer->Release();
+        }
+    }
+
+    /// <summary>
+    ///  Accepts storage media through a native CCW and observes the reference handed to SetData.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Only successful calls with fRelease set consume the medium. The recipient can release it
+    ///   immediately or retain it without AddRef, as required by the native IDataObject contract.
+    ///  </para>
+    /// </remarks>
+    private sealed unsafe class SetDataNativeRecipient(HRESULT result, bool releaseWithinCall)
+        : Com.IDataObject.Interface, Com.IManagedWrapper<Com.IDataObject>, IDisposable
+    {
+        private Com.STGMEDIUM _retainedMedium;
+
+        public int SetDataCalls { get; private set; }
+        public bool ReleaseRequested { get; private set; }
+        public bool AcceptedOwnership { get; private set; }
+        public bool HasRetainedMedium { get; private set; }
+        public int MediumReleases { get; private set; }
+        public nint DataPointer { get; private set; }
+        public nint ReleaseOwner { get; private set; }
+        public uint ReferencesDuringCall { get; private set; }
+        public Com.FORMATETC Format { get; private set; }
+
+        public HRESULT SetData(Com.FORMATETC* pformatetc, Com.STGMEDIUM* pmedium, BOOL fRelease)
+        {
+            SetDataCalls++;
+            ReleaseRequested = fRelease;
+            DataPointer = pmedium->hGlobal;
+            ReleaseOwner = (nint)pmedium->pUnkForRelease;
+            ReferencesDuringCall = GetSetDataReferenceCount((Com.IUnknown*)DataPointer);
+            Format = *pformatetc;
+
+            if (fRelease && result.Succeeded)
+            {
+                AcceptedOwnership = true;
+                if (releaseWithinCall)
+                {
+                    PInvokeCore.ReleaseStgMedium(ref *pmedium);
+                    MediumReleases++;
+                }
+                else
+                {
+                    _retainedMedium = *pmedium;
+                    HasRetainedMedium = true;
+                }
+            }
+
+            return result;
+        }
+
+        public void ReleaseRetainedMedium()
+        {
+            if (!HasRetainedMedium)
+            {
+                return;
+            }
+
+            Com.STGMEDIUM medium = _retainedMedium;
+            _retainedMedium = default;
+            HasRetainedMedium = false;
+            PInvokeCore.ReleaseStgMedium(ref medium);
+            MediumReleases++;
+        }
+
+        public void Dispose() => ReleaseRetainedMedium();
+
+        public HRESULT GetData(Com.FORMATETC* pformatetcIn, Com.STGMEDIUM* pmedium) => HRESULT.E_NOTIMPL;
+        public HRESULT GetDataHere(Com.FORMATETC* pformatetc, Com.STGMEDIUM* pmedium) => HRESULT.E_NOTIMPL;
+        public HRESULT QueryGetData(Com.FORMATETC* pformatetc) => HRESULT.E_NOTIMPL;
+        public HRESULT GetCanonicalFormatEtc(Com.FORMATETC* pformatectIn, Com.FORMATETC* pformatetcOut) => HRESULT.E_NOTIMPL;
+        public HRESULT EnumFormatEtc(uint dwDirection, Com.IEnumFORMATETC** ppenumFormatEtc) => HRESULT.E_NOTIMPL;
+        public HRESULT DAdvise(Com.FORMATETC* pformatetc, uint advf, Com.IAdviseSink* pAdvSink, uint* pdwConnection) => HRESULT.E_NOTIMPL;
+        public HRESULT DUnadvise(uint dwConnection) => HRESULT.E_NOTIMPL;
+        public HRESULT EnumDAdvise(Com.IEnumSTATDATA** ppenumAdvise) => HRESULT.E_NOTIMPL;
+    }
+}

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/HtmlShimTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/HtmlShimTests.cs
@@ -1,0 +1,358 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Windows.Win32.Web.MsHtml;
+
+namespace System.Windows.Forms.Tests;
+
+/// <summary>
+///  Verifies subscription bookkeeping independently of MSHTML and COM reference-count caching.
+/// </summary>
+public class HtmlShimTests
+{
+    [Fact]
+    public void RemoveHandler_UnmatchedOrNull_PreservesRegisteredHandlers()
+    {
+        using TestShim shim = new();
+        object key = new();
+        int calls = 0;
+        EventHandler handler = (_, _) => calls++;
+
+        shim.AddHandler(key, handler);
+        shim.RemoveHandler(key, new EventHandler((_, _) => { }));
+        shim.RemoveHandler(new object(), handler);
+        shim.RemoveHandler(key, null);
+        shim.FireEvent(key, EventArgs.Empty);
+
+        Assert.True(shim.Connected);
+        Assert.Equal(1, calls);
+        Assert.Equal(0, shim.DisconnectCalls);
+    }
+
+    [Fact]
+    public void AddHandler_Null_DoesNotConnect()
+    {
+        using TestShim shim = new();
+
+        shim.AddHandler(new object(), null);
+
+        Assert.False(shim.Connected);
+    }
+
+    [Fact]
+    public void RemoveHandler_PartOfMulticast_PreservesRemainingHandler()
+    {
+        using TestShim shim = new();
+        object key = new();
+        int firstCalls = 0;
+        int secondCalls = 0;
+        EventHandler first = (_, _) => firstCalls++;
+        EventHandler second = (_, _) => secondCalls++;
+        shim.AddHandler(key, first + second);
+
+        shim.RemoveHandler(key, first);
+        shim.FireEvent(key, EventArgs.Empty);
+
+        Assert.True(shim.Connected);
+        Assert.Equal(0, firstCalls);
+        Assert.Equal(1, secondCalls);
+
+        shim.RemoveHandler(key, second);
+        shim.RemoveHandler(key, second);
+        Assert.False(shim.Connected);
+        Assert.Equal(1, shim.DisconnectCalls);
+    }
+
+    [Fact]
+    public void RemoveHandler_Multicast_RemovesActualInvocationCount()
+    {
+        using TestShim shim = new();
+        object key = new();
+        object otherKey = new();
+        EventHandler first = (_, _) => { };
+        EventHandler second = (_, _) => { };
+        shim.AddHandler(key, first);
+        shim.AddHandler(key, second);
+        shim.AddHandler(otherKey, first);
+
+        shim.RemoveHandler(key, first + second);
+        Assert.True(shim.Connected);
+        shim.RemoveHandler(otherKey, first);
+        Assert.False(shim.Connected);
+    }
+
+    [Fact]
+    public void RemoveHandler_Duplicate_RemovesOneOccurrence()
+    {
+        using TestShim shim = new();
+        object key = new();
+        int calls = 0;
+        EventHandler handler = (_, _) => calls++;
+        shim.AddHandler(key, handler);
+        shim.AddHandler(key, handler);
+
+        shim.RemoveHandler(key, handler);
+        shim.FireEvent(key, EventArgs.Empty);
+
+        Assert.Equal(1, calls);
+        Assert.True(shim.Connected);
+        shim.RemoveHandler(key, handler);
+        Assert.False(shim.Connected);
+    }
+
+    [Fact]
+    public void DetachEventHandler_SameDelegateDifferentNames_DetachesCorrectProxy()
+    {
+        using TestShim shim = new();
+        int calls = 0;
+        EventHandler handler = (_, _) => calls++;
+        shim.AttachEventHandler("onclick", handler);
+        shim.AttachEventHandler("onmouseover", handler);
+
+        shim.DetachEventHandler("onclick", handler);
+        HtmlToClrEventProxy remaining = Assert.Single(shim.Attached);
+        Assert.Equal("onmouseover", remaining.EventName);
+        remaining.OnHtmlEvent();
+        Assert.Equal(1, calls);
+        shim.DetachEventHandler("onmouseover", handler);
+        Assert.Empty(shim.Attached);
+    }
+
+    [Fact]
+    public void DetachEventHandler_Duplicate_DetachesMostRecentRegistration()
+    {
+        using TestShim shim = new();
+        EventHandler handler = (_, _) => { };
+        shim.AttachEventHandler("onclick", handler);
+        HtmlToClrEventProxy first = Assert.Single(shim.Attached);
+        shim.AttachEventHandler("onclick", handler);
+
+        shim.DetachEventHandler("onclick", handler);
+
+        Assert.Same(first, Assert.Single(shim.Attached));
+        shim.DetachEventHandler("onclick", handler);
+        Assert.Empty(shim.Attached);
+    }
+
+    [Fact]
+    public void DetachEventHandler_Unmatched_DoesNotConsumeRegistration()
+    {
+        using TestShim shim = new();
+        EventHandler handler = (_, _) => { };
+        shim.AttachEventHandler("onclick", handler);
+
+        shim.DetachEventHandler("onmouseover", handler);
+        shim.DetachEventHandler("onclick", new EventHandler((_, _) => { }));
+        Assert.Single(shim.Attached);
+
+        shim.DetachEventHandler("onclick", handler);
+        shim.DetachEventHandler("onclick", handler);
+        Assert.Empty(shim.Attached);
+        Assert.Equal(1, shim.DetachCalls);
+    }
+
+    [Fact]
+    public void RemoveHandler_LastStandardHandler_DoesNotDetachAttachedHandlers()
+    {
+        using TestShim shim = new();
+        object key = new();
+        EventHandler handler = (_, _) => { };
+        shim.AddHandler(key, handler);
+        shim.AttachEventHandler("onclick", handler);
+
+        shim.RemoveHandler(key, handler);
+
+        Assert.False(shim.Connected);
+        Assert.Single(shim.Attached);
+        Assert.Equal(0, shim.DetachCalls);
+    }
+
+    [Fact]
+    public void AttachEventHandler_Failure_DoesNotTrackFailedRegistration()
+    {
+        using TestShim shim = new() { FailAttach = true };
+
+        Assert.Throws<InvalidOperationException>(() => shim.AttachEventHandler("onclick", (_, _) => { }));
+        shim.Dispose();
+
+        Assert.Empty(shim.Attached);
+        Assert.Equal(0, shim.DetachCalls);
+    }
+
+    [Fact]
+    public void AttachEventHandler_NativeRejection_DoesNotTrackRegistration()
+    {
+        using TestShim shim = new() { RejectAttach = true };
+
+        shim.AttachEventHandler(null!, (_, _) => { });
+        shim.Dispose();
+
+        Assert.Empty(shim.Attached);
+        Assert.Equal(0, shim.DetachCalls);
+    }
+
+    [Fact]
+    public void DetachEventHandler_Failure_PreservesRegistrationForRetry()
+    {
+        using TestShim shim = new();
+        EventHandler handler = (_, _) => { };
+        shim.AttachEventHandler("onclick", handler);
+        shim.FailDetach = true;
+
+        Assert.Throws<InvalidOperationException>(() => shim.DetachEventHandler("onclick", handler));
+        Assert.Single(shim.Attached);
+
+        shim.FailDetach = false;
+        shim.DetachEventHandler("onclick", handler);
+        Assert.Empty(shim.Attached);
+    }
+
+    [Fact]
+    public void DetachEventHandler_ReentrantDetach_DoesNotDetachSameProxyTwice()
+    {
+        using TestShim shim = new();
+        EventHandler handler = (_, _) => { };
+        shim.AttachEventHandler("onclick", handler);
+        shim.OnDetach = () => shim.DetachEventHandler("onclick", handler);
+
+        shim.DetachEventHandler("onclick", handler);
+
+        Assert.Empty(shim.Attached);
+        Assert.Equal(1, shim.DetachCalls);
+    }
+
+    [Fact]
+    public void Dispose_DetachesEveryRegistrationAndIsReentrant()
+    {
+        TestShim shim = new();
+        EventHandler handler = (_, _) => { };
+        shim.AttachEventHandler("onclick", handler);
+        shim.AttachEventHandler("onclick", handler);
+        shim.AttachEventHandler("onmouseover", handler);
+        shim.OnDetach = shim.Dispose;
+
+        shim.Dispose();
+        shim.Dispose();
+
+        Assert.True(shim.IsDisposed);
+        Assert.Empty(shim.Attached);
+        Assert.Equal(3, shim.DetachCalls);
+        Assert.Equal(1, shim.ResourceReleaseCalls);
+    }
+
+    [Fact]
+    public void Dispose_DetachFailure_AttemptsRemainingRegistrationsAndReleasesOwner()
+    {
+        TestShim shim = new();
+        shim.AttachEventHandler("onclick", (_, _) => { });
+        shim.AttachEventHandler("onmouseover", (_, _) => { });
+        shim.FailDetach = true;
+
+        AggregateException exception = Assert.Throws<AggregateException>(shim.Dispose);
+
+        Assert.Equal(2, exception.InnerExceptions.Count);
+        Assert.Equal(2, shim.DetachCalls);
+        Assert.Equal(1, shim.ResourceReleaseCalls);
+        shim.Dispose();
+        Assert.Equal(2, shim.DetachCalls);
+    }
+
+    [Fact]
+    public void DisposeAll_Failure_DoesNotSkipAnotherShim()
+    {
+        TestShim first = new() { FailDetach = true };
+        TestShim second = new();
+        first.AttachEventHandler("onclick", (_, _) => { });
+        second.AttachEventHandler("onclick", (_, _) => { });
+
+        Assert.Throws<InvalidOperationException>(() => HtmlShim.DisposeAll([first, second]));
+
+        Assert.Equal(1, first.ResourceReleaseCalls);
+        Assert.Equal(1, second.ResourceReleaseCalls);
+        Assert.Empty(second.Attached);
+    }
+
+    [Fact]
+    public void Dispose_PreventsNewRegistrationsAndClearsStandardHandlers()
+    {
+        using TestShim shim = new();
+        object key = new();
+        int calls = 0;
+        shim.AddHandler(key, new EventHandler((_, _) => calls++));
+        shim.Dispose();
+
+        shim.FireEvent(key, EventArgs.Empty);
+
+        Assert.Equal(0, calls);
+        Assert.Throws<ObjectDisposedException>(() => shim.AddHandler(key, new EventHandler((_, _) => { })));
+        Assert.Throws<ObjectDisposedException>(() => shim.AttachEventHandler("onclick", (_, _) => { }));
+    }
+
+    /// <summary>
+    ///  Models native registrations by proxy identity without requiring MSHTML or an RCW cache.
+    /// </summary>
+    private sealed class TestShim : HtmlShim
+    {
+        public List<HtmlToClrEventProxy> Attached { get; } = [];
+        public bool Connected { get; private set; }
+        public int DisconnectCalls { get; private set; }
+        public int DetachCalls { get; private set; }
+        public int ResourceReleaseCalls { get; private set; }
+        public bool FailAttach { get; set; }
+        public bool RejectAttach { get; set; }
+        public bool FailDetach { get; set; }
+        public Action? OnDetach { get; set; }
+
+        public override IHTMLWindow2.Interface? AssociatedWindow => null;
+
+        public override void ConnectToEvents() => Connected = true;
+
+        public override void DisconnectFromEvents()
+        {
+            DisconnectCalls++;
+            Connected = false;
+        }
+
+        protected override bool AttachEventProxy(HtmlToClrEventProxy proxy)
+        {
+            if (FailAttach)
+            {
+                throw new InvalidOperationException("Injected native attach failure.");
+            }
+
+            if (RejectAttach)
+            {
+                return false;
+            }
+
+            Attached.Add(proxy);
+            return true;
+        }
+
+        protected override void DetachEventProxy(HtmlToClrEventProxy proxy)
+        {
+            DetachCalls++;
+            if (FailDetach)
+            {
+                throw new InvalidOperationException("Injected native detach failure.");
+            }
+
+            OnDetach?.Invoke();
+            Assert.True(Attached.Remove(proxy));
+        }
+
+        protected override object GetEventSender() => this;
+
+        protected override void Dispose(bool disposing)
+        {
+            try
+            {
+                base.Dispose(disposing);
+            }
+            finally
+            {
+                ResourceReleaseCalls++;
+            }
+        }
+    }
+}

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/HtmlWindowTests.Lifetime.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/HtmlWindowTests.Lifetime.cs
@@ -1,0 +1,442 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Text;
+using Moq;
+using Windows.Win32.Web.MsHtml;
+
+namespace System.Windows.Forms.Tests;
+
+/// <summary>
+///  Covers the manager-owned lifetime of HTML subscriptions using local MSHTML documents.
+/// </summary>
+public partial class HtmlWindowTests
+{
+    private const string LifetimeHtml = "<html><body><button id='button'>Click</button></body></html>";
+
+    [StaFact]
+    public unsafe void HtmlWindow_Lifetime_UnadvisableSource_DoesNotThrowOnSubscription()
+    {
+        using HtmlShimManager manager = new();
+        Mock<IHTMLWindow2.Interface> source = new();
+        HtmlWindow window = new(manager, ComHelpers.GetComPointer<IHTMLWindow2>(source.Object));
+        try
+        {
+            HtmlElementEventHandler handler = (_, _) => { };
+            window.Resize += handler;
+            window.Resize -= handler;
+            HtmlWindow.HtmlWindowShim shim = Assert.IsType<HtmlWindow.HtmlWindowShim>(manager.GetWindowShim(window));
+
+            Assert.Null(shim.TestAccessor.Dynamic._cookie);
+            Assert.False(shim.IsDisposed);
+            manager.Dispose();
+            Assert.True(shim.IsDisposed);
+        }
+        finally
+        {
+            window.NativeHtmlWindow.Dispose();
+        }
+    }
+
+    [StaFact]
+    public unsafe void HtmlWindow_Lifetime_UnsubscribeDisposedWrapper_DoesNotQueryItOrRemoveReplacementHandler()
+    {
+        using HtmlShimManager manager = new();
+        Mock<IHTMLWindow2.Interface> source = new();
+        HtmlWindow oldWindow = new(manager, ComHelpers.GetComPointer<IHTMLWindow2>(source.Object));
+        HtmlElementEventHandler handler = (_, _) => { };
+        oldWindow.Resize += handler;
+        manager.OnWindowUnloaded(oldWindow);
+
+        // MSHTML can reuse a window's COM identity across navigation. The disposed wrapper has the
+        // same dictionary hash as the replacement, but its revoked registration must not be queried.
+        HtmlWindow replacement = new(manager, ComHelpers.GetComPointer<IHTMLWindow2>(source.Object));
+        replacement.Resize += handler;
+        oldWindow.Resize -= handler;
+        oldWindow.DetachEventHandler("onresize", (_, _) => { });
+
+        HtmlWindow.HtmlWindowShim shim = manager.GetWindowShim(replacement)!;
+        EventHandlerList handlers = shim.TestAccessor.Dynamic._events;
+        Assert.NotNull(handlers[HtmlWindow.s_eventResize]);
+        Assert.False(shim.IsDisposed);
+    }
+
+    [WinFormsTheory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task HtmlWindow_Lifetime_UnsubscribeAfterTeardown_DoesNotCreateShims(bool navigate, bool subscribe)
+    {
+        using Control parent = new();
+        using WebBrowser browser = new() { Parent = parent };
+        HtmlDocument document = await NavigateLifetimeDocument(browser, LifetimeHtml);
+        HtmlElement button = document.GetElementById("button")!;
+        HtmlWindow window = document.Window!;
+        HtmlShimManager manager = document.TestAccessor.Dynamic._shimManager;
+        HtmlElementEventHandler standard = (_, _) => { };
+        EventHandler attached = (_, _) => { };
+
+        Unsubscribe();
+        Assert.Null(manager.TestAccessor.Dynamic._htmlDocumentShims);
+        Assert.Null(manager.TestAccessor.Dynamic._htmlElementShims);
+        Assert.Null(manager.TestAccessor.Dynamic._htmlWindowShims);
+
+        if (subscribe)
+        {
+            document.Click += standard;
+            button.Click += standard;
+            window.Resize += standard;
+            document.AttachEventHandler("onclick", attached);
+            button.AttachEventHandler("onclick", attached);
+            window.AttachEventHandler("onresize", attached);
+        }
+
+        if (navigate)
+        {
+            await NavigateLifetimeDocument(browser, LifetimeHtml);
+        }
+        else
+        {
+            browser.Disposed += (_, _) => Unsubscribe();
+            browser.Dispose();
+        }
+
+        Unsubscribe();
+        Unsubscribe();
+        Assert.Null(manager.GetDocumentShim(document));
+        Assert.Null(manager.GetElementShim(button));
+        Assert.Null(manager.GetWindowShim(window));
+
+        void Unsubscribe()
+        {
+            document.Click -= standard;
+            button.Click -= standard;
+            window.Resize -= standard;
+            document.DetachEventHandler("onclick", attached);
+            button.DetachEventHandler("onclick", attached);
+            window.DetachEventHandler("onresize", attached);
+        }
+    }
+
+    [WinFormsTheory]
+    [InlineData(false, false, false)]
+    [InlineData(false, false, true)]
+    [InlineData(false, true, false)]
+    [InlineData(false, true, true)]
+    [InlineData(true, false, false)]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, false)]
+    [InlineData(true, true, true)]
+    public async Task HtmlWindow_Lifetime_NavigationWithoutUnloadHandler_PrunesSubscriptions(
+        bool elementEvents,
+        bool attachedEvents,
+        bool windowFirst)
+    {
+        using Control parent = new();
+        using WebBrowser browser = new() { Parent = parent };
+        HtmlDocument document = await NavigateLifetimeDocument(browser, LifetimeHtml);
+
+        for (int navigation = 0; navigation < 3; navigation++)
+        {
+            HtmlElement button = document.GetElementById("button")!;
+            HtmlWindow window = document.Window!;
+            HtmlShimManager manager = document.TestAccessor.Dynamic._shimManager;
+            HtmlElementEventHandler standardHandler = (_, _) => { };
+            EventHandler attachedHandler = (_, _) => { };
+
+            if (windowFirst)
+            {
+                window.Resize += standardHandler;
+                window.Resize -= standardHandler;
+            }
+
+            if (elementEvents)
+            {
+                if (attachedEvents)
+                {
+                    button.AttachEventHandler("onclick", attachedHandler);
+                }
+                else
+                {
+                    button.Click += standardHandler;
+                }
+            }
+            else if (attachedEvents)
+            {
+                document.AttachEventHandler("onclick", attachedHandler);
+            }
+            else
+            {
+                document.Click += standardHandler;
+            }
+
+            HtmlShim shim = elementEvents
+                ? manager.GetElementShim(button)!
+                : manager.GetDocumentShim(document)!;
+            HtmlWindow.HtmlWindowShim windowShim = manager.GetWindowShim(window)!;
+            AxHost.ConnectionPointCookie cookie = windowShim.TestAccessor.Dynamic._cookie;
+            AgileComPointer<IHTMLWindow2> associatedWindow = shim.TestAccessor.Dynamic._associatedWindow;
+            Assert.True(cookie.Connected);
+            Assert.NotEqual(0u, (uint)associatedWindow.TestAccessor.Dynamic._cookie);
+
+            HtmlDocument nextDocument = await NavigateLifetimeDocument(browser, LifetimeHtml);
+
+            Assert.True(shim.IsDisposed);
+            Assert.True(windowShim.IsDisposed);
+            Assert.False(cookie.Connected);
+            Assert.Null(shim.TestAccessor.Dynamic._associatedWindow);
+            Assert.Equal(0u, (uint)associatedWindow.TestAccessor.Dynamic._cookie);
+            Assert.Null(manager.GetDocumentShim(document));
+            Assert.Null(manager.GetElementShim(button));
+            Assert.Null(manager.GetWindowShim(window));
+            Assert.NotNull(nextDocument.GetElementById("button"));
+            GC.KeepAlive(associatedWindow);
+            document = nextDocument;
+        }
+    }
+
+    [WinFormsFact]
+    public async Task HtmlWindow_Lifetime_LastApplicationHandlerRemoved_PreservesUnloadObservation()
+    {
+        using Control parent = new();
+        using WebBrowser browser = new() { Parent = parent };
+        HtmlDocument document = await NavigateLifetimeDocument(browser, LifetimeHtml);
+        HtmlWindow window = document.Window!;
+        HtmlShimManager manager = document.TestAccessor.Dynamic._shimManager;
+        HtmlElementEventHandler handler = (_, _) => { };
+        document.Click += handler;
+        HtmlDocument.HtmlDocumentShim documentShim = manager.GetDocumentShim(document)!;
+        window.Resize += handler;
+        window.Resize -= handler;
+
+        await NavigateLifetimeDocument(browser, LifetimeHtml);
+
+        Assert.True(documentShim.IsDisposed);
+        Assert.Null(manager.GetDocumentShim(document));
+    }
+
+    [WinFormsFact]
+    public async Task HtmlWindow_Lifetime_Dispose_ClearsAllOwnersAndRegistrations()
+    {
+        using Control parent = new();
+        using WebBrowser browser = new() { Parent = parent };
+        HtmlDocument document = await NavigateLifetimeDocument(browser, LifetimeHtml);
+        HtmlElement button = document.GetElementById("button")!;
+        HtmlWindow window = document.Window!;
+        HtmlShimManager manager = document.TestAccessor.Dynamic._shimManager;
+        EventHandler attached = (_, _) => { };
+        document.AttachEventHandler("onclick", attached);
+        button.AttachEventHandler("onclick", attached);
+        window.AttachEventHandler("onresize", attached);
+        HtmlDocument.HtmlDocumentShim documentShim = manager.GetDocumentShim(document)!;
+        HtmlElement.HtmlElementShim elementShim = manager.GetElementShim(button)!;
+        HtmlWindow.HtmlWindowShim windowShim = manager.GetWindowShim(window)!;
+        AgileComPointer<IHTMLWindow2> documentWindow = documentShim.TestAccessor.Dynamic._associatedWindow;
+        AgileComPointer<IHTMLWindow2> elementWindow = elementShim.TestAccessor.Dynamic._associatedWindow;
+
+        browser.Dispose();
+        manager.Dispose();
+        documentShim.Dispose();
+        elementShim.Dispose();
+        windowShim.Dispose();
+
+        Assert.Null(manager.TestAccessor.Dynamic._htmlDocumentShims);
+        Assert.Null(manager.TestAccessor.Dynamic._htmlElementShims);
+        Assert.Null(manager.TestAccessor.Dynamic._htmlWindowShims);
+        Assert.Null(documentShim.TestAccessor.Dynamic._attachedEventList);
+        Assert.Null(elementShim.TestAccessor.Dynamic._attachedEventList);
+        Assert.Null(windowShim.TestAccessor.Dynamic._attachedEventList);
+        Assert.Equal(0u, (uint)documentWindow.TestAccessor.Dynamic._cookie);
+        Assert.Equal(0u, (uint)elementWindow.TestAccessor.Dynamic._cookie);
+        Assert.True(documentShim.IsDisposed);
+        Assert.True(elementShim.IsDisposed);
+        Assert.True(windowShim.IsDisposed);
+        GC.KeepAlive(documentWindow);
+        GC.KeepAlive(elementWindow);
+    }
+
+    [WinFormsTheory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task HtmlWindow_Lifetime_AttachedDuplicatesAndNames_DetachIndependently(bool documentEvents)
+    {
+        using Control parent = new();
+        using WebBrowser browser = new() { Parent = parent };
+        HtmlDocument document = await NavigateLifetimeDocument(browser, LifetimeHtml);
+        HtmlElement button = document.GetElementById("button")!;
+        int calls = 0;
+        EventHandler handler = (_, _) => calls++;
+        Action<string, EventHandler> attach = documentEvents ? document.AttachEventHandler : button.AttachEventHandler;
+        Action<string, EventHandler> detach = documentEvents ? document.DetachEventHandler : button.DetachEventHandler;
+
+        attach("onclick", handler);
+        attach("onclick", handler);
+        attach("onmouseover", handler);
+        button.InvokeMember("click");
+        Assert.Equal(2, calls);
+
+        detach("onclick", handler);
+        button.InvokeMember("click");
+        Assert.Equal(3, calls);
+
+        detach("onmouseover", handler);
+        button.InvokeMember("click");
+        Assert.Equal(4, calls);
+
+        detach("onclick", handler);
+        button.InvokeMember("click");
+        Assert.Equal(4, calls);
+    }
+
+    [WinFormsFact]
+    public async Task HtmlWindow_Lifetime_MixedEventApis_RemovingStandardHandlerKeepsAttachedHandler()
+    {
+        using Control parent = new();
+        using WebBrowser browser = new() { Parent = parent };
+        HtmlDocument document = await NavigateLifetimeDocument(browser, LifetimeHtml);
+        HtmlElement button = document.GetElementById("button")!;
+        int calls = 0;
+        HtmlElementEventHandler standard = (_, _) => { };
+        EventHandler attached = (_, _) => calls++;
+        button.Click += standard;
+        button.AttachEventHandler("onclick", attached);
+
+        button.Click -= standard;
+        button.InvokeMember("click");
+
+        Assert.Equal(1, calls);
+        button.DetachEventHandler("onclick", attached);
+    }
+
+    [WinFormsFact]
+    public async Task HtmlWindow_Lifetime_UnloadHandlerDisposesBrowser_DoesNotRecreateShims()
+    {
+        using Control parent = new();
+        using WebBrowser browser = new() { Parent = parent };
+        HtmlDocument document = await NavigateLifetimeDocument(browser, LifetimeHtml);
+        HtmlWindow window = document.Window!;
+        HtmlShimManager manager = document.TestAccessor.Dynamic._shimManager;
+        TaskCompletionSource completed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        window.Unload += (_, _) =>
+        {
+            browser.Dispose();
+            completed.TrySetResult();
+        };
+        HtmlWindow.HtmlWindowShim shim = manager.GetWindowShim(window)!;
+        using TempFile replacement = TempFile.Create(Encoding.UTF8.GetBytes(LifetimeHtml));
+
+        browser.Navigate(replacement.Path);
+        await completed.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        Assert.True(browser.IsDisposed);
+        Assert.True(shim.IsDisposed);
+        Assert.Null(manager.TestAccessor.Dynamic._htmlWindowShims);
+        Assert.Null(manager.GetWindowShim(window));
+    }
+
+    [WinFormsFact]
+    public async Task HtmlWindow_Lifetime_DetachFailure_DoesNotSkipBrowserDisposal()
+    {
+        using Control parent = new();
+        using WebBrowser browser = new() { Parent = parent };
+        HtmlDocument document = await NavigateLifetimeDocument(browser, LifetimeHtml);
+        HtmlShimManager manager = document.TestAccessor.Dynamic._shimManager;
+        ThrowingDocumentShim shim = new(document);
+        shim.AttachEventHandler("onclick", (_, _) => { });
+        Assert.Null(manager.TestAccessor.Dynamic._htmlDocumentShims);
+        manager.TestAccessor.Dynamic._htmlDocumentShims =
+            new Dictionary<HtmlDocument, HtmlDocument.HtmlDocumentShim> { [document] = shim };
+        IntPtr handle = browser.Handle;
+
+        COMException exception = Assert.Throws<COMException>(browser.Dispose);
+
+        Assert.Equal((int)HRESULT.E_FAIL, exception.HResult);
+        Assert.True(browser.IsDisposed);
+        Assert.False(PInvoke.IsWindow((HWND)handle));
+        Assert.True(shim.IsDisposed);
+        Assert.Null(shim.AssociatedWindow);
+        Assert.Null(manager.TestAccessor.Dynamic._htmlDocumentShims);
+    }
+
+    [WinFormsFact]
+    public async Task HtmlWindow_Lifetime_NavigatingFrame_PreservesSiblingSubscriptions()
+    {
+        using Control parent = new();
+        using WebBrowser browser = new() { Parent = parent };
+        using TempFile leftFile = TempFile.Create(Encoding.UTF8.GetBytes(LifetimeHtml));
+        using TempFile rightFile = TempFile.Create(Encoding.UTF8.GetBytes(LifetimeHtml));
+        HtmlDocument root = await NavigateLifetimeDocument(
+            browser,
+            $"<html><frameset cols='50%,50%'><frame src='{new Uri(leftFile.Path).AbsoluteUri}'><frame src='{new Uri(rightFile.Path).AbsoluteUri}'></frameset></html>");
+        HtmlWindow rootWindow = Assert.IsType<HtmlWindow>(root.Window);
+        HtmlWindowCollection frames = Assert.IsType<HtmlWindowCollection>(rootWindow.Frames);
+        HtmlWindow left = Assert.IsType<HtmlWindow>(frames[0]);
+        HtmlWindow right = Assert.IsType<HtmlWindow>(frames[1]);
+        HtmlDocument leftDocument = left.Document!;
+        HtmlDocument rightDocument = right.Document!;
+        int rightCalls = 0;
+        leftDocument.Click += (_, _) => { };
+        rightDocument.Click += (_, _) => rightCalls++;
+        HtmlShimManager manager = root.TestAccessor.Dynamic._shimManager;
+        HtmlDocument.HtmlDocumentShim leftShim = manager.GetDocumentShim(leftDocument)!;
+        HtmlDocument.HtmlDocumentShim rightShim = manager.GetDocumentShim(rightDocument)!;
+        using TempFile replacement = TempFile.Create(Encoding.UTF8.GetBytes(LifetimeHtml));
+
+        await WaitForLifetimeNavigation(browser, new Uri(replacement.Path), () => left.Navigate(replacement.Path));
+
+        Assert.True(leftShim.IsDisposed);
+        Assert.False(rightShim.IsDisposed);
+        Assert.Same(rightShim, manager.GetDocumentShim(rightDocument));
+        rightDocument.GetElementById("button")!.InvokeMember("click");
+        Assert.Equal(1, rightCalls);
+    }
+
+    private static async Task<HtmlDocument> NavigateLifetimeDocument(WebBrowser browser, string html)
+    {
+        using TempFile file = TempFile.Create(Encoding.UTF8.GetBytes(html));
+        await WaitForLifetimeNavigation(browser, new Uri(file.Path), () => browser.Navigate(file.Path));
+        return browser.Document!;
+    }
+
+    private static async Task WaitForLifetimeNavigation(WebBrowser browser, Uri expected, Action navigate)
+    {
+        TaskCompletionSource completed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        WebBrowserDocumentCompletedEventHandler handler = (_, e) =>
+        {
+            if (e.Url == expected)
+            {
+                completed.TrySetResult();
+            }
+        };
+
+        browser.DocumentCompleted += handler;
+        try
+        {
+            navigate();
+            await completed.Task.WaitAsync(TimeSpan.FromSeconds(30));
+        }
+        finally
+        {
+            browser.DocumentCompleted -= handler;
+        }
+    }
+
+    /// <summary>
+    ///  Injects a teardown error after detaching the real native registration so the test leaves no sink behind.
+    /// </summary>
+    private sealed class ThrowingDocumentShim : HtmlDocument.HtmlDocumentShim
+    {
+        public ThrowingDocumentShim(HtmlDocument document) : base(document)
+        {
+        }
+
+        protected override void DetachEventProxy(HtmlToClrEventProxy proxy)
+        {
+            base.DetachEventProxy(proxy);
+            HRESULT.E_FAIL.ThrowOnFailure();
+        }
+    }
+}

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/HtmlWindowTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/HtmlWindowTests.cs
@@ -9,7 +9,7 @@ using Windows.Win32.Web.MsHtml;
 namespace System.Windows.Forms.Tests;
 
 [Collection("Sequential")] // workaround for WebBrowser control corrupting memory when run on multiple UI threads
-public class HtmlWindowTests
+public partial class HtmlWindowTests
 {
     [WinFormsFact]
     public async Task HtmlWindow_Opener_NoneReturnsNull()

--- a/src/test/unit/System.Windows.Forms/System/Windows/Forms/WebBrowserTests.cs
+++ b/src/test/unit/System.Windows.Forms/System/Windows/Forms/WebBrowserTests.cs
@@ -8,6 +8,8 @@ using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Windows.Forms.TestUtilities;
+using Windows.Win32.System.Com;
+using Windows.Win32.System.Ole;
 using Point = System.Drawing.Point;
 using Size = System.Drawing.Size;
 
@@ -16,6 +18,42 @@ namespace System.Windows.Forms.Tests;
 [Collection("Sequential")] // workaround for WebBrowser control corrupting memory when run on multiple UI threads
 public class WebBrowserTests
 {
+    [WinFormsFact]
+    public unsafe void WebBrowser_OpenCloseView_ReleasesNativeAndSiteReferences()
+    {
+        for (int iteration = 0; iteration < 3; iteration++)
+        {
+            using Form form = new();
+            using WebBrowser browser = new() { Dock = DockStyle.Fill };
+            using var siteObserver = ComHelpers.GetComScope<IOleClientSite>(browser.ActiveXSite);
+            siteObserver.Value->AddRef();
+            uint siteReferencesBefore = siteObserver.Value->Release();
+            form.Controls.Add(browser);
+            form.Show();
+            browser.Focus();
+
+            HWND formWindow = (HWND)form.Handle;
+            HWND browserWindow = (HWND)browser.Handle;
+            using (var observer = ComHelpers.GetComScope<IUnknown>(browser.ActiveXInstance))
+            {
+                form.Close();
+                browser.Dispose();
+                Assert.False(PInvoke.IsWindow(formWindow));
+                Assert.False(PInvoke.IsWindow(browserWindow));
+                Assert.Null(browser.ActiveXInstance);
+
+                observer.Value->AddRef();
+                Assert.Equal(1u, observer.Value->Release());
+            }
+
+            // A leaked site reference can root the disposed browser even after native browser destruction.
+            // Observe its CCW separately, without assuming anything about the live browser RCW's count.
+            siteObserver.Value->AddRef();
+            Assert.Equal(siteReferencesBefore, siteObserver.Value->Release());
+            GC.KeepAlive(browser);
+        }
+    }
+
     [WinFormsFact]
     public void WebBrowser_Ctor_Default()
     {

--- a/src/test/unit/System.Windows.Forms/WebBrowserBaseTests.cs
+++ b/src/test/unit/System.Windows.Forms/WebBrowserBaseTests.cs
@@ -5,7 +5,10 @@
 
 using System.ComponentModel;
 using System.Drawing;
+using System.Runtime.InteropServices;
 using Moq;
+using Windows.Win32.System.Com;
+using Windows.Win32.System.Ole;
 using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests;
@@ -13,6 +16,128 @@ namespace System.Windows.Forms.Tests;
 [Collection("Sequential")] // workaround for WebBrowser control corrupting memory when run on multiple UI threads (instantiated via GUID)
 public class WebBrowserBaseTests
 {
+    [WinFormsTheory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public unsafe void WebBrowserBase_LoadedToPassive_ReleasesNativeReferences(bool useHost)
+    {
+        using WebBrowser control = new();
+        object nativeObject;
+        if (useHost)
+        {
+            control.TransitionUpTo(WebBrowserHelper.AXState.Loaded);
+            nativeObject = control.ActiveXInstance;
+        }
+        else
+        {
+            Guid classId = new("8856F961-340A-11D0-A96B-00C04FD705A2");
+            using ComScope<IUnknown> created = new(null);
+            PInvokeCore.CoCreateInstance(&classId, null, CLSCTX.CLSCTX_INPROC_SERVER, IID.Get<IUnknown>(), created).ThrowOnFailure();
+            nativeObject = Marshal.GetObjectForIUnknown((nint)created.Value);
+        }
+
+        Assert.True(Marshal.IsComObject(nativeObject));
+        using ComScope<IUnknown> observer = new((IUnknown*)Marshal.GetIUnknownForObject(nativeObject));
+        try
+        {
+            // The wrapper must remain usable after its creation reference has been released.
+            ((IOleObject.Interface)nativeObject).GetMiscStatus(DVASPECT.DVASPECT_CONTENT, out _).ThrowOnFailure();
+        }
+        finally
+        {
+            if (useHost)
+            {
+                control.TransitionDownTo(WebBrowserHelper.AXState.Passive);
+            }
+            else
+            {
+                Marshal.FinalReleaseComObject(nativeObject);
+            }
+        }
+
+        Assert.Null(control.ActiveXInstance);
+        Assert.False(control.IsHandleCreated);
+
+        // Direct creation is the control case: with the RCW gone, only this observer may own a reference.
+        observer.Value->AddRef();
+        uint remainingReferences = observer.Value->Release();
+        Assert.Equal(1u, remainingReferences);
+    }
+
+    [WinFormsFact]
+    public unsafe void WebBrowserBase_RunningToPassive_ReleasesClientSiteReference()
+    {
+        using WebBrowser control = new();
+        WebBrowserSiteBase site = control.ActiveXSite;
+        using var observer = ComHelpers.GetComScope<IOleClientSite>(site);
+        observer.Value->AddRef();
+        uint before = observer.Value->Release();
+
+        control.TransitionUpTo(WebBrowserHelper.AXState.Running);
+        Assert.Equal(WebBrowserHelper.AXState.Running, control.ActiveXState);
+        using (var oleObject = ComHelpers.GetComScope<IOleObject>(control.ActiveXInstance))
+        {
+            using ComScope<IOleClientSite> retainedSite = new(null);
+            oleObject.Value->GetClientSite(retainedSite).ThrowOnFailure();
+            Assert.False(retainedSite.IsNull);
+            Assert.Same(site, ComHelpers.GetObjectForIUnknown(retainedSite.AsUnknown));
+        }
+
+        control.TransitionDownTo(WebBrowserHelper.AXState.Passive);
+        Assert.Null(control.ActiveXInstance);
+        IOleClientSite* observedSite = observer.Value;
+        Assert.Throws<NotImplementedException>(() => observedSite->SaveObject());
+
+        // Window/native teardown is insufficient: an extra site CCW reference still roots the host.
+        // Compare the same managed site's count before activation and after every native owner is gone.
+        observer.Value->AddRef();
+        Assert.Equal(before, observer.Value->Release());
+        GC.KeepAlive(control);
+    }
+
+    [WinFormsTheory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public unsafe void WebBrowserContainer_SetActiveObject_ReleasesClientSiteReference(bool useContainer)
+    {
+        using WebBrowser control = new();
+        control.TransitionUpTo(WebBrowserHelper.AXState.Loaded);
+        using var oleObject = ComHelpers.GetComScope<IOleObject>(control.ActiveXInstance);
+        using var activeObject = ComHelpers.GetComScope<IOleInPlaceActiveObject>(control.ActiveXInstance);
+        using WebBrowserSiteBase site = new(control);
+        using var clientSite = ComHelpers.GetComScope<IOleClientSite>(site);
+        using var observer = clientSite.Query<IUnknown>();
+        oleObject.Value->SetClientSite(clientSite).ThrowOnFailure();
+
+        try
+        {
+            observer.Value->AddRef();
+            uint before = observer.Value->Release();
+
+            if (useContainer)
+            {
+                WebBrowserContainer container = new(control);
+                Assert.Equal(HRESULT.S_OK, ((IOleInPlaceFrame.Interface)container).SetActiveObject(activeObject, default));
+            }
+            else
+            {
+                using ComScope<IOleClientSite> returnedSite = new(null);
+                oleObject.Value->GetClientSite(returnedSite).ThrowOnFailure();
+                Assert.Same(site, ComHelpers.GetObjectForIUnknown(returnedSite.AsUnknown));
+            }
+
+            IOleClientSite* observedSite = clientSite.Value;
+            Assert.Throws<NotImplementedException>(() => observedSite->SaveObject());
+            observer.Value->AddRef();
+            uint after = observer.Value->Release();
+            Assert.Equal(before, after);
+        }
+        finally
+        {
+            oleObject.Value->SetClientSite(null).ThrowOnFailure();
+        }
+    }
+
     public static IEnumerable<object[]> Bounds_Set_TestData()
     {
         yield return new object[] { 0, 0, 0, 0 };


### PR DESCRIPTION
This is a fix-attempt based on a different, experimental Agent-approach to evaluate quality/plausibility of bug-fixes in an actual, real-world scenario.

Alternative to ** https://github.com/dotnet/winforms/pull/15059 **

---
Executing Agent's description:

Balance caller-owned conversion, activation, and connection-point references so native teardown does not leave a site or event sink rooting its managed host. Adapt the necessary browser/HTML prerequisites from Jeremy Kuhne's dotnet/winforms#15059 without importing unrelated changes.

Observe HTML window unload independently of application subscriptions, preserve actual delegate/proxy multiplicity, and tear down the correct window's subscriptions while allowing other frames to remain active. Keep ordinary event disconnection separate from final attached-event cleanup, and complete owned-resource cleanup on reentrant/error paths. Keep removal non-creating after teardown, reject revoked registrations before native-identity dictionary comparisons, and preserve nonthrowing subscription behavior for windows that lack the optional event connection point.

Honor successful SetData ownership transfer without reading or releasing a medium the recipient may already have freed. Cover native reference balance, continued usability, event delivery, navigation, and failure paths. Explain the ownership invariants and failure mechanisms at the changes.

Leave the generated-COM GIT strategy/cache redesign for separate work.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/15087)