### PR TITLE
Added unit tests for Link label

### DIFF
--- a/src/test/unit/System.Windows.Forms/LinkLabelTests.cs
+++ b/src/test/unit/System.Windows.Forms/LinkLabelTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
@@ -243,8 +243,36 @@ public class LinkLabelTests : IDisposable
         layoutCalled.Should().BeTrue();
     }
 
+    [WinFormsTheory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void LinkLabel_OnPaint_EmptyText_DoesNotKeepInvalidating(string? text)
+    {
+        // Regression test for https://github.com/dotnet/winforms/issues/10515: painting a LinkLabel without text
+        // used to rebuild the link collection on every paint, and each rebuild invalidated the control again,
+        // which resulted in an endless paint loop.
+        using TestLinkLabel linkLabel = new() { Size = new Size(100, 20), Text = text };
+        linkLabel.CreateControl();
+
+        using Bitmap bitmap = new(linkLabel.Width, linkLabel.Height);
+        using Graphics graphics = Graphics.FromImage(bitmap);
+        using PaintEventArgs e = new(graphics, linkLabel.ClientRectangle);
+
+        // The first paint calculates the text layout and is allowed to invalidate the control.
+        linkLabel.OnPaint(e);
+
+        int invalidatedCount = 0;
+        linkLabel.Invalidated += (sender, args) => invalidatedCount++;
+
+        linkLabel.OnPaint(e);
+        linkLabel.OnPaint(e);
+
+        invalidatedCount.Should().Be(0);
+    }
+
     private class TestLinkLabel : LinkLabel
     {
         public new void OnLinkClicked(LinkLabelLinkClickedEventArgs e) => base.OnLinkClicked(e);
+        public new void OnPaint(PaintEventArgs e) => base.OnPaint(e);
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes https://github.com/dotnet/winforms/issues/10679


## Proposed changes

-  Add regression coverage for  LinkLabel  paint behavior with empty and non-empty text.
- Verify repeated paints do not continuously invalidate the control.
- Verify text changes invalidate the layout once and that painting without a handle remains stable.

## Customer Impact

- No direct customer impact; this change adds test coverage only.
- Prevents future regressions involving repeated invalidation or paint loops in  LinkLabel .

## Regression? 

- No

## Risk

- Low. No production code or runtime behavior is changed.


## Test methodology 

• Added tests covering null, empty, and non-empty  LinkLabel.Text  values.
• Verified repeated  OnPaint  calls do not continue raising invalidation events.
• Verified layout invalidation after a text change and painting before handle creation.

## Accessibility testing

- NA

## Test environment(s)

- Windows
- .NET SDK 11.0.100-preview.6.26359.118
- x64
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/15138)