### PR TITLE
Fix cancellation handling in GetEnumValidationInfo

### DIFF
--- a/src/System.Windows.Forms.PrivateSourceGenerators/src/System/Windows/Forms/SourceGenerators/EnumValidationGenerator.cs
+++ b/src/System.Windows.Forms.PrivateSourceGenerators/src/System/Windows/Forms/SourceGenerators/EnumValidationGenerator.cs
@@ -208,10 +208,7 @@ namespace SourceGenerated
 
         foreach (SyntaxNode argument in argumentsToValidate)
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                yield break;
-            }
+            cancellationToken.ThrowIfCancellationRequested();
 
             SemanticModel semanticModel = GetSemanticModel(compilation, argument.SyntaxTree);
 

--- a/src/System.Windows.Forms.PrivateSourceGenerators/tests/UnitTests/EnumValidationTests.cs
+++ b/src/System.Windows.Forms.PrivateSourceGenerators/tests/UnitTests/EnumValidationTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
 using System.Collections.Immutable;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
@@ -284,6 +285,32 @@ namespace Paint
 @"if ((intValue & 15) == intValue) return;";
 
         VerifyGeneratedMethodLines(source, "Paint.Colours", expected);
+    }
+
+    [Fact]
+    public void GetEnumValidationInfo_CancellationRequested_ThrowsOperationCanceledException()
+    {
+        SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(
+            "enum Example { Value }",
+            cancellationToken: TestContext.Current.CancellationToken);
+        CSharpCompilation compilation = CSharpCompilation.Create("original", [syntaxTree]);
+        MethodInfo method = typeof(EnumValidationGenerator).GetMethod(
+            "GetEnumValidationInfo",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        using CancellationTokenSource cancellationTokenSource = new();
+        cancellationTokenSource.Cancel();
+
+        var validationInfos = (IEnumerable)method.Invoke(
+            null,
+            [
+                compilation,
+                ImmutableArray.Create<SyntaxNode>(syntaxTree.GetRoot(TestContext.Current.CancellationToken)),
+                cancellationTokenSource.Token
+            ])!;
+
+        IEnumerator enumerator = validationInfos.GetEnumerator();
+        OperationCanceledException exception = Assert.Throws<OperationCanceledException>(() => enumerator.MoveNext());
+        Assert.Equal(cancellationTokenSource.Token, exception.CancellationToken);
     }
 
     private static void VerifyGeneratedMethodLines(string source, string expectedEnumName, string expectedBody)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #13565


## Proposed changes

- Updated GetEnumValidationInfo to replace yield break with cancellationToken.ThrowIfCancellationRequested() when cancellation is requested.

- Ensured generator properly throws OperationCanceledException instead of silently exiting, preventing incomplete results from being treated as successful and cached.

- Added regression test verifying enumeration throws with the original cancellation token.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Prevents partial generator output from being incorrectly treated as successful.

- Ensures cancellation is correctly propagated, improving reliability of source generator behavior.

## Regression? 

- No

## Risk

- Low

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

- Manual test and unit test.

## Test environment(s) <!-- Remove any that don't apply -->

- .NET SDK 11.0.100-preview.6.26359.118


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/15131)